### PR TITLE
Avoid reference blocking group receive stall in payload verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1408,7 +1408,7 @@ jobs:
       - name: Build reference connection-group peer locally
         if: matrix.profile == 'handshake'
         run: >-
-          c++ -std=c++17 -O2 interop/group_peer.cpp
+          c++ -std=c++17 -O2 -DROBOTWEAX_SRT_REFERENCE_GROUP_RECEIVE=1 interop/group_peer.cpp
           -Ireference-srt/srtcore -Ireference-build
           reference-build/libsrt.a -lcrypto -lpthread -ldl
           -o reference-group-peer

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -407,3 +407,29 @@ When a test fails:
 Use a clean build directory before attributing a result to source changes.
 See [Building](building.md) for cache hygiene and [Known limitations](limitations.md)
 for combinations that are intentionally unsupported.
+
+### Pinned reference group receive
+
+The Haivision 1.5.7 group helper is compiled with
+`ROBOTWEAX_SRT_REFERENCE_GROUP_RECEIVE=1`. This selects bounded nonblocking
+receive only for the helper's payload-range verification. It retries only
+`SRT_EASYNCRCV`, retains the five-second per-message deadline and all payload,
+hash, sequence and member-metadata checks, then restores the receive mode.
+Robotweax's helper and the separate blocking receive-contract probes are
+unchanged. This is not a transport-library workaround or a relaxed gate.
+
+The reason is a reproduced Linux reference-side stall: payload was ACKed, but
+the reference application remained in `CUDTGroup::recv_WaitForReadReady` /
+`CEPoll::swait`; its send queue was empty. The final hash reply appeared only
+after the caller timed out and started closing its members. Packet capture
+and two post-stall thread snapshots established this distinction from a
+Robotweax reply-receive failure. See diagnostic runs
+[34282020452](https://github.com/Robotweax/srt/actions/runs/34282020452) and
+[34282329261](https://github.com/Robotweax/srt/actions/runs/34282329261).
+The precise internal reference readiness race remains unproven; a passing
+retry or added logging alone must not be treated as a fix.
+
+With the reference-only nonblocking path, the subsequent
+[60-case Linux run](https://github.com/Robotweax/srt/actions/runs/34282747581)
+passed without phase logging. This validates the harness mitigation, not a
+repair of Haivision's internal blocking implementation.

--- a/interop/group_peer.cpp
+++ b/interop/group_peer.cpp
@@ -3,6 +3,11 @@
 
 #include "srt.h"
 
+#if defined(ROBOTWEAX_SRT_REFERENCE_GROUP_RECEIVE)                             \
+    && defined(ROBOTWEAX_SRT_COMPAT_SRT_H)
+#error "Reference receive workaround must not be enabled for the Robotweax peer"
+#endif
+
 #if defined(_WIN32)
 #  include <ws2tcpip.h>
 #else
@@ -654,36 +659,93 @@ void report_group_transfer_failure(const char* operation, const char* reason,
     std::cerr << "}\n";
 }
 
-bool receive_group_range(
-    SRTSOCKET group, std::size_t first, std::size_t last,
+#if defined(ROBOTWEAX_SRT_REFERENCE_GROUP_RECEIVE)
+// Haivision 1.5.7's blocking group receive can remain in its internal
+// read-readiness wait with payload already received, until peer shutdown.
+// Use the public nonblocking API for payload verification only. Keep the
+// dedicated blocking receive-contract probes independent of this workaround.
+class ReferencePayloadReceiveMode {
+public:
+    explicit ReferencePayloadReceiveMode(SRTSOCKET group)
+        : group_(group)
+    {
+    }
+    bool enable()
+    {
+        int size = static_cast<int>(sizeof(original_));
+        if (srt_getsockopt(group_, 0, SRTO_RCVSYN, &original_, &size)
+            == SRT_ERROR) {
+            return false;
+        }
+        const bool asynchronous = false;
+        active_ = srt_setsockopt(group_, 0, SRTO_RCVSYN, &asynchronous,
+                      static_cast<int>(sizeof(asynchronous)))
+            != SRT_ERROR;
+        return active_;
+    }
+    ~ReferencePayloadReceiveMode()
+    {
+        if (active_) {
+            (void)srt_setsockopt(group_, 0, SRTO_RCVSYN, &original_,
+                static_cast<int>(sizeof(original_)));
+        }
+    }
+
+private:
+    SRTSOCKET group_;
+    bool original_ = true;
+    bool active_ = false;
+};
+#endif
+
+bool receive_group_range(SRTSOCKET group, std::size_t first, std::size_t last,
     std::size_t expected_members, SRT_GROUP_TYPE group_type,
     std::uint64_t& hash)
 {
     constexpr int timeout_milliseconds = 5'000;
-    if (srt_setsockopt(group, 0, SRTO_RCVTIMEO,
-            &timeout_milliseconds,
-            static_cast<int>(sizeof(timeout_milliseconds))) == SRT_ERROR) {
+    if (srt_setsockopt(group, 0, SRTO_RCVTIMEO, &timeout_milliseconds,
+            static_cast<int>(sizeof(timeout_milliseconds)))
+        == SRT_ERROR) {
         report_group_transfer_failure(
             "receive-range/set-timeout", "api", group, first, SRT_ERROR, 0);
         return false;
     }
-    std::array<char, 1'500> buffer{};
+    std::array<char, 1'500> buffer {};
+#if defined(ROBOTWEAX_SRT_REFERENCE_GROUP_RECEIVE)
+    ReferencePayloadReceiveMode receive_mode(group);
+    if (!receive_mode.enable()) {
+        return false;
+    }
+#endif
     for (std::size_t index = first; index < last; ++index) {
-        std::array<SRT_SOCKGROUPDATA, 4> members{};
+        std::array<SRT_SOCKGROUPDATA, 4> members {};
         SRT_MSGCTRL control = srt_msgctrl_default;
         control.grpdata = members.data();
         control.grpdata_size = members.size();
         group_phase("receive-payload", "begin", index);
-        const int received = srt_recvmsg2(group, buffer.data(),
-            static_cast<int>(buffer.size()), &control);
+        int received = srt_recvmsg2(
+            group, buffer.data(), static_cast<int>(buffer.size()), &control);
+#if defined(ROBOTWEAX_SRT_REFERENCE_GROUP_RECEIVE)
+        const auto deadline = std::chrono::steady_clock::now()
+            + std::chrono::milliseconds(timeout_milliseconds);
+        while (received == SRT_ERROR
+            && srt_getlasterror(nullptr) == SRT_EASYNCRCV
+            && std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            control = srt_msgctrl_default;
+            control.grpdata = members.data();
+            control.grpdata_size = members.size();
+            received = srt_recvmsg2(group, buffer.data(),
+                static_cast<int>(buffer.size()), &control);
+        }
+#endif
         group_phase("receive-payload", "end", index, received);
         const auto expected = group_payload(index);
         if (received != static_cast<int>(expected.size())
             || !std::equal(expected.begin(), expected.end(), buffer.begin())
             || control.pktseq < 0 || control.msgno <= 0
             || control.grpdata == nullptr
-            || !valid_group_member_states(
-                control.grpdata, control.grpdata_size,
+            || !valid_group_member_states(control.grpdata, control.grpdata_size,
                 expected_members, group_type)) {
             report_group_transfer_failure("receive-range",
                 received == SRT_ERROR                               ? "api"

--- a/interop/tests/test_ci_build_scope.py
+++ b/interop/tests/test_ci_build_scope.py
@@ -26,6 +26,18 @@ def preparation_script() -> str:
 @unittest.skipUnless(os.name == "posix" and shutil.which("bash"),
                      "reference preparation runs in POSIX bash")
 class CiBuildScopeTests(unittest.TestCase):
+    def test_group_receive_workaround_is_reference_only(self) -> None:
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+        macro = "-DROBOTWEAX_SRT_REFERENCE_GROUP_RECEIVE=1"
+        self.assertEqual(workflow.count(macro), 1)
+        step = workflow.split(
+            "      - name: Build reference connection-group peer locally\n", 1
+        )[1].split("      - name:", 1)[0]
+        self.assertIn(macro, step)
+        self.assertIn("reference-build/libsrt.a", step)
+        self.assertNotIn("ROBOTWEAX_SRT_REFERENCE_GROUP_RECEIVE",
+                         (ROOT / "CMakeLists.txt").read_text())
+
     def run_preparation(self, handshake: bool, benchmark: bool,
                         configure_fails: bool = False) -> tuple[int, list]:
         with tempfile.TemporaryDirectory(prefix="srt-build-scope-") as directory:


### PR DESCRIPTION
## Evidence
- Main CI timeout reproduced in Linux run 34282020452 (1/20 failures), with passive packet capture and normal peer pipes.
- Two additional stalled reference stacks in run 34282329261 show Haivision 1.5.7 inside CUDTGroup::recv_WaitForReadReady / CEPoll::swait; its send queue is empty. Hash reply DATA appears only after caller shutdown.
- This is a reference payload-receive stall, not evidence of a lost Robotweax reply.

## Change
Compile only the Haivision payload probe with a bounded nonblocking receive path, retry only EASYNCRCV, preserve the 5-second deadline, payload/hash/sequence/member validation, and restore receive mode. Keep separate blocking receive-contract probes and the Robotweax helper unchanged. Compile-time and CI scope guards prevent enabling this for Robotweax. No library, ABI, transport, or timeout changes.

## Validation
- Before: reproducible failures with packet and thread evidence.
- After: 60/60 uninstrumented Linux Broadcast mirror/bonded cases pass (34282747581).
- All 15 local macOS group baseline/receive-contract cases pass.
- Full Python harness: 542 tests pass; additional CI scope regression test added.

Diagnostic tooling stays on codex/group-reply-investigation, outside this PR. The exact internal Haivision readiness race is not claimed fixed; this is an isolated harness mitigation. Regular PR CI remains required.