### PR TITLE
Add experimental Android and iOS build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1520,6 +1520,8 @@ install(FILES
 install(DIRECTORY docs/
     DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/robotweax_srt/docs
     FILES_MATCHING PATTERN "*.md")
+install(FILES examples/ios/README.md
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/robotweax_srt/examples/ios)
 install(FILES examples/README.md
     DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/robotweax_srt/examples)
 install(FILES

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,8 @@ developers and transport integrators using the installed public API.
   basic socket lifecycle.
 - [Building and installing](building.md) — build profiles, CMake options,
   installation, package discovery, and platform notes.
+- [Experimental mobile builds](mobile-building.md) — Android and iOS cross-build
+  instructions, local verification evidence, and qualification boundaries.
 - [Integration guide](integration.md) — public headers, endpoint roles, I/O,
   readiness, encryption, errors, and shutdown.
 - [FFmpeg integration](ffmpeg-integration.md) — opt-in package discovery,

--- a/docs/building.md
+++ b/docs/building.md
@@ -20,6 +20,9 @@ matches the compiler and generator.
 
 ## Important CMake options
 
+For unqualified mobile cross-build experiments, see
+[Experimental Android and iOS builds](mobile-building.md).
+
 | Option | Default | Purpose |
 | --- | --- | --- |
 | `BUILD_SHARED_LIBS` | `OFF` | Build a shared rather than static library |

--- a/docs/mobile-building.md
+++ b/docs/mobile-building.md
@@ -52,8 +52,47 @@ The attempted Android-to-macOS cases did **not** pass: `sendto(10.0.2.2)` return
 `ENETUNREACH`. A separate shell `ip route get 10.0.2.2` and ping also reported
 unreachable, while socket creation, options and bind succeeded. This identifies a
 routing problem in the test environment, not a demonstrated SRT handshake defect.
-Host interoperability remains open until routing is resolved and the cases rerun.
-Do not count the Android loopback results as desktop interoperability evidence.
+The original failures remain part of the test record; loopback alone is not
+desktop interoperability evidence. After emulator restart and network initialization,
+the separate host tests passed as described below.
+
+### Android routing recovery and network readiness
+
+On the subsequent 2026-09-09 run, restarting the same AVD and allowing Android's
+network services to initialize restored routing without root, manual routes,
+firewall changes or SRT modifications. The initial boot observation had only the
+dummy network and no connectivity service; the later observation had a default
+Wi-Fi network and a policy route to `10.0.2.2` through `wlan0` (table 1016).
+Host ping then passed, followed by **4/4 Android caller to macOS listener** cases:
+AES-256-CTR/GCM, each blocking/nonblocking, with exact echo, statistics and both
+processes exiting 0. These extend, rather than replace, the original loopback tests.
+
+The exact reason the previous run remained without a usable route is not proven.
+Recovery after restart does not establish a permanent emulator fix. Treat ADB
+availability and `sys.boot_completed=1` as insufficient network readiness signals.
+Before launching a network case, check the actual target route with a bounded wait:
+
+```sh
+ADB="$HOME/Library/Android/sdk/platform-tools/adb"
+SERIAL=emulator-5554
+ready=false
+for attempt in $(seq 1 30); do
+  if "$ADB" -s "$SERIAL" shell ip route get 10.0.2.2; then
+    ready=true
+    break
+  fi
+  sleep 2
+done
+if [ "$ready" != true ]; then
+  echo "Android host route unavailable; do not start SRT tests" >&2
+  exit 1
+fi
+```
+
+This is a routing precondition, not proof that a UDP listener is reachable. Keep
+the actual encrypted transfer as the end-to-end gate. On failure retain `ip rule`,
+`ip route show table all` and network-service diagnostics; do not disable Android
+security protections or retry SRT tests until a failed run disappears.
 
 To repeat a case, run the message demo as `listener --port PORT` and as
 `caller --host HOST --port PORT --message TEXT`, adding identical

--- a/docs/mobile-building.md
+++ b/docs/mobile-building.md
@@ -195,6 +195,10 @@ this step does not yet create an XCFramework or Swift package.
 
 ## Qualification still required
 
+An experimental [UIKit encrypted echo app](../examples/ios/README.md) is available
+for actual Simulator app-process testing. It is separate from the native CLI smoke
+tests and does not constitute physical-device qualification.
+
 1. Compile all three target variants and link a consumer calling the public C API.
 2. Verify startup/cleanup, encrypted caller/listener send/receive against a desktop
    peer, exact payload integrity, statistics and timeout/cancellation behavior.

--- a/docs/mobile-building.md
+++ b/docs/mobile-building.md
@@ -21,11 +21,51 @@ The bound calculation and public API are unchanged.
 | iOS ARM64 simulator | Same Xcode, simulator SDK 26.5, deployment 15.0 | Static library + simulator consumer link passed |
 
 Host: macOS ARM64; CMake 4.4.2, Ninja. OpenSSL revision and recipes appear below.
-These were local cross-build checks, not mobile CI or runtime tests. Consumers
-were not executed on devices/simulators. Signing, app packaging, JNI/Swift wrappers,
-network transfers, timing and background behavior remain unqualified. Android NDK
+These were local cross-build checks, not mobile CI. Subsequent runtime smoke
+checks are recorded below. Signing, app packaging, JNI/Swift wrappers,
+device networking, timing and background behavior remain unqualified. Android NDK
 emitted CMake deprecation warnings; OpenSSL's Android API define emitted a macro
 redefinition warning. Neither was a SRT compiler error.
+
+## Initial emulator runtime checks (2026-09-09)
+
+Source baseline: mobile branch commit `739ce62`. Android was tested first and
+shut down before iOS was started, to avoid concurrent emulator memory pressure.
+
+| Environment | Public C consumer | Encrypted message demo |
+| --- | --- | --- |
+| Android 15/API 35 AOSP ARM64, emulator 37.1.11 | Exit 0 | 4/4 two-process loopback cases passed |
+| iOS 26.5, iPhone 17 Pro simulator | Exit 0 | 4/4 simulator caller to macOS listener cases passed |
+
+Each four-case set used AES-256-CTR and AES-256-GCM, each in blocking and
+epoll-driven nonblocking mode. `examples/srt_message_demo.cpp` verified an exact
+synthetic payload echo, called `srt_bistats`, exchanged completion messages and
+exited successfully on both ends. Each case sent one short application message;
+these are smoke checks, not throughput, key-rotation or endurance qualification.
+
+Android execution used `adb shell` with the matching `libc++_shared.so` in
+`LD_LIBRARY_PATH`; iOS used `simctl spawn` on the simulator-built executable.
+These are native process tests, not installed APK/iOS-app tests, and do not validate
+application sandbox permissions or background execution.
+
+The attempted Android-to-macOS cases did **not** pass: `sendto(10.0.2.2)` returned
+`ENETUNREACH`. A separate shell `ip route get 10.0.2.2` and ping also reported
+unreachable, while socket creation, options and bind succeeded. This identifies a
+routing problem in the test environment, not a demonstrated SRT handshake defect.
+Host interoperability remains open until routing is resolved and the cases rerun.
+Do not count the Android loopback results as desktop interoperability evidence.
+
+To repeat a case, run the message demo as `listener --port PORT` and as
+`caller --host HOST --port PORT --message TEXT`, adding identical
+`--crypto ctr` or `--crypto gcm`, `--passphrase-env SRT_TEST_KEY` and
+`--timeout-ms 15000` on both sides. Add `--nonblocking` to both for the asynchronous
+case. Use only a synthetic test key. For iOS `simctl spawn`, propagate it via
+`SIMCTL_CHILD_SRT_TEST_KEY`; for Android, set it in the remote process environment.
+For Android loopback both processes run inside the emulator with host `127.0.0.1`;
+for the iOS test only the caller runs in the simulator, against the macOS listener.
+Apply an outer process timeout as the blocking listener may otherwise wait for a
+peer indefinitely. Preserve failed attempts and do not infer performance from RTT
+values produced by this one-message exchange.
 
 ## Prerequisites
 

--- a/docs/mobile-building.md
+++ b/docs/mobile-building.md
@@ -1,0 +1,70 @@
+# Experimental Android and iOS builds
+
+Mobile support is under development. These configuration recipes are not evidence
+of a successful mobile build, device interoperability or a supported minimum OS.
+The desktop build matrix remains the qualified platform set.
+
+## Prerequisites
+
+- CMake 3.20+, Ninja, Python 3.10+, and the exact target toolchain.
+- Android: an explicitly selected Android NDK with its CMake toolchain.
+- iOS: full Xcode with device/simulator SDKs; Command Line Tools alone are insufficient.
+- OpenSSL 3 Crypto built separately for each target, installed as
+  `include/openssl/...` and `lib/libcrypto.a`. Android static Crypto must be PIC.
+  Device ARM64, simulator ARM64 and macOS ARM64 libraries are not interchangeable.
+
+Use the same deployment target in OpenSSL and SRT builds. Record NDK/Xcode,
+compiler, SDK, OpenSSL revision/configuration and SRT commit with each result.
+The helper supplies explicit Crypto/include paths, but does not prove the archive
+has the correct platform or deployment target. A final application link and device
+test are mandatory; creating a static archive alone cannot prove dependency linkage.
+
+## Configure and build
+
+From the repository root, replace the placeholder paths below. Deployment versions
+are initial experiment examples, not minimum-version support commitments.
+
+```sh
+./tools/python tools/mobile_configure.py android-arm64 \
+  --ndk /path/to/android-ndk \
+  --openssl-root /path/to/openssl-android-arm64 \
+  --deployment-target 28 --build-dir build-mobile-android
+cmake --build build-mobile-android --parallel 2 --target robotweax_srt
+
+./tools/python tools/mobile_configure.py ios-arm64 \
+  --openssl-root /path/to/openssl-ios-arm64 \
+  --deployment-target 15.0 --build-dir build-mobile-ios
+cmake --build build-mobile-ios --parallel 2 --target robotweax_srt
+
+./tools/python tools/mobile_configure.py ios-simulator-arm64 \
+  --openssl-root /path/to/openssl-ios-simulator-arm64 \
+  --deployment-target 15.0 --build-dir build-mobile-ios-simulator
+cmake --build build-mobile-ios-simulator --parallel 2 --target robotweax_srt
+```
+
+Add `--plan` to print the command without running CMake or checking dependencies.
+The helper never installs SDKs, deletes caches, changes Xcode selection or accepts
+licenses. Normal configuration requires an empty build directory and explicit
+target dependencies. It builds Release/PIC/static with AES-GCM enabled, and disables
+host tests/tools/examples. Existing desktop defaults are unchanged.
+
+Android consumers must package the matching shared C++ runtime and link Crypto
+and all transitive dependencies. iOS consumers must link matching target libraries;
+this step does not yet create an XCFramework or Swift package.
+
+## Qualification still required
+
+1. Compile all three target variants and link a consumer calling the public C API.
+2. Verify startup/cleanup, encrypted caller/listener send/receive against a desktop
+   peer, exact payload integrity, statistics and timeout/cancellation behavior.
+3. Test real devices: app pause/resume, screen lock, network loss/reconnect and IPv6.
+4. Measure timing, CPU, power and memory; simulator results do not qualify devices.
+5. Add narrowly selected compile/link CI and app packaging only after the builds
+   are reproducible. Do not enable expensive mobile jobs for unrelated commits.
+
+Multicast permissions, local-network privacy and background execution are app-level
+integration work, not supplied by a static SRT library. No network migration or
+unrestricted background streaming is promised.
+
+Toolchain references: [Android NDK CMake](https://developer.android.com/ndk/guides/cmake)
+and [CMake cross compilation](https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html).

--- a/docs/mobile-building.md
+++ b/docs/mobile-building.md
@@ -1,8 +1,31 @@
 # Experimental Android and iOS builds
 
-Mobile support is under development. These configuration recipes are not evidence
-of a successful mobile build, device interoperability or a supported minimum OS.
+Mobile support is under development. Initial compile/link checks pass as recorded
+below; device interoperability and a supported minimum OS are not yet established.
 The desktop build matrix remains the qualified platform set.
+
+## Initial compile/link evidence (2026-09-09)
+
+All three targets built the Release static SRT library with AES-GCM enabled and
+linked `tests/package_consumer/c_consumer.c` (compiled as C11, linked with the target
+C++ driver) against SRT and target OpenSSL 3.6.3. The source is the mobile branch
+with explicit `std::int64_t` template selection in the two timeout `std::min`
+calls in `compat/connection.cpp` and `compat/epoll.cpp`. Android libc++ exposes
+different `long` / `long long` aliases here; implicit template deduction failed.
+The bound calculation and public API are unchanged.
+
+| Target | Toolchain / target setting | Result |
+| --- | --- | --- |
+| Android ARM64 | NDK r27d (27.3.13750724), Clang 18.0.4, API 28 | Static library + AArch64 ELF consumer link passed |
+| iOS ARM64 device | Xcode 26.6, AppleClang 21.0.0, SDK 26.5, deployment 15.0 | Static library + Mach-O consumer link passed |
+| iOS ARM64 simulator | Same Xcode, simulator SDK 26.5, deployment 15.0 | Static library + simulator consumer link passed |
+
+Host: macOS ARM64; CMake 4.4.2, Ninja. OpenSSL revision and recipes appear below.
+These were local cross-build checks, not mobile CI or runtime tests. Consumers
+were not executed on devices/simulators. Signing, app packaging, JNI/Swift wrappers,
+network transfers, timing and background behavior remain unqualified. Android NDK
+emitted CMake deprecation warnings; OpenSSL's Android API define emitted a macro
+redefinition warning. Neither was a SRT compiler error.
 
 ## Prerequisites
 
@@ -18,6 +41,45 @@ compiler, SDK, OpenSSL revision/configuration and SRT commit with each result.
 The helper supplies explicit Crypto/include paths, but does not prove the archive
 has the correct platform or deployment target. A final application link and device
 test are mandatory; creating a static archive alone cannot prove dependency linkage.
+
+Select Xcode for this shell without changing the machine-wide developer directory:
+
+```sh
+export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+xcrun --sdk iphoneos --show-sdk-path
+xcrun --sdk iphonesimulator --show-sdk-path
+```
+
+Keep the Android NDK in a permanent installation directory rather than relying on
+a mounted installer volume. Pass that exact directory to `--ndk`.
+
+### Building target OpenSSL
+
+The initial experiment pins OpenSSL 3.6.3 at commit
+`aae016bfd52fcad2bc9657c2c782cfdf73b1ed5f`. This is a reproduction pin, not a
+recommendation to freeze security updates indefinitely. Use separate empty build
+directories and installation prefixes for each target. With `OPENSSL_SOURCE`
+pointing to that checkout and `PREFIX` to the target installation, run one of:
+
+```sh
+# iOS device, from its empty OpenSSL build directory:
+perl "$OPENSSL_SOURCE/Configure" ios64-xcrun no-shared no-tests \
+  --prefix="$PREFIX" --libdir=lib -miphoneos-version-min=15.0
+
+# iOS ARM64 simulator, from a different empty directory:
+perl "$OPENSSL_SOURCE/Configure" iossimulator-arm64-xcrun no-shared no-tests \
+  --prefix="$PREFIX" --libdir=lib -mios-simulator-version-min=15.0
+
+# Android ARM64 on a macOS build host, from another empty directory:
+export ANDROID_NDK_ROOT=/path/to/android-ndk
+export PATH="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/darwin-x86_64/bin:$PATH"
+perl "$OPENSSL_SOURCE/Configure" android-arm64 no-shared no-tests \
+  --prefix="$PREFIX" --libdir=lib -D__ANDROID_API__=28 -fPIC
+```
+
+After the selected configuration, run `make -j2 build_libs` and
+`make install_dev`. These commands build libraries; they do not execute OpenSSL's
+test suite or qualify cryptographic behavior on a device.
 
 ## Configure and build
 

--- a/examples/ios/CMakeLists.txt
+++ b/examples/ios/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.20)
+project(SRTMobileDemo LANGUAGES C CXX OBJCXX)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    message(FATAL_ERROR "This example requires an iOS device or simulator toolchain")
+endif()
+foreach(input SRT_ARCHIVE CRYPTO_ARCHIVE SRT_INCLUDE_DIR)
+    if(NOT EXISTS "${${input}}")
+        message(FATAL_ERROR "Provide ${input} for the same target SDK/architecture")
+    endif()
+endforeach()
+add_executable(SRTMobileDemo MACOSX_BUNDLE main.mm)
+target_include_directories(SRTMobileDemo PRIVATE "${SRT_INCLUDE_DIR}")
+target_compile_definitions(SRTMobileDemo PRIVATE ENABLE_AEAD_API_PREVIEW)
+target_compile_options(SRTMobileDemo PRIVATE -fobjc-arc)
+target_link_libraries(SRTMobileDemo PRIVATE "${SRT_ARCHIVE}" "${CRYPTO_ARCHIVE}"
+    "-framework UIKit" "-framework Foundation")
+set_target_properties(SRTMobileDemo PROPERTIES
+    OBJCXX_STANDARD 20
+    MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist"
+    MACOSX_BUNDLE_GUI_IDENTIFIER "ai.robotweax.srt.mobile-demo")

--- a/examples/ios/Info.plist
+++ b/examples/ios/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleExecutable</key><string>SRTMobileDemo</string>
+<key>CFBundleIdentifier</key><string>ai.robotweax.srt.mobile-demo</string>
+<key>CFBundleName</key><string>SRT Mobile Test</string>
+<key>CFBundlePackageType</key><string>APPL</string>
+<key>CFBundleVersion</key><string>1</string>
+<key>CFBundleShortVersionString</key><string>0.1</string>
+<key>LSRequiresIPhoneOS</key><true/>
+<key>UILaunchScreen</key><dict/>
+<key>NSLocalNetworkUsageDescription</key><string>Connect to your SRT test peer on the local network.</string>
+<key>UISupportedInterfaceOrientations</key><array><string>UIInterfaceOrientationPortrait</string></array>
+</dict></plist>

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -1,0 +1,56 @@
+# Experimental iOS encrypted echo app
+
+This UIKit/Objective-C++ example uses the public SRT C API. It is a one-shot
+IPv4 Caller, not a streaming bridge or production mobile SDK. Enter the desktop
+peer address, port and a test passphrase, choose AES-CTR or AES-GCM, then connect.
+It verifies an exact echo, shows a non-destructive statistics snapshot and closes.
+Disconnect/backgrounding requests cancellation; an in-flight call can take up to
+the configured three-second timeout. Socket ownership stays on one worker.
+There is no automatic reconnect or background streaming.
+
+## Build for Apple Silicon Simulator
+
+First build simulator SRT and OpenSSL as described in
+[mobile-building](../../docs/mobile-building.md). Use absolute paths below.
+
+```sh
+export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+cmake -S examples/ios -B build-ios-app -G Ninja \
+  -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphonesimulator \
+  -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=15.0 \
+  -DSRT_INCLUDE_DIR="$PWD/include" \
+  -DSRT_ARCHIVE=/absolute/path/to/simulator/libsrt.a \
+  -DCRYPTO_ARCHIVE=/absolute/path/to/simulator/libcrypto.a
+cmake --build build-ios-app
+xcrun simctl install booted build-ios-app/SRTMobileDemo.app
+xcrun simctl launch booted ai.robotweax.srt.mobile-demo
+```
+
+Start the desktop `robotweax_srt_message_demo` built with AES-GCM enabled:
+
+```sh
+export SRT_TEST_KEY=synthetic-mobile-test-key
+./build-examples/robotweax_srt_message_demo listener \
+  --bind 127.0.0.1 --port 24580 --crypto gcm \
+  --passphrase-env SRT_TEST_KEY --timeout-ms 15000
+```
+
+Use the same key and crypto mode in the app. Restart the listener for each test.
+For a physical device, use a reachable LAN address and listener binding, a signed
+device build, and grant local-network access. Physical devices are not yet tested.
+No passphrase is stored by the app; use synthetic credentials only for this demo.
+
+## Automation and evidence
+
+Simulator launch environment variables `SIMCTL_CHILD_SRT_DEMO_HOST`,
+`SIMCTL_CHILD_SRT_DEMO_PORT`, `SIMCTL_CHILD_SRT_DEMO_KEY`,
+`SIMCTL_CHILD_SRT_DEMO_CRYPTO` (`ctr` or `gcm`) populate the form.
+`SIMCTL_CHILD_SRT_DEMO_AUTORUN=1` starts the same connection path automatically.
+The final non-secret result is written to the app's `Documents/result.txt`.
+Remove any previous result before an automated run to avoid reading stale output.
+
+On 2026-09-09, an installed app on iPhone 17 Pro Simulator (iOS 26.5,
+Xcode 26.6, arm64) passed both CTR and GCM exact echo exchanges against the
+macOS desktop peer, including `srt_bistats(socket, stats, 0, 1)` and orderly
+completion. Both desktop peers exited successfully. Simulator results do not
+establish device timing, power use, LAN privacy behavior or background reliability.

--- a/examples/ios/main.mm
+++ b/examples/ios/main.mm
@@ -1,0 +1,154 @@
+/* SPDX-License-Identifier: MIT */
+#import <UIKit/UIKit.h>
+#include <srt/srt.h>
+#include <arpa/inet.h>
+#include <atomic>
+#include <cstring>
+#include <string>
+
+@interface DemoController : UIViewController {
+    std::atomic<bool> cancelled;
+    BOOL running;
+}
+@property UITextField *hostField;
+@property UITextField *portField;
+@property UITextField *keyField;
+@property UISegmentedControl *crypto;
+@property UIButton *connectButton;
+@property UILabel *status;
+@end
+
+@implementation DemoController
+- (UITextField *)field:(NSString *)placeholder value:(NSString *)value {
+    UITextField *field = [UITextField new];
+    field.placeholder = placeholder;
+    field.text = value;
+    field.borderStyle = UITextBorderStyleRoundedRect;
+    field.autocorrectionType = UITextAutocorrectionTypeNo;
+    field.autocapitalizationType = UITextAutocapitalizationTypeNone;
+    return field;
+}
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.view.backgroundColor = UIColor.systemBackgroundColor;
+    NSDictionary *env = NSProcessInfo.processInfo.environment;
+    self.hostField = [self field:@"Peer IPv4 address" value:env[@"SRT_DEMO_HOST"] ?: @"127.0.0.1"];
+    self.portField = [self field:@"UDP port" value:env[@"SRT_DEMO_PORT"] ?: @"24580"];
+    self.portField.keyboardType = UIKeyboardTypeNumberPad;
+    self.keyField = [self field:@"Test passphrase (10–79 ASCII bytes)" value:env[@"SRT_DEMO_KEY"] ?: @""];
+    self.keyField.secureTextEntry = YES;
+    self.crypto = [[UISegmentedControl alloc] initWithItems:@[@"AES-CTR", @"AES-GCM"]];
+    self.crypto.selectedSegmentIndex = [env[@"SRT_DEMO_CRYPTO"] isEqual:@"ctr"] ? 0 : 1;
+    self.connectButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.connectButton setTitle:@"Connect & verify echo" forState:UIControlStateNormal];
+    [self.connectButton addTarget:self action:@selector(start) forControlEvents:UIControlEventTouchUpInside];
+    UIButton *stop = [UIButton buttonWithType:UIButtonTypeSystem];
+    [stop setTitle:@"Disconnect" forState:UIControlStateNormal];
+    [stop addTarget:self action:@selector(stop) forControlEvents:UIControlEventTouchUpInside];
+    self.status = [UILabel new];
+    self.status.numberOfLines = 0;
+    self.status.text = @"Idle — experimental caller-only echo test";
+    UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[self.hostField, self.portField, self.keyField, self.crypto, self.connectButton, stop, self.status]];
+    stack.axis = UILayoutConstraintAxisVertical;
+    stack.spacing = 16;
+    stack.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:stack];
+    [NSLayoutConstraint activateConstraints:@[
+        [stack.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor constant:24],
+        [stack.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor constant:20],
+        [stack.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-20]]];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(stop) name:UIApplicationDidEnterBackgroundNotification object:nil];
+    if ([env[@"SRT_DEMO_AUTORUN"] isEqual:@"1"]) {
+        dispatch_async(dispatch_get_main_queue(), ^{ [self start]; });
+    }
+}
+- (void)stop {
+    if (running) {
+        cancelled.store(true);
+        self.status.text = @"Disconnecting (bounded by connection/I/O timeout)…";
+    }
+}
+- (void)start {
+    if (running) return;
+    [self.view endEditing:YES];
+    NSString *host = self.hostField.text;
+    NSString *portText = self.portField.text;
+    NSScanner *scanner = [NSScanner scannerWithString:portText];
+    int port = 0;
+    sockaddr_in address{};
+    address.sin_family = AF_INET;
+    NSData *key = [self.keyField.text dataUsingEncoding:NSASCIIStringEncoding allowLossyConversion:NO];
+    if (![scanner scanInt:&port] || !scanner.isAtEnd || port < 1 || port > 65535 ||
+        inet_pton(AF_INET, host.UTF8String, &address.sin_addr) != 1 || key.length < 10 || key.length > 79) {
+        self.status.text = @"Enter a numeric IPv4 address, port 1–65535 and a 10–79 byte ASCII passphrase.";
+        return;
+    }
+    address.sin_port = htons(static_cast<uint16_t>(port));
+    const int mode = self.crypto.selectedSegmentIndex == 0 ? 1 : 2;
+    running = YES;
+    cancelled.store(false);
+    self.connectButton.enabled = NO;
+    self.status.text = @"Connecting…";
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        // One worker exclusively owns startup, socket I/O, close and cleanup.
+        // The UI only publishes cancellation; it never closes a reused handle.
+        NSString *result = @"FAIL: startup";
+        if (srt_startup() != SRT_ERROR) {
+            SRTSOCKET socket = srt_create_socket();
+            const int timeout = 3000;
+            const int keyLength = 32;
+            bool ok = socket != SRT_INVALID_SOCK;
+            auto option = [&](SRT_SOCKOPT name, const void *value, int size) {
+                if (ok) ok = srt_setsockflag(socket, name, value, size) != SRT_ERROR;
+            };
+            option(SRTO_CONNTIMEO, &timeout, sizeof(timeout));
+            option(SRTO_RCVTIMEO, &timeout, sizeof(timeout));
+            option(SRTO_SNDTIMEO, &timeout, sizeof(timeout));
+            option(SRTO_PBKEYLEN, &keyLength, sizeof(keyLength));
+            option(SRTO_PASSPHRASE, key.bytes, static_cast<int>(key.length));
+            option(SRTO_CRYPTOMODE, &mode, sizeof(mode));
+            if (ok && !cancelled.load()) ok = srt_connect(socket, reinterpret_cast<const sockaddr *>(&address), sizeof(address)) != SRT_ERROR;
+            std::string payload = "Robotweax iOS app encrypted echo";
+            auto exchange = [&](const std::string &message) {
+                if (cancelled.load() || !ok) return false;
+                if (srt_sendmsg(socket, message.data(), static_cast<int>(message.size()), -1, 0) != static_cast<int>(message.size())) return false;
+                char buffer[65536];
+                const int size = srt_recvmsg(socket, buffer, sizeof(buffer));
+                return size == static_cast<int>(message.size()) && std::memcmp(buffer, message.data(), message.size()) == 0;
+            };
+            ok = exchange(payload);
+            SRT_TRACEBSTATS stats{};
+            if (ok) ok = srt_bistats(socket, &stats, 0, 1) != SRT_ERROR;
+            if (ok) ok = exchange("__robotweax_srt_demo_complete__");
+            if (cancelled.load()) result = @"CANCELLED";
+            else if (ok) result = [NSString stringWithFormat:@"PASS: encrypted echo verified\nRTT %.3f ms\nSent %lld / received %lld packets", stats.msRTT, (long long)stats.pktSentTotal, (long long)stats.pktRecvTotal];
+            else result = [NSString stringWithFormat:@"FAIL: %s (or echo mismatch)", srt_getlasterror_str()];
+            if (socket != SRT_INVALID_SOCK) srt_close(socket);
+            srt_cleanup();
+        }
+        // Non-secret result for automation; never persist the passphrase.
+        NSString *directory = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
+        [result writeToFile:[directory stringByAppendingPathComponent:@"result.txt"] atomically:YES encoding:NSUTF8StringEncoding error:nil];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            running = NO;
+            self.connectButton.enabled = YES;
+            self.status.text = result;
+        });
+    });
+}
+@end
+
+@interface DemoDelegate : UIResponder <UIApplicationDelegate>
+@property (nonatomic, strong) UIWindow *window;
+@end
+@implementation DemoDelegate
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)options {
+    self.window = [[UIWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
+    self.window.rootViewController = [DemoController new];
+    [self.window makeKeyAndVisible];
+    return YES;
+}
+@end
+int main(int argc, char **argv) {
+    @autoreleasepool { return UIApplicationMain(argc, argv, nil, NSStringFromClass(DemoDelegate.class)); }
+}

--- a/interop/ci_changes.py
+++ b/interop/ci_changes.py
@@ -25,6 +25,8 @@ FORMAT_TOOLING_FILES = {
     "interop/tests/test_clang_format_tool.py",
 }
 PYTHON_TOOLING_FILES = {
+    "tools/mobile_configure.py",
+    "interop/tests/test_mobile_configure.py",
     "tools/check_dco.py",
     "tools/python",
     "interop/tests/test_dco.py",

--- a/interop/tests/test_ci_changes.py
+++ b/interop/tests/test_ci_changes.py
@@ -15,6 +15,8 @@ import ci_changes  # noqa: E402
 class CiChangeClassifierTests(unittest.TestCase):
     def test_python_ci_tooling_does_not_start_protocol_builds(self) -> None:
         for path in (
+            "tools/mobile_configure.py",
+            "interop/tests/test_mobile_configure.py",
             "tools/python",
             "interop/tests/test_python_launcher.py",
             "interop/tests/test_ci_gate.py",

--- a/interop/tests/test_mobile_configure.py
+++ b/interop/tests/test_mobile_configure.py
@@ -1,0 +1,64 @@
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "tools/mobile_configure.py"
+SPEC = importlib.util.spec_from_file_location("mobile_configure", SCRIPT)
+mobile = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(mobile)
+
+
+class MobileConfigureTests(unittest.TestCase):
+    def args(self, target="android-arm64", extra=None):
+        values = [target, "--build-dir", "/tmp/mobile-build",
+                  "--openssl-root", "/tmp/target crypto", "--deployment-target", "28"]
+        if target == "android-arm64":
+            values += ["--ndk", "/tmp/android ndk"]
+        return mobile.parser().parse_args(values + (extra or []))
+
+    def test_android_explicit_dependency_and_abi(self):
+        command = mobile.command(self.args())
+        self.assertIn("-DANDROID_ABI=arm64-v8a", command)
+        self.assertIn("-DANDROID_PLATFORM=android-28", command)
+        crypto = Path("/tmp/target crypto/lib/libcrypto.a").resolve()
+        self.assertIn(f"-DOPENSSL_CRYPTO_LIBRARY={crypto}", command)
+        self.assertIn("-DCMAKE_POSITION_INDEPENDENT_CODE=ON", command)
+
+    def test_ios_sdk_distinction(self):
+        for target, sdk in (("ios-arm64", "iphoneos"), ("ios-simulator-arm64", "iphonesimulator")):
+            command = mobile.command(self.args(target, ["--deployment-target", "15.0"]))
+            self.assertIn(f"-DCMAKE_OSX_SYSROOT={sdk}", command)
+            self.assertIn("-DCMAKE_SYSTEM_NAME=iOS", command)
+            self.assertFalse(any("ANDROID" in part for part in command))
+
+    def test_invalid_deployment_target(self):
+        for value in ("20", "28;other", "28.0"):
+            with self.assertRaises(ValueError):
+                mobile.command(self.args(extra=["--deployment-target", value]))
+
+    def test_android_requires_ndk(self):
+        args = self.args()
+        args.ndk = None
+        with self.assertRaises(ValueError):
+            mobile.command(args)
+
+    def test_ios_rejects_ndk(self):
+        with self.assertRaises(ValueError):
+            mobile.command(self.args("ios-arm64", ["--ndk", "/tmp/ndk"]))
+
+    def test_rejects_dirty_build_without_deleting(self):
+        with tempfile.TemporaryDirectory() as directory:
+            args = self.args(extra=["--build-dir", directory])
+            marker = Path(directory) / "CMakeCache.txt"
+            marker.touch()
+            with self.assertRaisesRegex(ValueError, "must be empty"):
+                mobile.preflight(args)
+            self.assertTrue(marker.exists())
+
+    def test_missing_crypto_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            args = self.args(extra=["--build-dir", directory, "--openssl-root", directory])
+            with self.assertRaisesRegex(ValueError, "Missing target OpenSSL"):
+                mobile.preflight(args)

--- a/src/compat/connection.cpp
+++ b/src/compat/connection.cpp
@@ -4617,7 +4617,7 @@ SRTSOCKET accept_bond_sockets(
             std::chrono::milliseconds>(
             Clock::time_point::max() - now).count();
         return now + std::chrono::milliseconds{
-            std::min(timeout_milliseconds, maximum)};
+            std::min<std::int64_t>(timeout_milliseconds, maximum)};
     }();
 
     for (;;) {

--- a/src/compat/connection.cpp
+++ b/src/compat/connection.cpp
@@ -4616,8 +4616,9 @@ SRTSOCKET accept_bond_sockets(
         const auto maximum = std::chrono::duration_cast<
             std::chrono::milliseconds>(
             Clock::time_point::max() - now).count();
-        return now + std::chrono::milliseconds{
-            std::min<std::int64_t>(timeout_milliseconds, maximum)};
+        return now
+            + std::chrono::milliseconds {
+                std::min<std::int64_t>(timeout_milliseconds, maximum)};
     }();
 
     for (;;) {

--- a/src/compat/epoll.cpp
+++ b/src/compat/epoll.cpp
@@ -437,7 +437,7 @@ void collect_system_events(PollRecord& record)
     const auto maximum = std::chrono::duration_cast<
         std::chrono::milliseconds>(
         Clock::time_point::max() - Clock::now()).count();
-    const auto bounded = std::min(timeout_milliseconds, maximum);
+    const auto bounded = std::min<std::int64_t>(timeout_milliseconds, maximum);
     return Clock::now() + std::chrono::milliseconds{bounded};
 }
 

--- a/tools/mobile_configure.py
+++ b/tools/mobile_configure.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Configure an experimental mobile build without implicit host OpenSSL discovery."""
+
+import argparse
+from pathlib import Path
+import re
+import shlex
+import subprocess
+import sys
+
+
+SOURCE = Path(__file__).resolve().parents[1]
+
+
+def parser():
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("target", choices=("android-arm64", "ios-arm64", "ios-simulator-arm64"))
+    result.add_argument("--build-dir", required=True, type=Path)
+    result.add_argument("--openssl-root", required=True, type=Path,
+                        help="Target OpenSSL 3 prefix containing include/ and lib/libcrypto.a")
+    result.add_argument("--ndk", type=Path, help="Exact Android NDK installation")
+    result.add_argument("--deployment-target", required=True,
+                        help="Android API level (e.g. 28) or iOS version (e.g. 15.0); not a support claim")
+    result.add_argument("--plan", action="store_true",
+                        help="Print configuration without checking/installing SDKs or creating files")
+    return result
+
+
+def command(args):
+    android = args.target == "android-arm64"
+    pattern = r"[0-9]+" if android else r"[0-9]+(?:\.[0-9]+){0,2}"
+    if not re.fullmatch(pattern, args.deployment_target):
+        raise ValueError("Invalid deployment target")
+    if android and (args.ndk is None or int(args.deployment_target) < 21):
+        raise ValueError("Android ARM64 requires --ndk and API level >= 21")
+    if not android and args.ndk is not None:
+        raise ValueError("--ndk is only valid for Android")
+    build = args.build_dir.resolve()
+    if build == SOURCE or (SOURCE / ".git") == build or (SOURCE / ".git") in build.parents:
+        raise ValueError("Use a separate, empty build directory")
+    root = args.openssl_root.resolve()
+    options = ["cmake", "-S", str(SOURCE), "-B", str(build), "-G", "Ninja",
+               "-DCMAKE_BUILD_TYPE=Release", "-DBUILD_SHARED_LIBS=OFF",
+               "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
+               "-DROBOTWEAX_SRT_BUILD_TESTS=OFF",
+               "-DROBOTWEAX_SRT_BUILD_TOOLS=OFF",
+               "-DROBOTWEAX_SRT_BUILD_BENCHMARKS=OFF",
+               "-DROBOTWEAX_SRT_BUILD_FUZZERS=OFF",
+               "-DROBOTWEAX_SRT_BUILD_EXAMPLES=OFF",
+               "-DENABLE_AEAD_API_PREVIEW=ON",
+               "-DOPENSSL_USE_STATIC_LIBS=TRUE",
+               f"-DOPENSSL_INCLUDE_DIR={root / 'include'}",
+               f"-DOPENSSL_CRYPTO_LIBRARY={root / 'lib/libcrypto.a'}"]
+    if android:
+        options += [f"-DCMAKE_TOOLCHAIN_FILE={args.ndk.resolve() / 'build/cmake/android.toolchain.cmake'}",
+                    "-DANDROID_ABI=arm64-v8a", f"-DANDROID_PLATFORM=android-{args.deployment_target}",
+                    "-DANDROID_STL=c++_shared"]
+    else:
+        sdk = "iphonesimulator" if "simulator" in args.target else "iphoneos"
+        options += ["-DCMAKE_SYSTEM_NAME=iOS", f"-DCMAKE_OSX_SYSROOT={sdk}",
+                    "-DCMAKE_OSX_ARCHITECTURES=arm64",
+                    f"-DCMAKE_OSX_DEPLOYMENT_TARGET={args.deployment_target}"]
+    return options
+
+
+def preflight(args):
+    build = args.build_dir.resolve()
+    if build.exists() and (not build.is_dir() or any(build.iterdir())):
+        raise ValueError("Build directory must be empty; use a new directory (nothing is deleted)")
+    root = args.openssl_root.resolve()
+    for relative in ("include/openssl/opensslv.h", "lib/libcrypto.a"):
+        if not (root / relative).is_file():
+            raise ValueError(f"Missing target OpenSSL file: {root / relative}")
+    if args.target == "android-arm64":
+        if not (args.ndk / "build/cmake/android.toolchain.cmake").is_file():
+            raise ValueError("Android NDK toolchain not found")
+    else:
+        sdk = "iphonesimulator" if "simulator" in args.target else "iphoneos"
+        subprocess.run(["xcrun", "--sdk", sdk, "--show-sdk-path"], check=True)
+
+
+def main():
+    args = parser().parse_args()
+    try:
+        invocation = command(args)
+        if args.plan:
+            print("PLAN ONLY: SDK availability and target dependencies are not validated.")
+        else:
+            preflight(args)
+        print(shlex.join(invocation), flush=True)
+        if not args.plan:
+            subprocess.run(invocation, check=True)
+        return 0
+    except (ValueError, OSError, subprocess.CalledProcessError) as error:
+        print(f"Mobile configure failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Scope
Add opt-in, reproducible static Release cross-build configuration for Android ARM64, iOS ARM64 and iOS Simulator ARM64 with explicit target OpenSSL. Fix two std::min template deductions exposed by Android libc++. Include an isolated, optional UIKit encrypted-echo example; normal desktop builds remain unchanged.

This is experimental build support, not full mobile runtime qualification. Physical-device tests, background streaming, network migration, JNI/Swift wrappers and supported minimum OS guarantees are out of scope.

## Validation
- All three targets built and linked a public C consumer locally.
- Android and iOS Simulator encrypted CTR/GCM smoke checks passed, including desktop-peer exchanges.
- Installed iOS Simulator app passed CTR and GCM exact echo and non-destructive statistics checks.
- 60 mobile configuration and CI classification Python tests passed.
- Local desktop epoll/timeout regression checks passed as recorded during development.
- Required repository CI must pass before merge; mobile checks above were local, not CI.

See docs/mobile-building.md and examples/ios/README.md for reproducible instructions and qualification limits. No new broad mobile CI matrix is introduced.