### PR TITLE
Fix cleanup lifetime for application singletons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1427,53 +1427,12 @@ jobs:
           --reference-peer ./reference-api-peer
       - name: Run connection-group admission, payload, and late-join matrix
         if: matrix.profile == 'handshake'
-        env:
-          ROBOTWEAX_SRT_GROUP_PHASE_TRACE: "1"
-        run: |
-          # Temporary issue #5 PR diagnostic: preserve the original test and
-          # its exit status; collect only synthetic loopback traffic and logs.
-          if ! command -v tcpdump >/dev/null; then
-            sudo apt-get update
-            sudo apt-get install --no-install-recommends -y tcpdump
-          fi
-          mkdir -p group-reply-evidence
-          git rev-parse HEAD > group-reply-evidence/revision.txt
-          uname -a > group-reply-evidence/host.txt
-          c++ --version > group-reply-evidence/compiler.txt
-          sha256sum build/robotweax_srt_group_peer reference-group-peer reference-build/libsrt.a > group-reply-evidence/binaries.sha256
-          ldd reference-group-peer > group-reply-evidence/reference-linkage.txt
-          ldd build/robotweax_srt_group_peer > group-reply-evidence/robotweax-linkage.txt
-          for cache in build/CMakeCache.txt reference-build/CMakeCache.txt; do
-            if [[ -f "$cache" ]]; then
-              cp "$cache" "group-reply-evidence/$(dirname "$cache")-cache.txt"
-            fi
-          done
-          sudo tcpdump -i lo -n -s 0 -U -c 100000 -w "$PWD/group-reply-evidence/loopback.pcap" 'udp and (host 127.0.0.1 or host ::1)' > group-reply-evidence/tcpdump.log 2>&1 &
-          capture=$!
-          trap 'sudo kill -INT "$capture" 2>/dev/null || true' EXIT
-          sleep 1
-          kill -0 "$capture"
-          set +e
-          python3 interop/run_group_interop.py \
-            --robotweax-peer build/robotweax_srt_group_peer \
-            --reference-peer ./reference-group-peer \
-            --expected-reference-version "$REFERENCE_SRT_VERSION" \
-            --baseline-only \
-            --evidence-directory group-reply-evidence/cases > group-reply-evidence/driver.log 2>&1
-          status=$?
-          sudo kill -INT "$capture" 2>/dev/null
-          wait "$capture"
-          sudo chmod a+r group-reply-evidence/loopback.pcap
-          cat group-reply-evidence/driver.log
-          exit "$status"
-      - name: Preserve group reply diagnostic evidence (no binaries)
-        if: always() && matrix.profile == 'handshake'
-        uses: actions/upload-artifact@v7
-        with:
-          name: group-reply-${{ github.run_id }}-${{ github.run_attempt }}
-          path: group-reply-evidence/
-          retention-days: 7
-          if-no-files-found: warn
+        run: >-
+          python3 interop/run_group_interop.py
+          --robotweax-peer build/robotweax_srt_group_peer
+          --reference-peer ./reference-group-peer
+          --expected-reference-version "$REFERENCE_SRT_VERSION"
+          --baseline-only
       - name: Run individual Message and Stream receive contracts
         if: matrix.profile == 'handshake'
         run: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,6 +454,7 @@ jobs:
           --parallel
           --target robotweax_srt_shared_lifecycle_tests
           robotweax_srt_global_lifecycle_tests
+          robotweax_srt_late_cleanup_tests
           robotweax_srt_c_api_test
           robotweax_srt_compatible_header_test
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1427,12 +1427,53 @@ jobs:
           --reference-peer ./reference-api-peer
       - name: Run connection-group admission, payload, and late-join matrix
         if: matrix.profile == 'handshake'
