### PR TITLE
Install missing access_control.h compatibility header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ version returned by `srt_getversion()`.
 
 ## Unreleased
 
+- Install the standalone `<srt/access_control.h>` compatibility header with
+  all 21 `SRT_REJX_*` application rejection constants, including
+  `SRT_REJX_OVERLOAD`. Add installed C/C++ consumer coverage to prevent
+  accidental fallback to another SRT provider's header (issue #4).
+
 - Fix cleanup from an application singleton destructor when sockets, groups,
   or epoll resources are first created after startup returns. Initialize
   dormant cleanup dependencies before the application owner completes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1500,6 +1500,7 @@ install(FILES
     include/srt.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(FILES
+    include/srt/access_control.h
     include/srt/logging_api.h
     include/srt/srt.h
     include/srt/version.h

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -195,6 +195,14 @@ a complete SRT packet.
 
 ## Error contract
 
+Include `<srt/access_control.h>` for the `SRT_REJX_*` application rejection
+constants. For example, a listener callback can use
+`srt_setrejectreason(socket, SRT_REJX_OVERLOAD)` before rejecting a connection.
+These constants describe application policy; they do not provide an
+authentication or access-control engine. The header is standalone and is
+installed with Robotweax's other public headers, so no Haivision header is
+required. Legacy UDT headers are not part of this compatibility surface.
+
 Public calls return the compatible success or error sentinel and update a
 thread-local last-error record. Unsupported combinations fail explicitly.
 Connection rejection reasons, asynchronous completion errors, peer errors,

--- a/include/srt/access_control.h
+++ b/include/srt/access_control.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: MIT */
+
+#ifndef ROBOTWEAX_SRT_COMPAT_ACCESS_CONTROL_H
+#define ROBOTWEAX_SRT_COMPAT_ACCESS_CONTROL_H
+
+/* Public application rejection codes compatible with the SRT access-control
+ * convention. Applications choose these in a listener callback with
+ * srt_setrejectreason(); the constants do not implement access policy. */
+#define SRT_REJX_FALLBACK 1000 /* Unclassified application rejection. */
+#define SRT_REJX_KEY_NOTSUP 1001 /* Unsupported Stream ID key. */
+#define SRT_REJX_FILEPATH 1002 /* Invalid or unavailable file path. */
+#define SRT_REJX_HOSTNOTFOUND 1003 /* Unknown requested host. */
+#define SRT_REJX_BAD_REQUEST 1400 /* Invalid request syntax. */
+#define SRT_REJX_UNAUTHORIZED 1401 /* Authentication unsuccessful. */
+#define SRT_REJX_OVERLOAD 1402 /* Service capacity or usage quota exceeded. */
+#define SRT_REJX_FORBIDDEN 1403 /* Requested access is denied. */
+#define SRT_REJX_NOTFOUND 1404 /* Requested resource is unavailable. */
+#define SRT_REJX_BAD_MODE 1405 /* Unsupported requested mode. */
+#define SRT_REJX_UNACCEPTABLE 1406 /* Requested parameters cannot be served. */
+#define SRT_REJX_CONFLICT 1409 /* Request conflicts with resource state. */
+#define SRT_REJX_NOTSUP_MEDIA 1415 /* Unsupported media type. */
+#define SRT_REJX_LOCKED 1423 /* Resource access is locked. */
+#define SRT_REJX_FAILED_DEPEND 1424 /* Required dependent session is gone. */
+#define SRT_REJX_ISE 1500 /* Internal service failure. */
+#define SRT_REJX_UNIMPLEMENTED                                                 \
+    1501 /* Recognized operation is not implemented. */
+#define SRT_REJX_GW 1502 /* Gateway destination rejected the request. */
+#define SRT_REJX_DOWN 1503 /* Service is temporarily unavailable. */
+#define SRT_REJX_VERSION 1505 /* Unsupported SRT version. */
+#define SRT_REJX_NOROOM 1507 /* Insufficient storage capacity. */
+
+#endif

--- a/tests/package_consumer/c_consumer.c
+++ b/tests/package_consumer/c_consumer.c
@@ -1,4 +1,30 @@
+#include <srt/access_control.h>
 #include <srt/srt.h>
+
+#ifndef ROBOTWEAX_SRT_COMPAT_ACCESS_CONTROL_H
+#error "access_control.h must come from the Robotweax installation"
+#endif
+_Static_assert(SRT_REJX_FALLBACK == 1000, "SRT_REJX_FALLBACK");
+_Static_assert(SRT_REJX_KEY_NOTSUP == 1001, "SRT_REJX_KEY_NOTSUP");
+_Static_assert(SRT_REJX_FILEPATH == 1002, "SRT_REJX_FILEPATH");
+_Static_assert(SRT_REJX_HOSTNOTFOUND == 1003, "SRT_REJX_HOSTNOTFOUND");
+_Static_assert(SRT_REJX_BAD_REQUEST == 1400, "SRT_REJX_BAD_REQUEST");
+_Static_assert(SRT_REJX_UNAUTHORIZED == 1401, "SRT_REJX_UNAUTHORIZED");
+_Static_assert(SRT_REJX_OVERLOAD == 1402, "SRT_REJX_OVERLOAD");
+_Static_assert(SRT_REJX_FORBIDDEN == 1403, "SRT_REJX_FORBIDDEN");
+_Static_assert(SRT_REJX_NOTFOUND == 1404, "SRT_REJX_NOTFOUND");
+_Static_assert(SRT_REJX_BAD_MODE == 1405, "SRT_REJX_BAD_MODE");
+_Static_assert(SRT_REJX_UNACCEPTABLE == 1406, "SRT_REJX_UNACCEPTABLE");
+_Static_assert(SRT_REJX_CONFLICT == 1409, "SRT_REJX_CONFLICT");
+_Static_assert(SRT_REJX_NOTSUP_MEDIA == 1415, "SRT_REJX_NOTSUP_MEDIA");
+_Static_assert(SRT_REJX_LOCKED == 1423, "SRT_REJX_LOCKED");
+_Static_assert(SRT_REJX_FAILED_DEPEND == 1424, "SRT_REJX_FAILED_DEPEND");
+_Static_assert(SRT_REJX_ISE == 1500, "SRT_REJX_ISE");
+_Static_assert(SRT_REJX_UNIMPLEMENTED == 1501, "SRT_REJX_UNIMPLEMENTED");
+_Static_assert(SRT_REJX_GW == 1502, "SRT_REJX_GW");
+_Static_assert(SRT_REJX_DOWN == 1503, "SRT_REJX_DOWN");
+_Static_assert(SRT_REJX_VERSION == 1505, "SRT_REJX_VERSION");
+_Static_assert(SRT_REJX_NOROOM == 1507, "SRT_REJX_NOROOM");
 
 #if defined(ROBOTWEAX_SRT_EXPECT_AEAD_API_PREVIEW)                             \
     && !defined(ENABLE_AEAD_API_PREVIEW)

--- a/tests/package_consumer/cpp_consumer.cpp
+++ b/tests/package_consumer/cpp_consumer.cpp
@@ -1,4 +1,10 @@
+#include <srt/access_control.h>
 #include <srt/srt.h>
+
+#ifndef ROBOTWEAX_SRT_COMPAT_ACCESS_CONTROL_H
+#error "access_control.h must come from the Robotweax installation"
+#endif
+static_assert(SRT_REJX_OVERLOAD == 1402);
 
 #include <cstdint>
 #include <stdexcept>

--- a/tests/package_consumer/pkgconfig_consumer.cpp
+++ b/tests/package_consumer/pkgconfig_consumer.cpp
@@ -1,4 +1,10 @@
+#include <srt/access_control.h>
 #include <srt/srt.h>
+
+#ifndef ROBOTWEAX_SRT_COMPAT_ACCESS_CONTROL_H
+#error "access_control.h must come from the Robotweax installation"
+#endif
+static_assert(SRT_REJX_OVERLOAD == 1402);
 
 #if defined(ROBOTWEAX_SRT_EXPECT_AEAD_API_PREVIEW)                             \
     && !defined(ENABLE_AEAD_API_PREVIEW)

--- a/tests/package_consumer/run.cmake
+++ b/tests/package_consumer/run.cmake
@@ -77,6 +77,7 @@ set(installed_include_directory
 foreach(public_header IN ITEMS
         robotweax_srt.h
         srt.h
+        srt/access_control.h
         srt/logging_api.h
         srt/srt.h
         srt/version.h)

--- a/tests/test_srt_compat.cpp
+++ b/tests/test_srt_compat.cpp
@@ -9,6 +9,7 @@
 #include "compat/socket_io.hpp"
 #include "compat/socket_registry.hpp"
 #include "srt.h"
+#include "srt/access_control.h"
 
 #include <algorithm>
 #include <array>
@@ -367,7 +368,7 @@ int reject_listener_connection(
     observation.socket = socket;
     observation.stream_id = stream_id != nullptr ? stream_id : "";
     observation.reason_update_succeeded =
-        srt_setrejectreason(socket, 1'404) == 0;
+        srt_setrejectreason(socket, SRT_REJX_OVERLOAD) == 0;
     if (!observation.reason_update_succeeded) {
         return SRT_ERROR;
     }
@@ -4177,7 +4178,7 @@ TEST(srt_compat_listener_callback_rejects_before_accept)
                    static_cast<int>(sizeof(listener_name))),
         SRT_ERROR);
     REQUIRE_EQ(srt_getlasterror(nullptr), SRT_ECONNREJ);
-    REQUIRE_EQ(srt_getrejectreason(caller), 1'404);
+    REQUIRE_EQ(srt_getrejectreason(caller), SRT_REJX_OVERLOAD);
     REQUIRE_EQ(callback_observation.calls, 1);
     REQUIRE(callback_observation.socket != SRT_INVALID_SOCK);
     REQUIRE_EQ(callback_observation.stream_id,


### PR DESCRIPTION
## Summary
Closes #4.

Add a standalone MIT access_control.h with all 21 compatible SRT_REJX constants and original explanatory comments. Install it alongside the other public headers. No transport or ABI changes; legacy UDT/platform headers remain out of scope.

## Regression coverage
- Installed C consumer asserts all 21 numeric constants.
- C, C++, and pkg-config consumers require the Robotweax header guard, preventing silent fallback to a Haivision system header.
- Package test explicitly requires the installed file.
- Listener callback rejection test propagates SRT_REJX_OVERLOAD to the caller.

## Local validation (macOS Release)
- Preprocessed constants exactly match pinned Haivision 1.5.7: 21/21.
- Installed package consumer test: PASS.
- Public SRT compatibility tests: 52/52 PASS.
- git diff --check: PASS.

Platform CI required before merge.