### PR TITLE
Add broadcaster UDP/SRT bridge with multicast and reconnect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
           set -euo pipefail
           targets=(robotweax_srt)
           if [[ "$EXAMPLES" == "true" ]]; then
-            targets+=(robotweax_srt_message_demo robotweax_srt_file_demo robotweax_srt_group_demo)
+            targets+=(robotweax_srt_message_demo robotweax_srt_file_demo robotweax_srt_group_demo robotweax_srt_udp_bridge)
           fi
           cmake --build build --config Release --parallel --target "${targets[@]}"
       - name: Test
@@ -374,7 +374,7 @@ jobs:
           set -euo pipefail
           targets=(robotweax_srt)
           if [[ "$EXAMPLES" == "true" ]]; then
-            targets+=(robotweax_srt_message_demo robotweax_srt_file_demo robotweax_srt_group_demo)
+            targets+=(robotweax_srt_message_demo robotweax_srt_file_demo robotweax_srt_group_demo robotweax_srt_udp_bridge)
           fi
           cmake --build build --config Release --parallel --target "${targets[@]}"
       - name: Test
@@ -573,7 +573,7 @@ jobs:
           cmake --build build-aead-static
           --config Release
           --parallel
-          --target robotweax_srt_message_demo robotweax_srt_file_demo robotweax_srt_group_demo
+          --target robotweax_srt_message_demo robotweax_srt_file_demo robotweax_srt_group_demo robotweax_srt_udp_bridge
       - name: Test explicit CTR and GCM demo modes
         if: needs.changes.outputs.examples == 'true'
         run: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ version returned by `srt_getversion()`.
 
 ## Unreleased
 
+- Add the opt-in `robotweax_srt_udp_bridge` demo for continuous raw MPEG-TS
+  UDP → SRT → UDP forwarding using the public API. Supports IPv4 unicast/multicast,
+  Caller/Listener and Rendezvous in either media direction, configurable
+  latency, optional AES-CTR, live statistics and opt-in reconnect;
+  includes datagram-integrity/rejection tests and a player/source quickstart.
+
 ## 0.2.3 — 2026-09-07
 
 Compatibility-preserving maintenance and security hardening. The public C ABI

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,14 @@ set_target_properties(robotweax_srt PROPERTIES
     VISIBILITY_INLINES_HIDDEN YES)
 
 if(ROBOTWEAX_SRT_BUILD_EXAMPLES)
