### PR TITLE
Add question and enhancement issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request / Enhancement
+description: Suggest a new capability or an improvement
+title: "[Enhancement] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search existing issues before submitting a suggestion.
+        This is a public issue. Do not include credentials, passphrases, private addresses, or sensitive payloads.
+        For security-sensitive reports, follow [SECURITY.md](https://github.com/Robotweax/srt/blob/main/SECURITY.md).
+  - type: textarea
+    id: need
+    attributes:
+      label: Problem or use case
+      description: What are you trying to achieve, and what limitation do you encounter?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Suggested improvement
+      description: Describe the desired behavior and how you would know it meets your needs. A detailed implementation design is not required.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives or workarounds
+      description: What alternatives have you considered or tried?
+  - type: textarea
+    id: context
+    attributes:
+      label: Compatibility and additional context
+      description: If relevant, include affected platforms, applications, peer versions, public specifications, or API compatibility requirements.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,29 @@
+name: Question / Integration help
+description: Ask about the API, configuration, builds, or integration
+title: "[Question] "
+labels:
+  - question
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search existing issues and check the [documentation](https://github.com/Robotweax/srt/blob/main/docs/README.md) first.
+        This is a public issue. Do not include credentials, passphrases, private addresses, or sensitive payloads.
+        For security-sensitive reports, follow [SECURITY.md](https://github.com/Robotweax/srt/blob/main/SECURITY.md).
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What would you like to understand or accomplish?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment and integration context
+      description: If relevant, include the Robotweax version or commit, OS, compiler, application, peer library/version, and connection mode. Leave blank for general questions.
+  - type: textarea
+    id: tried
+    attributes:
+      label: What you have checked or tried
+      description: Link relevant documentation or issues and include any minimal example or sanitized output that helps explain the question.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,25 @@ The public support boundary is documented in
 [Compatibility status](docs/compatibility.md). Unsupported behavior must fail
 explicitly; it must not be approximated silently.
 
+## Questions, bug reports, and suggestions
+
+Use [GitHub Issues](https://github.com/Robotweax/srt/issues/new/choose) as the
+preferred channel for technical questions and suggestions so others can find and
+benefit from the answers. Search existing issues and the
+[documentation](docs/README.md) first, then choose the appropriate template:
+
+- **Question / Integration help** for API, configuration, build, or integration
+  questions. Environment details are optional for general questions.
+- **Feature request / Enhancement** for new capabilities or improvements. Explain
+  the use case and desired behavior; an implementation proposal is not required.
+- **Bug report** for reproducible unexpected behavior.
+- **Interoperability failure** for problems communicating with another SRT
+  implementation.
+
+Keep reports focused on one topic and redact credentials, passphrases, private
+addresses, and sensitive payloads. Do not post vulnerabilities in public issues;
+use the private reporting process in [SECURITY.md](SECURITY.md).
+
 ## Developer Certificate of Origin
 
 Every commit contributed through a pull request must carry a `Signed-off-by`


### PR DESCRIPTION
## Summary
- Add Question / Integration help and Feature request / Enhancement forms.
- Keep general questions lightweight and direct security reports to the private reporting process.
- Document the preferred issue channels in CONTRIBUTING.md; preserve existing bug and interoperability forms.

## Validation
- All issue-template YAML files parsed successfully with Ruby YAML.
- Form IDs checked for uniqueness.
- git diff --check passed.
- Documentation and issue forms only; no runtime changes.