-        run: >-
-          python3 interop/run_group_interop.py
-          --robotweax-peer build/robotweax_srt_group_peer
-          --reference-peer ./reference-group-peer
-          --expected-reference-version "$REFERENCE_SRT_VERSION"
-          --baseline-only
+        env:
+          ROBOTWEAX_SRT_GROUP_PHASE_TRACE: "1"
+        run: |
+          # Temporary issue #5 PR diagnostic: preserve the original test and
+          # its exit status; collect only synthetic loopback traffic and logs.
+          if ! command -v tcpdump >/dev/null; then
+            sudo apt-get update
+            sudo apt-get install --no-install-recommends -y tcpdump
+          fi
+          mkdir -p group-reply-evidence
+          git rev-parse HEAD > group-reply-evidence/revision.txt
+          uname -a > group-reply-evidence/host.txt
+          c++ --version > group-reply-evidence/compiler.txt
+          sha256sum build/robotweax_srt_group_peer reference-group-peer reference-build/libsrt.a > group-reply-evidence/binaries.sha256
+          ldd reference-group-peer > group-reply-evidence/reference-linkage.txt
+          ldd build/robotweax_srt_group_peer > group-reply-evidence/robotweax-linkage.txt
+          for cache in build/CMakeCache.txt reference-build/CMakeCache.txt; do
+            if [[ -f "$cache" ]]; then
+              cp "$cache" "group-reply-evidence/$(dirname "$cache")-cache.txt"
+            fi
+          done
+          sudo tcpdump -i lo -n -s 0 -U -c 100000 -w "$PWD/group-reply-evidence/loopback.pcap" 'udp and (host 127.0.0.1 or host ::1)' > group-reply-evidence/tcpdump.log 2>&1 &
+          capture=$!
+          trap 'sudo kill -INT "$capture" 2>/dev/null || true' EXIT
+          sleep 1
+          kill -0 "$capture"
+          set +e
+          python3 interop/run_group_interop.py \
+            --robotweax-peer build/robotweax_srt_group_peer \
+            --reference-peer ./reference-group-peer \
+            --expected-reference-version "$REFERENCE_SRT_VERSION" \
+            --baseline-only \
+            --evidence-directory group-reply-evidence/cases > group-reply-evidence/driver.log 2>&1
+          status=$?
+          sudo kill -INT "$capture" 2>/dev/null
+          wait "$capture"
+          sudo chmod a+r group-reply-evidence/loopback.pcap
+          cat group-reply-evidence/driver.log
+          exit "$status"
+      - name: Preserve group reply diagnostic evidence (no binaries)
+        if: always() && matrix.profile == 'handshake'
+        uses: actions/upload-artifact@v7
+        with:
+          name: group-reply-${{ github.run_id }}-${{ github.run_attempt }}
+          path: group-reply-evidence/
+          retention-days: 7
+          if-no-files-found: warn
       - name: Run individual Message and Stream receive contracts
         if: matrix.profile == 'handshake'
         run: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ version returned by `srt_getversion()`.
 
 ## Unreleased
 
+- Fix cleanup from an application singleton destructor when sockets, groups,
+  or epoll resources are first created after startup returns. Initialize
+  dormant cleanup dependencies before the application owner completes
+  construction; add process-exit coverage, including static SRT embedded in
+  a shared library (issue #5).
+
 - Add the opt-in `robotweax_srt_udp_bridge` demo for continuous raw MPEG-TS
   UDP → SRT → UDP forwarding using the public API. Supports IPv4 unicast/multicast,
   Caller/Listener and Rendezvous in either media direction, configurable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,6 +369,38 @@ if(ROBOTWEAX_SRT_BUILD_TESTS)
         robotweax_srt_global_lifecycle_tests
         PROPERTIES TIMEOUT 5)
 