+    add_executable(robotweax_srt_udp_bridge examples/srt_udp_bridge.cpp)
+    target_link_libraries(robotweax_srt_udp_bridge PRIVATE RobotweaxSRT::srt)
+    if(WIN32)
+        target_link_libraries(robotweax_srt_udp_bridge PRIVATE ws2_32)
+    endif()
+    target_compile_features(robotweax_srt_udp_bridge PRIVATE cxx_std_20)
+    set_target_properties(robotweax_srt_udp_bridge PROPERTIES CXX_EXTENSIONS OFF)
+
     add_executable(robotweax_srt_message_demo
         examples/srt_message_demo.cpp)
     target_link_libraries(robotweax_srt_message_demo
@@ -463,6 +471,12 @@ if(ROBOTWEAX_SRT_BUILD_TESTS)
 
     find_package(Python3 3.10 REQUIRED COMPONENTS Interpreter)
     if(ROBOTWEAX_SRT_BUILD_EXAMPLES)
+        add_test(NAME robotweax_srt_udp_bridge_loopback
+            COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/examples/test_udp_bridge.py
+                --demo $<TARGET_FILE:robotweax_srt_udp_bridge>)
+        set_tests_properties(robotweax_srt_udp_bridge_loopback
+            PROPERTIES TIMEOUT 120 LABELS "example;integration")
         foreach(message_demo_scenario IN ITEMS
                 caller-listener
                 rendezvous)

--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ Read the [Integration guide](docs/integration.md),
 [socket-option reference](docs/socket-options.md) before porting an existing
 application.
 
+For a continuous MPEG-TS UDP → SRT → UDP relay, start with the
+[live UDP/SRT bridge demo](docs/udp-srt-bridge.md).
+
 For runnable public-API examples, build the opt-in
 [`srt_message_demo`, `srt_file_demo`, and `srt_group_demo`](examples/README.md),
 or copy the

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ developers and transport integrators using the installed public API.
 - [FFmpeg integration](ffmpeg-integration.md) — opt-in package discovery,
   reproducible builds, runtime verification, and the qualified media profile.
 - [Testing](testing.md) — local verification and focused test selection.
+- [Live UDP/SRT bridge](udp-srt-bridge.md) — continuous MPEG-TS UDP → SRT → UDP
+  forwarding with the public API.
 - [Public API examples](../examples/README.md) — runnable Caller, Listener,
   Rendezvous, and Connection Group demonstrations for Message, File/Stream,
   Broadcast, and weighted Backup APIs.

--- a/docs/udp-srt-bridge.md
+++ b/docs/udp-srt-bridge.md
@@ -1,0 +1,295 @@
+# Live MPEG-TS UDP ↔ SRT bridge
+
+This demo is an unreleased addition; it is not included in the `v0.2.3` tag.
+
+`robotweax_srt_udp_bridge` demonstrates a continuous live bridge using only
+the public `<srt/srt.h>` API. The same executable has two application modes:
+
+```text
+MPEG-TS source ──UDP──> bridge send ──SRT──> bridge receive ──UDP──> player
+```
+
+There is no transcoding, remuxing, RTP encapsulation, or private control frame.
+Each input UDP datagram becomes one SRT Message and one output UDP datagram.
+Payload bytes are unchanged. SRT's live receiver delivery timing is used;
+the bridge does not parse PCR, restamp timestamps, or promise hard-real-time
+UDP output. This is an example application, not a supervised production relay.
+
+## Build
+
+Prerequisites: Git, CMake 3.20+, a C++20 compiler, and OpenSSL 3 development
+headers/libraries. See [Building](building.md). From the repository root:
+
+```sh
+cmake -S . -B build-bridge \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DROBOTWEAX_SRT_BUILD_EXAMPLES=ON \
+  -DROBOTWEAX_SRT_BUILD_TESTS=OFF \
+  -DROBOTWEAX_SRT_BUILD_BENCHMARKS=OFF \
+  -DROBOTWEAX_SRT_BUILD_TOOLS=OFF
+cmake --build build-bridge --target robotweax_srt_udp_bridge --parallel 2
+```
+
+For Visual Studio, add `--config Release` to the build command. The executable
+is then typically `build-bridge/Release/robotweax_srt_udp_bridge.exe`.
+The examples are opt-in and are not installed as production utilities.
+
+## Quick local test
+
+Use three or four terminals. Start the UDP destination/player first, then the
+SRT listener, then the SRT caller, and finally the UDP source. The bridge
+prints `CONNECTED` when ready to forward. Do not start the source before both
+bridges are connected: this demo has no pre-connection recording buffer.
+
+### 1. UDP player (optional external software)
+
+For example, using an independently installed FFmpeg/ffplay:
+
+```sh
+ffplay -f mpegts 'udp://127.0.0.1:5001'
+```
+
+VLC can instead open the network URL `udp://@127.0.0.1:5001`.
+These players are not bundled with Robotweax SRT.
+
+### 2. SRT receiver → UDP output
+
+```sh
+./build-bridge/robotweax_srt_udp_bridge receive \
+  --srt-mode listener --srt-host 127.0.0.1 --srt-port 9000 \
+  --udp-host 127.0.0.1 --udp-port 5001 --latency-ms 120
+```
+
+Wait for `READY SRT listener`.
+
+### 3. UDP input → SRT sender
+
+```sh
+./build-bridge/robotweax_srt_udp_bridge send \
+  --srt-mode caller --srt-host 127.0.0.1 --srt-port 9000 \
+  --udp-host 127.0.0.1 --udp-port 5000 --latency-ms 120
+```
+
+### 4. Feed the live source
+
+Configure your existing raw MPEG-TS-over-UDP source to send to
+`127.0.0.1:5000`, preferably with 1316-byte datagrams. Alternatively, replay a
+local file in real time with FFmpeg:
+
+```sh
+ffmpeg -re -i sample.ts -map 0 -c copy -f mpegts \
+  'udp://127.0.0.1:5000?pkt_size=1316'
+```
+
+The bridge prints `STATUS` once per second, including during input silence.
+Forwarding counts are local counts, not end-to-end acknowledgements or proof
+of lossless delivery. See the status and reconnect sections below.
+Stop the source and use Ctrl+C to stop each bridge. There is no EOF message
+inside the MPEG-TS payload and no guarantee to drain pending data on Ctrl+C.
+
+## Two machines
+
+On the receiving machine, use `--srt-host 0.0.0.0` to listen on all IPv4
+interfaces. On the sending machine, set `--srt-host` to the receiver's numeric
+IPv4 address. Allow the chosen SRT UDP port through the receiver's firewall;
+configure UDP port forwarding if the receiver is behind NAT.
+
+`--udp-host` means **bind address** in `send` mode and **output destination**
+in `receive` mode. Use a local interface address (or `0.0.0.0`) to receive
+UDP from another device. Use the player's address for remote UDP output.
+Loopback addresses are the safer default when testing on one machine.
+
+The SRT connection initiator is independent of media direction. Both `send`
+and `receive` support Caller, Listener, and Rendezvous. A sender can also use
+`--srt-mode listener` while the receiver uses `--srt-mode caller`.
+Only one peer is served per invocation.
+
+## Rendezvous in either media direction
+
+Select `--srt-mode rendezvous` on **both** applications. Each binds its own
+`--srt-bind-host` / `--srt-local-port` and connects to the other application's
+`--srt-host` / `--srt-port`. Start both within the connection timeout window.
+For an interactive test, the commands below allow 30 seconds.
+
+On one machine, use different local SRT ports, cross-connected as follows.
+The UDP source/player ports remain 5000 and 5001:
+
+```sh
+./build-bridge/robotweax_srt_udp_bridge send \
+  --srt-mode rendezvous \
+  --srt-bind-host 127.0.0.1 --srt-local-port 9001 \
+  --srt-host 127.0.0.1 --srt-port 9002 \
+  --udp-host 127.0.0.1 --udp-port 5000 \
+  --connect-timeout-ms 30000
+```
+
+```sh
+./build-bridge/robotweax_srt_udp_bridge receive \
+  --srt-mode rendezvous \
+  --srt-bind-host 127.0.0.1 --srt-local-port 9002 \
+  --srt-host 127.0.0.1 --srt-port 9001 \
+  --udp-host 127.0.0.1 --udp-port 5001 \
+  --connect-timeout-ms 30000
+```
+
+Wait for `CONNECTED` on both sides before starting the UDP source. The earlier
+`CONNECTING SRT rendezvous` line only announces an attempt, not an established
+connection. Optional AES-CTR works in Rendezvous as described below.
+
+On separate machines, use an appropriate local bind address (default
+`0.0.0.0`) and the peer's reachable IPv4 address. Firewall/NAT configuration
+must allow the matching UDP endpoints in both directions. Rendezvous is not
+a guarantee of traversal through arbitrary NATs. See [Rendezvous](rendezvous.md).
+The two local-bind options are deliberately rejected outside Rendezvous mode;
+for Listener mode, `--srt-host` / `--srt-port` already define the bind endpoint.
+
+## Optional AES-CTR encryption
+
+Set the same passphrase in an environment variable on both machines, then
+add `--passphrase-env BRIDGE_SECRET` to both bridge commands. Its value must
+contain 10–79 bytes. Pass only the variable's name on the command line, not
+the secret itself. Use your shell's hidden-input mechanism or a credential
+provider to populate it; do not paste real credentials into shared commands.
+
+This selects AES-CTR with a 256-bit key. No passphrase means no encryption.
+This bridge deliberately does not expose AES-GCM selection, even when built
+with the extension enabled. AES-CTR does not authenticate payload integrity;
+read [Security](../SECURITY.md) and the
+[0.2.3 qualification limits](release-notes-0.2.3.md#qualification-limits-and-release-acceptance).
+The independent cryptographic review remains outstanding.
+
+## UDP multicast
+
+Use an IPv4 multicast group as `--udp-host`. In `send` mode the bridge joins
+that input group; in `receive` mode it transmits to that output group.
+`--udp-interface` is the **local IPv4 address**, not an interface name or the
+group address. Default `0.0.0.0` lets the OS choose. Select it explicitly on
+multi-interface hosts. Input binds the wildcard address and joins the group
+on this interface. Membership is released when the socket closes.
+
+For example, join an existing source on the sending machine:
+
+```sh
+./build-bridge/robotweax_srt_udp_bridge send \
+  --udp-host 239.10.20.30 --udp-port 5000 --udp-interface 192.168.10.20 \
+  --srt-mode caller --srt-host 192.168.20.30 --srt-port 9000
+```
+
+On the receiving machine, output to another multicast group:
+
+```sh
+./build-bridge/robotweax_srt_udp_bridge receive \
+  --srt-mode listener --srt-host 0.0.0.0 --srt-port 9000 \
+  --udp-host 239.10.20.31 --udp-port 5001 --udp-interface 192.168.20.30 \
+  --udp-ttl 1
+```
+
+Replace interface addresses with addresses assigned to the respective hosts.
+`--udp-ttl` accepts 1–255, defaults to 1, and applies only to multicast output.
+Multicast loopback retains the OS default; local subscribers can receive
+output. Routers, IGMP snooping, firewalls and group membership must permit the
+traffic. Source-Specific Multicast (SSM), interface names, IPv6 multicast and
+RTP depacketization are not implemented. The application joins any-source
+multicast; do not treat group membership as sender authentication.
+
+## Live status and statistics
+
+`--stats-interval-ms` controls the reporting interval (200–60000, default 1000).
+`--input-idle-ms` controls input inactivity classification (200–60000, default
+2000). Status continues even with no incoming datagrams. Reports can be delayed
+by a bounded blocking send; this is not a hard-real-time sampling service.
+
+- `connection=CONNECTED`, `input=WAITING|ACTIVE|IDLE` distinguish SRT state
+  from application input activity. `input_kind=UDP` describes the sender's
+  input; `input_kind=SRT` describes the receiver's input. An idle receiver
+  cannot tell whether the remote UDP source stopped or traffic was lost.
+- `input_payload_mbps` and `output_payload_mbps` are interval rates of
+  **successfully forwarded payload bytes**, excluding UDP/IP/SRT headers.
+  They are equal because the bridge does not transcode or repacketize.
+  They are not interface/wire bitrate, encoder bitrate, or remote delivery
+  confirmations; discarded packets before forwarding are not included.
+- `forwarded_datagrams` and `forwarded_bytes` are cumulative for the current
+  connection generation, as are the underlying SRT totals.
+- `rtt_ms`, `retrans_total`, `snd_drop_total`, `rcv_drop_total` expose SRT RTT,
+  retransmissions and final sender/receiver drops. In particular, gap/loss
+  detection is not presented as final packet loss.
+- `snd_buffer_bytes`, `rcv_buffer_bytes`, `snd_buffer_ms`, `rcv_buffer_ms`
+  expose instantaneous buffer occupancy and duration.
+- `snd_latency_ms` and `rcv_latency_ms` expose the SRT-reported effective
+  TSBPD delays. They are not glass-to-glass latency. Fields irrelevant to a
+  socket's media direction can be zero; see [Statistics](statistics.md).
+- All SRT statistics use `srt_bistats(socket, &stats, 0, 1)`: no counter reset.
+  Failed snapshots emit `stats_available=false` and omit SRT fields rather
+  than fabricating zero values. No new protocol or telemetry API is used.
+
+## Reconnect and recovery
+
+Add `--reconnect on` to either or both endpoints to enable automatic retry
+(default `off`). This works in Caller, Listener and Rendezvous roles. Tune
+`--reconnect-delay-ms` (100–60000, default 1000) and
+`--peer-idle-timeout-ms` (1000–60000, default 5000) if necessary. Both
+Rendezvous peers must still overlap their connection attempts; use a
+sufficient `--connect-timeout-ms` window.
+
+States are `CONNECTING` (Caller/Rendezvous), `READY SRT listener` (waiting),
+`CONNECTED`, `DISCONNECTED`, `RECONNECTING`, and `STOPPED`. A recovered
+`CONNECTED` line contains an incremented `generation` and `recovery_ms`,
+measured from detected failure to the bridge being ready again. It does not
+include the unknown time before the failure was detected. Initial connection
+retries also report this interval, with generation 1 on first success.
+
+Transient no-server, timeout and disconnected errors can be retried.
+Authentication/connection rejection, invalid configuration or MPEG-TS,
+partial-message anomalies and local UDP errors remain fatal (exit 1).
+Logs include the SRT error code, not the passphrase. A cable interruption
+and a peer process restart are not reliably distinguishable from SRT error
+codes alone; `input=IDLE` while connected is reported separately.
+
+UDP input is bound/joined **only after SRT connects** and is closed on session
+failure. Input during an outage is not buffered or replayed. There is no
+promise of lossless restart: the datagram involved in a failed send has
+unknown delivery status, and the number of UDP datagrams lost outside the
+socket's lifetime is unknown. Retry never blindly resends that datagram.
+
+## Payload and operational limits
+
+- Numeric IPv4 unicast and any-source multicast. No hostname resolution,
+  IPv6, Source-Specific Multicast, or broadcast output.
+- Raw MPEG-TS only: each datagram must contain 1–7 complete 188-byte packets
+  (188–1316 bytes), with `0x47` at every packet boundary. This is basic framing
+  validation, not validation of the entire MPEG transport stream.
+- 192/204-byte TS variants, RTP headers, empty/oversized/unaligned datagrams
+  and bad sync bytes are rejected with a diagnostic and exit code 1. They
+  are not truncated or automatically repacketized. The receiver validates
+  incoming SRT Messages in the same way.
+- SRT Live/Message mode, TSBPD enabled, configurable latency (default 120 ms).
+  The bridge does not add a second pacing queue. Late SRT packets may be
+  dropped according to the live transport policy; UDP itself is unreliable.
+- No unbounded queue. SRT sends time out after one second. Reconnect is
+  opt-in and can abandon queued live data; see the recovery policy above.
+- Listener waiting is interruptible; Caller and Rendezvous connection attempts are bounded
+  by `--connect-timeout-ms` (default 10000). Ctrl+C is a local stop request,
+  not a reliable delivery acknowledgement or graceful protocol EOF.
+- Caller `--stream-id` is optional. No listener-side authentication/routing
+  policy is supplied by this demo; do not use Stream ID as authentication.
+- External SRT peers must use compatible live Message framing and payload
+  sizes. The bridge's automated test is Robotweax↔Robotweax, not an additional
+  claim of qualification against every encoder, receiver or SRT library.
+
+## Focused test
+
+Configure a separate build with tests and examples enabled, and build the
+bridge target. Then run:
+
+```sh
+ctest --test-dir build-bridge-tests -C Release \
+  -R '^robotweax_srt_udp_bridge_loopback$' --output-on-failure
+```
+
+The test checks all seven datagram sizes byte-for-byte, both Caller/Listener
+directions, Rendezvous with either sender or receiver started first, plain
+and AES-CTR Rendezvous transfer, multicast input/output, active and idle status,
+and sender/receiver restarts in all three SRT roles. Invalid UDP payloads are
+rejected even with reconnect enabled. It does
+not measure maximum throughput or simulate WAN loss. Python 3.10+ is required
+when tests are enabled.

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,9 +6,18 @@ the public `RobotweaxSRT::srt` target. They are not production relay tools and
 do not replace application-specific reconnect, credential, or monitoring
 policy.
 
+## Live MPEG-TS UDP ↔ SRT bridge
+
+The [UDP/SRT bridge guide](../docs/udp-srt-bridge.md) shows how to build and run
+`robotweax_srt_udp_bridge send` and `robotweax_srt_udp_bridge receive` as a
+continuous MPEG-TS UDP → SRT → UDP path. It preserves datagram boundaries and
+supports IPv4 unicast, Caller/Listener and Rendezvous in either media direction,
+configurable latency, optional AES-CTR, UDP multicast input/output, live SRT
+statistics and opt-in reconnect. It does not transcode or promise lossless restart.
+
 ## Build the networked examples
 
-The three networked example executables are opt-in and are not installed with
+The four networked example executables are opt-in and are not installed with
 the library. The standalone consumer source described below is installed as
 part of the public documentation package.
 
@@ -20,11 +29,11 @@ cmake -S . -B build-examples \
   -DROBOTWEAX_SRT_BUILD_TOOLS=OFF
 cmake --build build-examples \
   --target robotweax_srt_message_demo robotweax_srt_file_demo \
-    robotweax_srt_group_demo --parallel
+    robotweax_srt_group_demo robotweax_srt_udp_bridge --parallel
 ```
 
 Multi-config generators place the executable in a configuration directory and
-require `--config Release` when building. All three executables depend only on
+require `--config Release` when building. All four executables depend only on
 the installed public SRT interface.
 
 ## Installed package consumer

--- a/examples/srt_udp_bridge.cpp
+++ b/examples/srt_udp_bridge.cpp
@@ -1,0 +1,756 @@
+/* SPDX-License-Identifier: MIT */
+
+// A deliberately small public-API live bridge. No private wire framing is added:
+// one complete UDP datagram is one SRT Message and one output UDP datagram.
+#include <srt/srt.h>
+
+#include <array>
+#include <cerrno>
+#include <charconv>
+#include <chrono>
+#include <csignal>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
+
+#if !defined(_WIN32)
+#include <arpa/inet.h>
+#include <sys/select.h>
+#include <unistd.h>
+#endif
+
+namespace {
+
+volatile std::sig_atomic_t stopping = 0;
+constexpr int max_payload =
+    1316; // Seven 188-byte MPEG-TS packets; no RTP header.
+
+void stop(int)
+{
+    stopping = 1;
+}
+
+[[noreturn]] void srt_error(const char* operation)
+{
+    throw std::runtime_error(
+        std::string {operation} + ": " + srt_getlasterror_str());
+}
+
+class TransportFailure : public std::runtime_error {
+public:
+    TransportFailure(const std::string& message, int code)
+        : std::runtime_error(message)
+        , code(code)
+    {
+    }
+    int code;
+};
+
+[[noreturn]] void transport_error(const char* operation)
+{
+    const int code = srt_getlasterror(nullptr);
+    throw TransportFailure(
+        std::string {operation} + ": " + srt_getlasterror_str(), code);
+}
+
+[[nodiscard]] bool retryable(int code)
+{
+    // Rejection (including authentication/configuration errors) is deliberately
+    // fatal. Do not turn every public API error into an infinite retry loop.
+    return code == SRT_ENOSERVER || code == SRT_ECONNLOST || code == SRT_ENOCONN
+        || code == SRT_ETIMEOUT;
+}
+
+[[nodiscard]] int udp_error_code()
+{
+#if defined(_WIN32)
+    return WSAGetLastError();
+#else
+    return errno;
+#endif
+}
+
+[[noreturn]] void udp_error(const char* operation)
+{
+    throw std::runtime_error(std::string {operation} + ": socket error "
+        + std::to_string(udp_error_code()));
+}
+
+class Runtime {
+public:
+    Runtime()
+    {
+        if (srt_startup() == SRT_ERROR) {
+            srt_error("srt_startup");
+        }
+    }
+    ~Runtime()
+    {
+        (void)srt_cleanup();
+    }
+    Runtime(const Runtime&) = delete;
+    Runtime& operator=(const Runtime&) = delete;
+};
+
+class SrtSocket {
+public:
+    explicit SrtSocket(SRTSOCKET value)
+        : value_(value)
+    {
+    }
+    ~SrtSocket()
+    {
+        if (value_ != SRT_INVALID_SOCK) {
+            (void)srt_close(value_);
+        }
+    }
+    SrtSocket(const SrtSocket&) = delete;
+    SrtSocket& operator=(const SrtSocket&) = delete;
+    [[nodiscard]] SRTSOCKET get() const
+    {
+        return value_;
+    }
+
+private:
+    SRTSOCKET value_;
+};
+
+class UdpSocket {
+public:
+    UdpSocket()
+        : value_(::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP))
+    {
+        if (value_ == SYSSOCKET_INVALID) {
+            udp_error("UDP socket");
+        }
+    }
+    ~UdpSocket()
+    {
+#if defined(_WIN32)
+        (void)closesocket(value_);
+#else
+        (void)::close(value_);
+#endif
+    }
+    UdpSocket(const UdpSocket&) = delete;
+    UdpSocket& operator=(const UdpSocket&) = delete;
+    [[nodiscard]] SYSSOCKET get() const
+    {
+        return value_;
+    }
+
+private:
+    SYSSOCKET value_;
+};
+
+struct Configuration {
+    bool sender = false;
+    bool listener = false;
+    bool rendezvous = false;
+    std::string udp_host = "127.0.0.1";
+    std::string srt_host;
+    std::string srt_bind_host;
+    int srt_local_port = 0;
+    int udp_port = 0;
+    int srt_port = 0;
+    int latency_ms = 120;
+    int connect_timeout_ms = 10000;
+    std::string udp_interface = "0.0.0.0";
+    int udp_ttl = 1;
+    bool reconnect = false;
+    int reconnect_delay_ms = 1000;
+    int peer_idle_timeout_ms = 5000;
+    int stats_interval_ms = 1000;
+    int input_idle_ms = 2000;
+    std::string passphrase_env;
+    std::string stream_id;
+};
+
+void usage()
+{
+    std::cout
+        << "Usage: robotweax_srt_udp_bridge send|receive [options]\n"
+        << "  --udp-host IPv4      UDP input bind (send) / destination "
+           "(receive)\n"
+        << "                      Default: 127.0.0.1; multicast groups "
+           "supported\n"
+        << "  --udp-interface IPv4 Multicast local interface address (default "
+           "0.0.0.0: OS choice)\n"
+        << "  --udp-ttl N         Multicast output TTL, 1..255 (default 1)\n"
+        << "  --udp-port PORT      Required UDP input/output port\n"
+        << "  --srt-host IPv4      SRT remote (caller/rendezvous) / bind "
+           "(listener)\n"
+        << "                      Default: 127.0.0.1 caller/rendezvous / "
+           "0.0.0.0 "
+           "listener\n"
+        << "  --srt-port PORT      Required SRT port\n"
+        << "  --srt-mode MODE      caller|listener|rendezvous; default "
+           "send=caller, "
+           "receive=listener\n"
+        << "  --srt-bind-host IPv4 Rendezvous local bind address (default "
+           "0.0.0.0)\n"
+        << "  --srt-local-port PORT Required local port for rendezvous\n"
+        << "  --latency-ms MS      SRT latency, 20..60000 (default 120)\n"
+        << "  --connect-timeout-ms MS  Caller/rendezvous timeout (default "
+           "10000)\n"
+        << "  --stream-id ID       Caller Stream ID (optional)\n"
+        << "  --reconnect on|off   Retry transient SRT failures (default off)\n"
+        << "  --reconnect-delay-ms MS Retry delay, 100..60000 (default 1000)\n"
+        << "  --peer-idle-timeout-ms MS SRT peer timeout, 1000..60000 (default "
+           "5000)\n"
+        << "  --stats-interval-ms MS Status interval, 200..60000 (default "
+           "1000)\n"
+        << "  --input-idle-ms MS   Input inactivity threshold, 200..60000 "
+           "(default 2000)\n"
+        << "  --passphrase-env VAR AES-CTR, 256-bit key; read passphrase from "
+           "VAR\n"
+        << "Payload: raw MPEG-TS, 1..7 aligned 188-byte packets per UDP "
+           "datagram.\n"
+        << "Start the UDP source after CONNECTED. Ctrl+C stops the bridge.\n"
+        << "No RTP, transcoding, or hard-real-time "
+           "guarantee.\n";
+}
+
+[[nodiscard]] int integer(std::string_view text, int minimum, int maximum)
+{
+    int value = 0;
+    const auto result =
+        std::from_chars(text.data(), text.data() + text.size(), value);
+    if (result.ec != std::errc {} || result.ptr != text.data() + text.size()
+        || value < minimum || value > maximum) {
+        throw std::runtime_error(
+            "invalid numeric option: " + std::string {text});
+    }
+    return value;
+}
+
+[[nodiscard]] Configuration parse(int argc, char** argv)
+{
+    if (argc < 2
+        || (std::string_view {argv[1]} != "send"
+            && std::string_view {argv[1]} != "receive")) {
+        throw std::runtime_error(
+            "choose send or receive; use --help for options");
+    }
+    Configuration c;
+    c.sender = std::string_view {argv[1]} == "send";
+    c.listener = !c.sender;
+    bool ttl_explicit = false;
+    for (int i = 2; i < argc; ++i) {
+        const std::string_view option {argv[i]};
+        if (++i == argc) {
+            throw std::runtime_error(
+                "missing value for " + std::string {option});
+        }
+        const std::string value {argv[i]};
+        if (option == "--udp-host") {
+            c.udp_host = value;
+        } else if (option == "--udp-interface") {
+            c.udp_interface = value;
+        } else if (option == "--udp-ttl") {
+            c.udp_ttl = integer(value, 1, 255);
+            ttl_explicit = true;
+        } else if (option == "--reconnect") {
+            if (value != "on" && value != "off") {
+                throw std::runtime_error("--reconnect must be on or off");
+            }
+            c.reconnect = value == "on";
+        } else if (option == "--reconnect-delay-ms") {
+            c.reconnect_delay_ms = integer(value, 100, 60000);
+        } else if (option == "--peer-idle-timeout-ms") {
+            c.peer_idle_timeout_ms = integer(value, 1000, 60000);
+        } else if (option == "--stats-interval-ms") {
+            c.stats_interval_ms = integer(value, 200, 60000);
+        } else if (option == "--input-idle-ms") {
+            c.input_idle_ms = integer(value, 200, 60000);
+        } else if (option == "--udp-port") {
+            c.udp_port = integer(value, 1, 65535);
+        } else if (option == "--srt-host") {
+            c.srt_host = value;
+        } else if (option == "--srt-port") {
+            c.srt_port = integer(value, 1, 65535);
+        } else if (option == "--srt-bind-host") {
+            if (value.empty()) {
+                throw std::runtime_error(
+                    "--srt-bind-host requires an IPv4 address");
+            }
+            c.srt_bind_host = value;
+        } else if (option == "--srt-local-port") {
+            c.srt_local_port = integer(value, 1, 65535);
+        } else if (option == "--latency-ms") {
+            c.latency_ms = integer(value, 20, 60000);
+        } else if (option == "--connect-timeout-ms") {
+            c.connect_timeout_ms = integer(value, 1, 60000);
+        } else if (option == "--srt-mode") {
+            if (value != "caller" && value != "listener"
+                && value != "rendezvous") {
+                throw std::runtime_error(
+                    "--srt-mode must be caller, listener or rendezvous");
+            }
+            c.listener = value == "listener";
+            c.rendezvous = value == "rendezvous";
+        } else if (option == "--passphrase-env") {
+            if (value.empty()) {
+                throw std::runtime_error(
+                    "--passphrase-env requires a variable name");
+            }
+            c.passphrase_env = value;
+        } else if (option == "--stream-id") {
+            c.stream_id = value;
+        } else {
+            throw std::runtime_error("unknown option: " + std::string {option});
+        }
+    }
+    if (c.udp_port == 0 || c.srt_port == 0) {
+        throw std::runtime_error("--udp-port and --srt-port are required");
+    }
+    in_addr udp_ip {};
+    const bool multicast = inet_pton(AF_INET, c.udp_host.c_str(), &udp_ip) == 1
+        && (ntohl(udp_ip.s_addr) & 0xf0000000U) == 0xe0000000U;
+    if ((ttl_explicit && (c.sender || !multicast))
+        || (c.udp_interface != "0.0.0.0" && !multicast)) {
+        throw std::runtime_error(
+            "--udp-interface requires multicast; --udp-ttl requires multicast "
+            "output (receive)");
+    }
+    if ((c.listener || c.rendezvous) && !c.stream_id.empty()) {
+        throw std::runtime_error(
+            "--stream-id is only supported in caller mode");
+    }
+    if (c.srt_host.empty()) {
+        c.srt_host = c.listener ? "0.0.0.0" : "127.0.0.1";
+    }
+    if (c.rendezvous && c.srt_local_port == 0) {
+        throw std::runtime_error("rendezvous requires --srt-local-port");
+    }
+    if (!c.rendezvous && (c.srt_local_port != 0 || !c.srt_bind_host.empty())) {
+        throw std::runtime_error(
+            "--srt-local-port and --srt-bind-host require rendezvous mode");
+    }
+    if (c.srt_bind_host.empty()) {
+        c.srt_bind_host = "0.0.0.0";
+    }
+    return c;
+}
+
+[[nodiscard]] sockaddr_in endpoint(const std::string& host, int port,
+    bool binding, bool allow_multicast = false)
+{
+    sockaddr_in address {};
+    address.sin_family = AF_INET;
+    address.sin_port = htons(static_cast<std::uint16_t>(port));
+    if (inet_pton(AF_INET, host.c_str(), &address.sin_addr) != 1) {
+        throw std::runtime_error("a numeric IPv4 address is required: " + host);
+    }
+    const auto ip = ntohl(address.sin_addr.s_addr);
+    if (ip >= 0xf0000000U || (ip >= 0xe0000000U && !allow_multicast)
+        || (!binding && ip == 0)) {
+        throw std::runtime_error("unicast IPv4 address required: " + host);
+    }
+    return address;
+}
+
+template <typename T>
+void option(SRTSOCKET socket, SRT_SOCKOPT name, const T& value)
+{
+    if (srt_setsockflag(socket, name, &value, static_cast<int>(sizeof(value)))
+        == SRT_ERROR) {
+        srt_error("srt_setsockflag");
+    }
+}
+
+void configure(SRTSOCKET socket, const Configuration& c)
+{
+    option(socket, SRTO_TRANSTYPE, SRTT_LIVE);
+    option(socket, SRTO_MESSAGEAPI, true);
+    option(socket, SRTO_SENDER, c.sender);
+    option(socket, SRTO_TSBPDMODE, true);
+    option(socket, SRTO_LATENCY, c.latency_ms);
+    option(socket, SRTO_PAYLOADSIZE, max_payload);
+    option(socket, SRTO_CONNTIMEO, c.connect_timeout_ms);
+    option(socket, SRTO_PEERIDLETIMEO, c.peer_idle_timeout_ms);
+    option(socket, SRTO_SNDTIMEO, 1000);
+    option(socket, SRTO_RCVTIMEO, 250);
+    if (!c.stream_id.empty()
+        && srt_setsockflag(socket, SRTO_STREAMID, c.stream_id.data(),
+               static_cast<int>(c.stream_id.size()))
+            == SRT_ERROR) {
+        srt_error("Stream ID");
+    }
+    if (!c.passphrase_env.empty()) {
+        const char* secret = std::getenv(c.passphrase_env.c_str());
+        if (secret == nullptr || std::string_view {secret}.size() < 10
+            || std::string_view {secret}.size() > 79) {
+            throw std::runtime_error(
+                "passphrase environment variable must contain 10..79 bytes");
+        }
+        if (srt_setsockflag(socket, SRTO_PASSPHRASE, secret,
+                static_cast<int>(std::string_view {secret}.size()))
+            == SRT_ERROR) {
+            // Never include secret contents in diagnostics.
+            throw std::runtime_error("cannot configure passphrase");
+        }
+        option(socket, SRTO_PBKEYLEN, 32);
+    }
+#ifdef ENABLE_AEAD_API_PREVIEW
+    // This demo selects CTR explicitly even in an extension-enabled build.
+    option(socket, SRTO_CRYPTOMODE, 1);
+#endif
+}
+
+[[nodiscard]] SRTSOCKET accept_connection(SRTSOCKET listener)
+{
+    option(listener, SRTO_RCVSYN, false);
+    if (srt_listen(listener, 1) == SRT_ERROR) {
+        srt_error("srt_listen");
+    }
+    std::cout << "READY SRT listener" << std::endl;
+    while (!stopping) {
+        const auto accepted = srt_accept(listener, nullptr, nullptr);
+        if (accepted != SRT_INVALID_SOCK) {
+            return accepted;
+        }
+        if (srt_getlasterror(nullptr) != SRT_EASYNCRCV) {
+            srt_error("srt_accept");
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds {50});
+    }
+    return SRT_INVALID_SOCK;
+}
+
+void validate_ts(const char* bytes, int size)
+{
+    if (size <= 0 || size > max_payload || size % 188 != 0) {
+        throw std::runtime_error(
+            "invalid MPEG-TS datagram: need 188..1316 bytes, multiple of 188");
+    }
+    for (int offset = 0; offset < size; offset += 188) {
+        if (static_cast<unsigned char>(bytes[offset]) != 0x47U) {
+            throw std::runtime_error(
+                "invalid MPEG-TS sync byte (RTP is not supported)");
+        }
+    }
+}
+
+[[nodiscard]] bool udp_readable(SYSSOCKET socket)
+{
+#if !defined(_WIN32)
+    if (socket >= FD_SETSIZE) {
+        throw std::runtime_error("UDP descriptor exceeds select capacity");
+    }
+#endif
+    fd_set readable;
+    FD_ZERO(&readable);
+    FD_SET(socket, &readable);
+    timeval timeout {0, 250000};
+#if defined(_WIN32)
+    const int result = select(0, &readable, nullptr, nullptr, &timeout);
+#else
+    const int result =
+        select(socket + 1, &readable, nullptr, nullptr, &timeout);
+#endif
+    if (result < 0) {
+        if (stopping) {
+            return false;
+        }
+        udp_error("UDP select");
+    }
+    return result > 0;
+}
+
+template <typename T>
+void udp_option(SYSSOCKET socket, int level, int name, const T& value)
+{
+    if (setsockopt(socket, level, name, reinterpret_cast<const char*>(&value),
+            static_cast<int>(sizeof(value)))
+        != 0) {
+        udp_error("UDP setsockopt");
+    }
+}
+
+void configure_udp(
+    SYSSOCKET udp, const Configuration& c, const sockaddr_in& address)
+{
+#if defined(_WIN32)
+    const DWORD send_timeout = 1000;
+#else
+    const timeval send_timeout {1, 0};
+#endif
+    udp_option(udp, SOL_SOCKET, SO_SNDTIMEO, send_timeout);
+    const bool multicast =
+        (ntohl(address.sin_addr.s_addr) & 0xf0000000U) == 0xe0000000U;
+    const auto local_interface = endpoint(c.udp_interface, 0, true).sin_addr;
+    if (c.sender) {
+        auto binding = address;
+        if (multicast) {
+            udp_option(udp, SOL_SOCKET, SO_REUSEADDR, 1);
+            binding.sin_addr.s_addr = htonl(INADDR_ANY);
+        }
+        if (::bind(udp, reinterpret_cast<const sockaddr*>(&binding),
+                sizeof(binding))
+            != 0) {
+            udp_error("UDP bind");
+        }
+        if (multicast) {
+            ip_mreq membership {};
+            membership.imr_multiaddr = address.sin_addr;
+            membership.imr_interface = local_interface;
+            udp_option(udp, IPPROTO_IP, IP_ADD_MEMBERSHIP, membership);
+#if defined(__linux__) && defined(IP_MULTICAST_ALL)
+            // A shared port must not subscribe this socket to other sockets' groups.
+            udp_option(udp, IPPROTO_IP, IP_MULTICAST_ALL, 0);
+#endif
+        }
+    } else if (multicast) {
+        udp_option(udp, IPPROTO_IP, IP_MULTICAST_IF, local_interface);
+#if defined(_WIN32)
+        const DWORD ttl = static_cast<DWORD>(c.udp_ttl);
+#else
+        const auto ttl = static_cast<unsigned char>(c.udp_ttl);
+#endif
+        udp_option(udp, IPPROTO_IP, IP_MULTICAST_TTL, ttl);
+    }
+}
+
+using Clock = std::chrono::steady_clock;
+
+struct ConnectionHistory {
+    unsigned generation = 0;
+    std::optional<Clock::time_point> disconnected;
+};
+
+void relay(SRTSOCKET srt, const Configuration& c, ConnectionHistory& history)
+{
+    const bool sender = c.sender;
+    const auto destination = endpoint(c.udp_host, c.udp_port, sender, true);
+    // Do not buffer live input while disconnected. Rejoining/binding only after
+    // SRT establishment prevents stale UDP backlog crossing connection epochs.
+    UdpSocket udp_socket;
+    const auto udp = udp_socket.get();
+    configure_udp(udp, c, destination);
+    // Receive a full UDP datagram before validating, never a silently truncated TS payload.
+    std::array<char, 65536> buffer {};
+    std::uint64_t packets = 0;
+    std::uint64_t bytes = 0;
+    auto last_report = Clock::now();
+    auto last_input = last_report;
+    std::uint64_t previous_bytes = 0;
+    bool received_input = false;
+    ++history.generation;
+    std::cout << "CONNECTED direction=" << (sender ? "UDP->SRT" : "SRT->UDP")
+              << " generation=" << history.generation;
+    if (history.disconnected) {
+        std::cout << " recovery_ms="
+                  << std::chrono::duration_cast<std::chrono::milliseconds>(
+                         last_report - *history.disconnected)
+                         .count();
+        history.disconnected.reset();
+    }
+    std::cout << std::endl;
+    while (!stopping) {
+        const auto now = Clock::now();
+        if (now - last_report
+            >= std::chrono::milliseconds {c.stats_interval_ms}) {
+            const auto idle_ms =
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    now - last_input)
+                    .count();
+            const double rate = static_cast<double>(bytes - previous_bytes)
+                * 8.0 / std::chrono::duration<double>(now - last_report).count()
+                / 1000000.0;
+            std::cout << "STATUS connection=CONNECTED generation="
+                      << history.generation << " input="
+                      << (idle_ms >= c.input_idle_ms
+                                 ? "IDLE"
+                                 : (received_input ? "ACTIVE" : "WAITING"))
+                      << " input_kind=" << (sender ? "UDP" : "SRT")
+                      << " input_age_ms=" << idle_ms
+                      << " forwarded_datagrams=" << packets
+                      << " forwarded_bytes=" << bytes
+                      << " input_payload_mbps=" << rate
+                      << " output_payload_mbps=" << rate;
+            // Non-destructive snapshot: never reset the application's counters.
+            SRT_TRACEBSTATS stats {};
+            if (srt_bistats(srt, &stats, 0, 1) == SRT_ERROR) {
+                std::cout << " stats_available=false";
+            } else {
+                std::cout << " stats_available=true rtt_ms=" << stats.msRTT
+                          << " retrans_total=" << stats.pktRetransTotal
+                          << " snd_drop_total=" << stats.pktSndDropTotal
+                          << " rcv_drop_total=" << stats.pktRcvDropTotal
+                          << " snd_buffer_bytes=" << stats.byteSndBuf
+                          << " rcv_buffer_bytes=" << stats.byteRcvBuf
+                          << " snd_buffer_ms=" << stats.msSndBuf
+                          << " rcv_buffer_ms=" << stats.msRcvBuf
+                          << " snd_latency_ms=" << stats.msSndTsbPdDelay
+                          << " rcv_latency_ms=" << stats.msRcvTsbPdDelay;
+            }
+            std::cout << std::endl;
+            last_report = now;
+            previous_bytes = bytes;
+        }
+        if (sender) {
+            if (srt_getsockstate(srt) != SRTS_CONNECTED) {
+                throw TransportFailure("SRT disconnected", SRT_ECONNLOST);
+            }
+            if (!udp_readable(udp)) {
+                continue;
+            }
+            const int count = static_cast<int>(
+                recv(udp, buffer.data(), static_cast<int>(buffer.size()), 0));
+            if (count < 0) {
+                if (stopping) {
+                    break;
+                }
+                udp_error("UDP receive");
+            }
+            validate_ts(buffer.data(), count);
+            const int sent = srt_sendmsg(srt, buffer.data(), count, -1, 1);
+            if (sent == SRT_ERROR) {
+                transport_error("SRT send (backpressure or connection failure; "
+                                "current datagram delivery unknown)");
+            }
+            if (sent != count) {
+                throw std::runtime_error("unexpected partial SRT Message send");
+            }
+            bytes += static_cast<std::uint64_t>(count);
+        } else {
+            const int count = srt_recvmsg(
+                srt, buffer.data(), static_cast<int>(buffer.size()));
+            if (count == SRT_ERROR) {
+                if (srt_getlasterror(nullptr) == SRT_ETIMEOUT) {
+                    continue;
+                }
+                transport_error("SRT receive");
+            }
+            validate_ts(buffer.data(), count);
+            const int sent = static_cast<int>(sendto(udp, buffer.data(), count,
+                0, reinterpret_cast<const sockaddr*>(&destination),
+                sizeof(destination)));
+            if (sent < 0) {
+                udp_error("UDP send");
+            }
+            if (sent != count) {
+                throw std::runtime_error(
+                    "unexpected partial UDP datagram send");
+            }
+            bytes += static_cast<std::uint64_t>(count);
+        }
+        ++packets;
+        received_input = true;
+        last_input = Clock::now();
+    }
+    std::cout << "STOPPED datagrams=" << packets << " bytes=" << bytes
+              << std::endl;
+}
+
+void session(const Configuration& c, ConnectionHistory& history)
+{
+    const auto srt_address = endpoint(c.srt_host, c.srt_port, c.listener);
+    SrtSocket socket {srt_create_socket()};
+    if (socket.get() == SRT_INVALID_SOCK) {
+        srt_error("srt_create_socket");
+    }
+    configure(socket.get(), c);
+    if (c.rendezvous) {
+        const auto local = endpoint(c.srt_bind_host, c.srt_local_port, true);
+        std::cout << "CONNECTING SRT rendezvous local=" << c.srt_bind_host
+                  << ':' << c.srt_local_port << " peer=" << c.srt_host << ':'
+                  << c.srt_port << std::endl;
+        // The public helper enables rendezvous and binds before connecting.
+        // Both processes must connect within their connection timeout window.
+        if (srt_rendezvous(socket.get(),
+                reinterpret_cast<const sockaddr*>(&local), sizeof(local),
+                reinterpret_cast<const sockaddr*>(&srt_address),
+                sizeof(srt_address))
+            == SRT_ERROR) {
+            transport_error("srt_rendezvous");
+        }
+        relay(socket.get(), c, history);
+    } else if (c.listener) {
+        if (srt_bind(socket.get(),
+                reinterpret_cast<const sockaddr*>(&srt_address),
+                sizeof(srt_address))
+            == SRT_ERROR) {
+            srt_error("srt_bind");
+        }
+        SrtSocket accepted {accept_connection(socket.get())};
+        if (accepted.get() != SRT_INVALID_SOCK) {
+            option(accepted.get(), SRTO_RCVSYN, true);
+            option(accepted.get(), SRTO_RCVTIMEO, 250);
+            relay(accepted.get(), c, history);
+        }
+    } else {
+        std::cout << "CONNECTING SRT caller peer=" << c.srt_host << ':'
+                  << c.srt_port << std::endl;
+        if (srt_connect(socket.get(),
+                reinterpret_cast<const sockaddr*>(&srt_address),
+                sizeof(srt_address))
+            == SRT_ERROR) {
+            transport_error("srt_connect");
+        }
+        relay(socket.get(), c, history);
+    }
+}
+
+int run(const Configuration& c)
+{
+    Runtime runtime;
+    // Fail invalid addresses before entering the reconnect loop.
+    (void)endpoint(c.udp_host, c.udp_port, c.sender, true);
+    (void)endpoint(c.udp_interface, 0, true);
+    ConnectionHistory history;
+    unsigned retries = 0;
+    while (!stopping) {
+        try {
+            session(c, history);
+            break;
+        } catch (const TransportFailure& error) {
+            if (stopping) {
+                break;
+            }
+            if (!history.disconnected) {
+                history.disconnected = Clock::now();
+            }
+            std::cout << "DISCONNECTED generation=" << history.generation
+                      << " srt_error=" << error.code
+                      << " reason=" << error.what() << std::endl;
+            if (!c.reconnect || !retryable(error.code)) {
+                throw;
+            }
+            std::cout << "RECONNECTING attempt=" << ++retries
+                      << " delay_ms=" << c.reconnect_delay_ms << std::endl;
+            const auto deadline =
+                Clock::now() + std::chrono::milliseconds {c.reconnect_delay_ms};
+            while (!stopping && Clock::now() < deadline) {
+                std::this_thread::sleep_for(std::chrono::milliseconds {50});
+            }
+        }
+    }
+    std::cout << "STOPPED connections=" << history.generation
+              << " retries=" << retries << std::endl;
+    return 0;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    if (argc == 2 && std::string_view {argv[1]} == "--help") {
+        usage();
+        return 0;
+    }
+    std::signal(SIGINT, stop);
+    std::signal(SIGTERM, stop);
+    try {
+        return run(parse(argc, argv));
+    } catch (const std::exception& error) {
+        std::cerr << "ERROR " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/examples/test_udp_bridge.py
+++ b/examples/test_udp_bridge.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Public-API UDP/SRT/UDP datagram-integrity and rejection smoke tests."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import queue
+import socket
+import subprocess
+import threading
+import time
+
+
+class Peer:
+    def __init__(self, command: list[str], environment: dict[str, str]) -> None:
+        self.process = subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, env=environment,
+        )
+        self.lines: list[str] = []
+        self.events: queue.Queue[str] = queue.Queue()
+        self.reader = threading.Thread(target=self.read, daemon=True)
+        self.reader.start()
+
+    def read(self) -> None:
+        assert self.process.stdout is not None
+        for line in self.process.stdout:
+            self.lines.append(line)
+            self.events.put(line)
+        self.events.put("EOF")
+
+    def wait_for(self, prefix: str, contains: str = "") -> str:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            try:
+                line = self.events.get(timeout=max(0.01, deadline - time.monotonic()))
+            except queue.Empty:
+                break
+            if line.startswith(prefix) and contains in line:
+                return line
+            if line == "EOF":
+                break
+        raise AssertionError(f"missing {prefix}: {''.join(self.lines)}")
+
+    def close(self) -> None:
+        if self.process.poll() is None:
+            self.process.terminate()
+        try:
+            self.process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.process.kill()
+            self.process.wait(timeout=5)
+            raise AssertionError("bridge failed to stop")
+        finally:
+            self.reader.join(timeout=2)
+            if self.process.stdout is not None:
+                self.process.stdout.close()
+
+
+def free_port(excluded: set[int]) -> int:
+    for _ in range(30):
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as candidate:
+            candidate.bind(("127.0.0.1", 0))
+            port = candidate.getsockname()[1]
+            if port not in excluded:
+                return int(port)
+    raise RuntimeError("cannot allocate distinct loopback ports")
+
+
+def run_bridge(demo: Path, reverse: bool = False, encrypted: bool = False,
+               invalid: bytes | None = None, rendezvous: bool = False,
+               multicast: bool = False, restart_sender: bool | None = None) -> None:
+    environment = os.environ.copy()
+    secret_name = "ROBOTWEAX_BRIDGE_TEST_SECRET"
+    environment[secret_name] = "public-loopback-fixture-only"
+    peers: list[Peer] = []
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sink, \
+            socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as source:
+        input_host = "239.255.42.1" if multicast else "127.0.0.1"
+        output_host = "239.255.42.2" if multicast else "127.0.0.1"
+        sink.bind(("0.0.0.0" if multicast else "127.0.0.1", 0))
+        if multicast:
+            sink.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP,
+                            socket.inet_aton(output_host) + socket.inet_aton("127.0.0.1"))
+            source.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF,
+                              socket.inet_aton("127.0.0.1"))
+            source.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 1)
+        sink.settimeout(5)
+        output_port = int(sink.getsockname()[1])
+        input_port = free_port({output_port})
+        srt_port = free_port({input_port, output_port})
+        common = ["--srt-host", "127.0.0.1",
+                  "--latency-ms", "40", "--stats-interval-ms", "200",
+                  "--input-idle-ms", "400"]
+        if restart_sender is not None or invalid is not None:
+            common += ["--reconnect", "on", "--reconnect-delay-ms", "200",
+                       "--connect-timeout-ms", "2000", "--peer-idle-timeout-ms", "1000"]
+        if encrypted:
+            common += ["--passphrase-env", secret_name]
+        sender_command = [str(demo), "send", "--udp-port", str(input_port),
+                          "--srt-mode", "listener" if reverse else "caller",
+                          "--srt-port", str(srt_port), *common]
+        receiver_command = [str(demo), "receive", "--udp-port", str(output_port),
+                            "--srt-mode", "caller" if reverse else "listener",
+                            "--srt-port", str(srt_port), *common]
+        if rendezvous:
+            second_port = free_port({input_port, output_port, srt_port})
+            rv_common = [*common, "--srt-mode", "rendezvous",
+                         "--srt-bind-host", "127.0.0.1"]
+            sender_command = [str(demo), "send", "--udp-port", str(input_port),
+                              "--srt-port", str(second_port), "--srt-local-port",
+                              str(srt_port), *rv_common]
+            receiver_command = [str(demo), "receive", "--udp-port", str(output_port),
+                                "--srt-port", str(srt_port), "--srt-local-port",
+                                str(second_port), *rv_common]
+        sender_command += ["--udp-host", input_host]
+        receiver_command += ["--udp-host", output_host]
+        if multicast:
+            sender_command += ["--udp-interface", "127.0.0.1"]
+            receiver_command += ["--udp-interface", "127.0.0.1", "--udp-ttl", "3"]
+        try:
+            listener = Peer(sender_command if reverse else receiver_command, environment)
+            peers.append(listener)
+            listener.wait_for("CONNECTING SRT rendezvous" if rendezvous else "READY")
+            caller = Peer(receiver_command if reverse else sender_command, environment)
+            peers.append(caller)
+            listener.wait_for("CONNECTED")
+            caller.wait_for("CONNECTED")
+            sender = listener if reverse else caller
+            receiver = caller if reverse else listener
+            if invalid is not None:
+                source.sendto(invalid, (input_host, input_port))
+                if sender.process.wait(timeout=5) != 1:
+                    raise AssertionError("invalid UDP payload was not rejected")
+                sender.reader.join(timeout=2)
+                if "invalid MPEG-TS" not in "".join(sender.lines):
+                    raise AssertionError(f"wrong rejection: {sender.lines}")
+                sink.settimeout(0.15)
+                try:
+                    sink.recv(65536)
+                except socket.timeout:
+                    pass
+                else:
+                    raise AssertionError("invalid payload reached UDP output")
+            else:
+                # All supported datagram sizes, distinct payloads, exact ordering.
+                # Receive each datagram before sending the next: no dependence on
+                # host UDP receive-buffer capacity or a fixed startup sleep.
+                for index in range(28):
+                    ts_packet = b"\x47" + bytes([index]) * 187
+                    payload = ts_packet * (1 + index % 7)
+                    source.sendto(payload, (input_host, input_port))
+                    actual = sink.recv(65536)
+                    if actual != payload:
+                        raise AssertionError(f"payload/datagram mismatch at {index}")
+                # A short paced stream also exercises multiple in-flight messages,
+                # unlike the request/receive checks above. This is not a benchmark.
+                stream = [(b"\x47" + bytes([index]) * 187) * 7 for index in range(128)]
+                errors: queue.Queue[Exception] = queue.Queue()
+
+                def feed() -> None:
+                    try:
+                        for payload in stream:
+                            source.sendto(payload, (input_host, input_port))
+                            time.sleep(0.002)
+                    except Exception as error:
+                        errors.put(error)
+
+                feeder = threading.Thread(target=feed, daemon=True)
+                feeder.start()
+                try:
+                    for index, payload in enumerate(stream):
+                        if sink.recv(65536) != payload:
+                            raise AssertionError(f"paced stream mismatch at {index}")
+                finally:
+                    feeder.join(timeout=5)
+                if feeder.is_alive() or not errors.empty():
+                    raise AssertionError("UDP source thread did not complete successfully")
+                sink.settimeout(0.1)
+                try:
+                    sink.recv(65536)
+                except socket.timeout:
+                    pass
+                else:
+                    raise AssertionError("duplicate output datagram")
+                if any(peer.process.poll() is not None for peer in peers):
+                    raise AssertionError("bridge stopped during live transfer")
+                for peer in (sender, receiver):
+                    active = peer.wait_for("STATUS", "input=ACTIVE")
+                    fields = dict(part.split("=", 1) for part in active.split()[1:])
+                    assert fields["stats_available"] == "true", active
+                    assert float(fields["output_payload_mbps"]) > 0, active
+                    assert int(fields["forwarded_bytes"]) > 0, active
+                    assert float(fields["rtt_ms"]) >= 0, active
+                    idle = peer.wait_for("STATUS", "input=IDLE")
+                    assert "connection=CONNECTED" in idle, idle
+                    assert "stats_available=true" in idle, idle
+                if restart_sender is not None:
+                    retired = sender if restart_sender else receiver
+                    survivor = receiver if restart_sender else sender
+                    retired.close()
+                    peers.remove(retired)
+                    survivor.wait_for("RECONNECTING")
+                    replacement = Peer(sender_command if restart_sender else receiver_command, environment)
+                    peers.append(replacement)
+                    recovered = survivor.wait_for("CONNECTED", "generation=2")
+                    assert "recovery_ms=" in recovered, recovered
+                    replacement.wait_for("CONNECTED")
+                    payload = (b"\x47" + b"\xab" * 187) * 7
+                    source.sendto(payload, (input_host, input_port))
+                    sink.settimeout(5)
+                    assert sink.recv(65536) == payload, "restart payload mismatch"
+        except Exception as error:
+            raise AssertionError(
+                f"reverse={reverse}, rendezvous={rendezvous}, encrypted={encrypted}, "
+                f"invalid={invalid is not None}: "
+                f"{error}\n" + "\n".join("".join(peer.lines) for peer in peers)
+            ) from error
+        finally:
+            for peer in reversed(peers):
+                peer.close()
+
+
+def run_failure_policy(demo: Path) -> None:
+    """No-server retry, default-off disconnect and fatal auth rejection."""
+    for scenario in ("late-listener", "reconnect-off", "wrong-passphrase"):
+        input_port = free_port(set())
+        output_port = free_port({input_port})
+        srt_port = free_port({input_port, output_port})
+        common = ["--srt-host", "127.0.0.1", "--srt-port", str(srt_port),
+                  "--connect-timeout-ms", "1000", "--peer-idle-timeout-ms", "1000"]
+        sender_command = [str(demo), "send", "--udp-port", str(input_port), *common]
+        receiver_command = [str(demo), "receive", "--udp-port", str(output_port), *common]
+        sender_env = os.environ.copy()
+        receiver_env = os.environ.copy()
+        if scenario != "reconnect-off":
+            sender_command += ["--reconnect", "on", "--reconnect-delay-ms", "200"]
+        if scenario == "wrong-passphrase":
+            sender_command += ["--passphrase-env", "BRIDGE_POLICY_TEST_SECRET"]
+            receiver_command += ["--passphrase-env", "BRIDGE_POLICY_TEST_SECRET"]
+            sender_env["BRIDGE_POLICY_TEST_SECRET"] = "public-wrong-fixture"
+            receiver_env["BRIDGE_POLICY_TEST_SECRET"] = "public-right-fixture"
+        peers: list[Peer] = []
+        try:
+            if scenario == "late-listener":
+                sender = Peer(sender_command, sender_env)
+                peers.append(sender)
+                sender.wait_for("RECONNECTING")
+            receiver = Peer(receiver_command, receiver_env)
+            peers.append(receiver)
+            receiver.wait_for("READY")
+            if scenario != "late-listener":
+                sender = Peer(sender_command, sender_env)
+                peers.append(sender)
+            if scenario != "wrong-passphrase":
+                sender.wait_for("CONNECTED")
+                receiver.wait_for("CONNECTED")
+            if scenario == "reconnect-off":
+                receiver.close()
+                peers.remove(receiver)
+            if scenario != "late-listener":
+                assert sender.process.wait(timeout=5) == 1, scenario
+                sender.reader.join(timeout=2)
+                assert not any(line.startswith("RECONNECTING") for line in sender.lines), sender.lines
+            if scenario == "wrong-passphrase":
+                assert not any("public-wrong-fixture" in line or "public-right-fixture" in line
+                               for peer in peers for line in peer.lines), "secret in logs"
+        except Exception as error:
+            raise AssertionError(f"{scenario}: {error}\n" + "\n".join("".join(p.lines) for p in peers)) from error
+        finally:
+            for peer in reversed(peers):
+                peer.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--demo", type=Path, required=True)
+    demo = parser.parse_args().demo.resolve()
+    help_result = subprocess.run([str(demo), "--help"], capture_output=True, timeout=5)
+    assert help_result.returncode == 0
+    invalid_cli = subprocess.run(
+        [str(demo), "send", "--udp-port", "0", "--srt-port", "9000"],
+        capture_output=True, timeout=5,
+    )
+    assert invalid_cli.returncode == 1
+    for extra in (["--passphrase-env", ""],
+                  ["--passphrase-env", "ROBOTWEAX_UNSET_TEST_SECRET"],
+                  ["--srt-mode", "rendezvous"],
+                  ["--srt-mode", "unknown"],
+                  ["--srt-local-port", "9001"],
+                  ["--srt-bind-host", "127.0.0.1"],
+                  ["--srt-mode", "rendezvous", "--srt-local-port", "9001",
+                   "--stream-id", "not-supported-in-rendezvous"],
+                  ["--udp-interface", "127.0.0.1"],
+                  ["--udp-host", "239.1.2.3", "--udp-ttl", "2"],
+                  ["--reconnect", "maybe"],
+                  ["--stats-interval-ms", "0"]):
+        environment = os.environ.copy()
+        environment.pop("ROBOTWEAX_UNSET_TEST_SECRET", None)
+        rejected = subprocess.run(
+            [str(demo), "send", "--udp-port", str(free_port(set())),
+             "--srt-port", "9000", *extra],
+            capture_output=True, timeout=5, env=environment,
+        )
+        assert rejected.returncode == 1, extra
+    for reverse, encrypted in ((False, False), (True, False), (False, True)):
+        run_bridge(demo, reverse=reverse, encrypted=encrypted)
+    for reverse in (False, True):
+        for encrypted in (False, True):
+            run_bridge(demo, reverse=reverse, encrypted=encrypted, rendezvous=True)
+    for invalid in (b"", b"not MPEG-TS", b"\x00" * 188,
+                    (b"\x47" + b"\x00" * 187) * 8):
+        run_bridge(demo, invalid=invalid)
+    run_bridge(demo, multicast=True)
+    for reverse in (False, True):
+        for restart_sender in (False, True):
+            run_bridge(demo, reverse=reverse, restart_sender=restart_sender)
+    for restart_sender in (False, True):
+        run_bridge(demo, rendezvous=True, restart_sender=restart_sender)
+    run_failure_policy(demo)
+    print("PASS UDP->SRT->UDP: exact datagrams, all SRT roles, AES-CTR, multicast, stats, reconnect, invalid payload rejection")
+
+
+if __name__ == "__main__":
+    main()

--- a/interop/tests/test_ci_build_scope.py
+++ b/interop/tests/test_ci_build_scope.py
@@ -151,7 +151,7 @@ class CiConsumerScopeTests(unittest.TestCase):
                     targets = ["robotweax_srt"]
                     if examples:
                         targets += ["robotweax_srt_message_demo", "robotweax_srt_file_demo",
-                                    "robotweax_srt_group_demo"]
+                                    "robotweax_srt_group_demo", "robotweax_srt_udp_bridge"]
                     self.assertEqual(calls, [["--build", "build", "--config", "Release",
                                              "--parallel", "--target"] + targets])
                     test = self.step(job, "Test selected public consumers")

--- a/interop/tests/test_ci_changes.py
+++ b/interop/tests/test_ci_changes.py
@@ -145,6 +145,16 @@ class CiChangeClassifierTests(unittest.TestCase):
         self.assertFalse(harness.interop)
         self.assertFalse(harness.full)
 
+    def test_udp_bridge_changes_remain_in_public_example_scope(self) -> None:
+        for path in ("examples/srt_udp_bridge.cpp", "examples/test_udp_bridge.py"):
+            with self.subTest(path=path):
+                result = ci_changes.classify([path])
+                self.assertTrue(result.examples)
+                self.assertTrue(result.portable)
+                self.assertFalse(result.core_tests)
+                self.assertFalse(result.interop)
+                self.assertFalse(result.full)
+
     def test_runtime_scheduler_selects_caller_establishment_profiles(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

Add an opt-in public-API MPEG-TS UDP → SRT → UDP example for broadcaster evaluation. This is an unreleased example addition, not a change to the v0.2.3 tag or to the library ABI.

- Caller, Listener and Rendezvous in both media directions; optional AES-CTR from an environment variable.
- IPv4 UDP unicast and any-source multicast input/output, explicit local multicast interface and output TTL.
- Periodic active/idle status, payload forwarding rates, non-destructive public SRT statistics, buffer occupancy and effective TSBPD delays.
- Opt-in reconnect with error classification, connection generations and measured recovery time. No UDP buffering across disconnected sessions; authentication/configuration/payload errors remain fatal.
- Raw TS datagrams are preserved byte-for-byte; no RTP, transcoding, PCR restamping or private wire framing.
- Public build/source/player/multicast/recovery documentation and focused automated coverage.

## Validation

- macOS arm64 Release static and shared builds; shared build with AEAD preview enabled explicitly retains CTR in this demo.
- Complete bridge loopback suite: all seven TS datagram sizes, paced data, both Caller/Listener directions, both Rendezvous startup orders, encryption, multicast input/output, live and idle status, sender/receiver restart in every SRT role, late listener, default-off disconnect, fatal wrong-passphrase and malformed-payload handling.
- Shared Release bridge suite passed in about 39 seconds.
- 59 CI scope/build regression tests passed; C++ strict warnings, clang-format, Python compilation, documentation link validation and git diff whitespace checks passed.
- Linux and Windows are to be verified by this PR CI. No local Linux runner is available. Real decoder playback and routed multicast/WAN impairment are not claimed as tested.

## CI scope and limits

Add the bridge to the existing opt-in example targets and example CTest label. A classifier regression test keeps subsequent example-only changes out of core and reference-interop jobs. This initial PR also touches CMake and CI wiring, so the existing conservative classification can select wider validation.

No library implementation or public API changes. No Haivision binaries or new release artifacts are distributed. Reconnect can lose live data; recovery starts at failure detection, not at the physical outage, and neither UDP forwarding counters nor SRT statistics prove end-to-end media delivery.