+    add_executable(robotweax_srt_late_cleanup_tests
+        tests/late_cleanup_main.cpp tests/late_cleanup_probe.cpp)
+    target_link_libraries(robotweax_srt_late_cleanup_tests PRIVATE RobotweaxSRT::srt)
+    target_compile_features(robotweax_srt_late_cleanup_tests PRIVATE cxx_std_20)
+    set(ROBOTWEAX_SRT_LATE_CLEANUP_MODES
+        socket startup-only retained epoll group restart explicit
+        implicit-socket implicit-group implicit-epoll)
+    foreach(mode IN LISTS ROBOTWEAX_SRT_LATE_CLEANUP_MODES)
+        add_test(NAME robotweax_srt_late_cleanup_${mode}
+            COMMAND robotweax_srt_late_cleanup_tests ${mode})
+        set_tests_properties(robotweax_srt_late_cleanup_${mode} PROPERTIES TIMEOUT 10)
+        if(BUILD_SHARED_LIBS)
+            set_tests_properties(robotweax_srt_late_cleanup_${mode}
+                PROPERTIES LABELS "shared-library")
+        endif()
+    endforeach()
+    if(NOT BUILD_SHARED_LIBS)
+        # Exercise a static libsrt embedded in a downstream shared library.
+        set_property(TARGET robotweax_srt PROPERTY POSITION_INDEPENDENT_CODE ON)
+        add_library(robotweax_srt_late_cleanup_wrapper SHARED tests/late_cleanup_probe.cpp)
+        target_link_libraries(robotweax_srt_late_cleanup_wrapper PRIVATE RobotweaxSRT::srt)
+        target_compile_features(robotweax_srt_late_cleanup_wrapper PRIVATE cxx_std_20)
+        set_property(TARGET robotweax_srt_late_cleanup_wrapper PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
+        add_executable(robotweax_srt_embedded_cleanup_tests tests/late_cleanup_main.cpp)
+        target_link_libraries(robotweax_srt_embedded_cleanup_tests PRIVATE robotweax_srt_late_cleanup_wrapper)
+        foreach(mode IN LISTS ROBOTWEAX_SRT_LATE_CLEANUP_MODES)
+            add_test(NAME robotweax_srt_embedded_cleanup_${mode}
+                COMMAND robotweax_srt_embedded_cleanup_tests ${mode})
+            set_tests_properties(robotweax_srt_embedded_cleanup_${mode} PROPERTIES TIMEOUT 10)
+        endforeach()
+    endif()
+
     if(BUILD_SHARED_LIBS)
         # This probe must not link against Robotweax SRT: it loads only the
         # produced shared object and resolves the compatible C ABI at runtime.

--- a/src/compat/socket_registry.cpp
+++ b/src/compat/socket_registry.cpp
@@ -373,6 +373,7 @@ SocketRegistry& SocketRegistry::instance() noexcept
     prepare_runtime_work_executor_service();
     epoll_initialize();
     (void)default_crypto_provider();
+    (void)GroupRegistry::instance();
     static SocketRegistry registry;
     return registry;
 }
@@ -525,6 +526,11 @@ std::size_t service_deferred_closes(
 void runtime_start() noexcept
 {
     auto& lifecycle = runtime_lifecycle();
+    // Finish constructing cleanup dependencies before an application RAII
+    // owner finishes its constructor. Creating the first socket later must
+    // not register those destructors after the owner's cleanup destructor.
+    // These owners are dormant: no socket or worker is started here.
+    (void)SocketRegistry::instance();
     std::lock_guard lifecycle_lock(lifecycle.mutex);
     if (lifecycle.startup_count
         != std::numeric_limits<std::uint32_t>::max()) {
@@ -545,6 +551,7 @@ SRTSOCKET runtime_create_socket() noexcept
 SRTSOCKET runtime_create_group(SRT_GROUP_TYPE type) noexcept
 {
     auto& lifecycle = runtime_lifecycle();
+    (void)SocketRegistry::instance();
     std::lock_guard lifecycle_lock(lifecycle.mutex);
     if (lifecycle.startup_count == 0U) {
         lifecycle.startup_count = 1U;
@@ -555,6 +562,7 @@ SRTSOCKET runtime_create_group(SRT_GROUP_TYPE type) noexcept
 int runtime_create_epoll() noexcept
 {
     auto& lifecycle = runtime_lifecycle();
+    (void)SocketRegistry::instance();
     std::lock_guard lifecycle_lock(lifecycle.mutex);
     if (lifecycle.startup_count == 0U) {
         lifecycle.startup_count = 1U;

--- a/tests/late_cleanup_main.cpp
+++ b/tests/late_cleanup_main.cpp
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Robotweax GmbH
+extern "C" int late_cleanup_probe(const char* mode);
+
+int main(int argc, char** argv)
+{
+    return late_cleanup_probe(argc > 1 ? argv[1] : "socket");
+}

--- a/tests/late_cleanup_probe.cpp
+++ b/tests/late_cleanup_probe.cpp
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Robotweax GmbH
+#include "srt/srt.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+void require(bool ok)
+{
+    if (!ok) {
+        std::fputs("late cleanup probe failed\n", stderr);
+        std::abort();
+    }
+}
+
+struct Owner {
+    explicit Owner(const char* mode)
+    {
+        if (std::strcmp(mode, "implicit-epoll") == 0) {
+            require(srt_epoll_create() >= 0);
+        } else if (std::strcmp(mode, "implicit-group") == 0) {
+            require(srt_create_group(SRT_GTYPE_BROADCAST) != SRT_INVALID_SOCK);
+        } else if (std::strcmp(mode, "implicit-socket") == 0) {
+            require(srt_create_socket() != SRT_INVALID_SOCK);
+        } else {
+            require(srt_startup() == 0);
+        }
+    }
+    ~Owner()
+    {
+        require(srt_cleanup() == 0);
+        require(srt_cleanup() == 0);
+    }
+};
+
+Owner& owner(const char* mode)
+{
+    static Owner instance(mode);
+    return instance;
+}
+} // namespace
+
+// Also compiled into a shared wrapper around the static SRT library. The
+// executable calls only this entry point, matching plugin-style integration.
+extern "C" int late_cleanup_probe(const char* mode)
+{
+    (void)owner(mode);
+    // Explicit-startup resources are created AFTER the owner's constructor.
+    // A probe creating them inside that constructor misses this ordering bug.
+    if (std::strcmp(mode, "startup-only") == 0
+        || std::strncmp(mode, "implicit-", 9) == 0) {
+        return 0;
+    }
+    if (std::strcmp(mode, "restart") == 0) {
+        require(srt_cleanup() == 0);
+        require(srt_startup() == 0);
+    }
+    if (std::strcmp(mode, "epoll") == 0) {
+        require(srt_epoll_create() >= 0);
+    } else if (std::strcmp(mode, "group") == 0) {
+        require(srt_create_group(SRT_GTYPE_BROADCAST) != SRT_INVALID_SOCK);
+    } else {
+        const auto socket = srt_create_socket();
+        require(socket != SRT_INVALID_SOCK);
+        int version = 0;
+        int size = sizeof(version);
+        require(srt_getsockflag(socket, SRTO_VERSION, &version, &size) == 0);
+        if (std::strcmp(mode, "retained") != 0) {
+            require(srt_close(socket) == 0);
+        }
+    }
+    if (std::strcmp(mode, "explicit") == 0) {
+        require(srt_cleanup() == 0);
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes #5.

Construct dormant cleanup dependencies during startup, before an application
singleton finishes construction. Previously, creating the first socket after
that point registered internal static destructors too late: the deferred-close
manager was destroyed before the application's destructor called srt_cleanup.
The resulting lock of a destroyed mutex aborts on macOS.

The fix also prepares the dependencies for implicit group/epoll startup and
keeps the group registry alive through socket registry teardown. It does not
start workers or create sockets during explicit startup, change the public ABI,
or swallow the exception.

## Regression coverage

Add separate process-exit probes with resource creation after the application
owner constructor returns, covering closed/retained sockets, startup-only,
groups, epoll, restart, explicit cleanup, and implicit startup. Exercise both
direct linkage and static SRT embedded in a downstream shared library. Include
the direct probe in the existing shared-library CI job.

## Local verification

- macOS 26.6.2 arm64, AppleClang 21, Release, OpenSSL 3.6.3.
- Original reporter reproducer: both static and embedded-dylib variants failed
  5/5 runs before the fix and passed 5/5 after it.
- New socket regression probe also fails against the unchanged baseline.
- Static selected CTest matrix: 24/24 passed, including 578 core cases and
  24 lifecycle cases inside their test executables.
- Shared selected CTest matrix: 12/12 passed, including unload/reload coverage.
- Pinned clang-format check passed.

Linux/Windows and sanitizer results remain pending CI. No claims are made about
those platforms from the local macOS results. Issue #4 and the experimental
reorder branch are not part of this change.
