### PR TITLE
Identify Robotweax SRT product version at compile and runtime

### DIFF
--- a/docs/socket-options.md
+++ b/docs/socket-options.md
@@ -5,6 +5,39 @@ surface. Use `srt_setsockflag()` and `srt_getsockflag()` with the declared
 `SRT_SOCKOPT` value and value representation. Pre-connection, pre-bind,
 post-connection, and read-only constraints are part of each option's contract.
 
+## Identify the local implementation
+
+`<srt/srt.h>` exposes `ROBOTWEAX_SRT_VERSION_MAJOR`, `_MINOR`, `_PATCH`,
+`_STRING` and `_VALUE` (each with the `ROBOTWEAX_SRT_VERSION` prefix).
+These describe the headers' product release. They do not replace `SRT_VERSION_*`,
+which describe SRT compatibility. The packed numeric format is
+`major * 0x10000 + minor * 0x100 + patch`.
+
+`SRTO_ROBOTWEAX_VERSION` (`0x01000001`) is a read-only extension returning an
+`int32_t` containing the loaded library's product version. Query it using
+`srt_getsockflag()` with a valid socket or group, even before connecting. An
+`int` length must initially be at least `sizeof(int32_t)`; success sets it to
+that size. Null pointers or short buffers are invalid. The option is local:
+it is never negotiated or transmitted and says nothing about the peer.
+
+```c
+#if defined(ROBOTWEAX_SRT_VERSION_VALUE)
+int32_t product_version = 0;
+int length = sizeof(product_version);
+if (srt_getsockflag(socket, SRTO_ROBOTWEAX_VERSION,
+        &product_version, &length) == 0) {
+    /* product_version identifies the loaded implementation, not the headers. */
+}
+#endif
+```
+
+Failure means identification was unsuccessful, not proof of Haivision: older
+Robotweax releases lack this option, and invalid handles also fail. Handle the
+error normally. `srt_getversion()`, `SRTO_VERSION`, `SRTO_PEERVERSION` and all
+existing option numbers retain their compatibility semantics. This extension
+adds no exported function or structure field. A high option number reduces
+collision risk but is not an upstream namespace reservation.
+
 ```c
 #include <srt/srt.h>
 

--- a/include/srt/srt.h
+++ b/include/srt/srt.h
@@ -143,6 +143,11 @@ typedef enum SRT_SOCKOPT {
     SRTO_GROUPTYPE = 59,
     SRTO_PACKETFILTER = 60,
     SRTO_RETRANSMITALGO = 61,
+    /** Local library release as int32_t; read-only, not a peer/wire version.
+     * Requires a valid socket or group. Unsupported by older implementations.
+     * This extension does not change SRTO_E_SIZE or compatibility options.
+     */
+    SRTO_ROBOTWEAX_VERSION = 0x01000001,
 #ifdef ENABLE_AEAD_API_PREVIEW
     SRTO_CRYPTOMODE = 62,
     SRTO_E_SIZE = 63

--- a/include/srt/version.h
+++ b/include/srt/version.h
@@ -22,4 +22,13 @@
     SRT_MAKE_VERSION_VALUE( \
         SRT_VERSION_MAJOR, SRT_VERSION_MINOR, SRT_VERSION_PATCH)
 
+/* Local implementation release, not the wire/API compatibility version. */
+#define ROBOTWEAX_SRT_VERSION_MAJOR 0
+#define ROBOTWEAX_SRT_VERSION_MINOR 2
+#define ROBOTWEAX_SRT_VERSION_PATCH 3
+#define ROBOTWEAX_SRT_VERSION_STRING "0.2.3"
+#define ROBOTWEAX_SRT_VERSION_VALUE                                            \
+    SRT_MAKE_VERSION_VALUE(ROBOTWEAX_SRT_VERSION_MAJOR,                        \
+        ROBOTWEAX_SRT_VERSION_MINOR, ROBOTWEAX_SRT_VERSION_PATCH)
+
 #endif

--- a/interop/tests/test_api_inventory.py
+++ b/interop/tests/test_api_inventory.py
@@ -8,6 +8,14 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 
 
 class ApiInventoryTests(unittest.TestCase):
+    def test_product_version_macros_match_cmake_release(self):
+        cmake = (REPOSITORY_ROOT / "CMakeLists.txt").read_text()
+        version = re.search(r"project\(robotweax_srt VERSION ([0-9.]+)", cmake).group(1)
+        header = (REPOSITORY_ROOT / "include/srt/version.h").read_text()
+        for component, value in zip(("MAJOR", "MINOR", "PATCH"), version.split(".")):
+            self.assertRegex(header, rf"#define ROBOTWEAX_SRT_VERSION_{component} {value}\n")
+        self.assertIn(f'#define ROBOTWEAX_SRT_VERSION_STRING "{version}"', header)
+
     def test_installed_public_headers_have_machine_readable_license(self):
         for relative_path in (
             "include/robotweax_srt.h",

--- a/src/compat/group_registry.cpp
+++ b/src/compat/group_registry.cpp
@@ -392,6 +392,9 @@ int GroupRegistry::get_io_option(
             return SRT_ERROR;
         }
         switch (option) {
+        case SRTO_ROBOTWEAX_VERSION:
+            result = static_cast<std::int32_t>(ROBOTWEAX_SRT_VERSION_VALUE);
+            break;
         case SRTO_SNDSYN:
             boolean_result = record->send_synchronous;
             boolean_option = true;

--- a/src/compat/socket_options.cpp
+++ b/src/compat/socket_options.cpp
@@ -359,6 +359,9 @@ int get_socket_option(
     case SRTO_VERSION:
         return write_value(
             value, value_size, static_cast<std::int32_t>(SRT_VERSION_VALUE));
+    case SRTO_ROBOTWEAX_VERSION:
+        return write_value(value, value_size,
+            static_cast<std::int32_t>(ROBOTWEAX_SRT_VERSION_VALUE));
     case SRTO_PEERVERSION:
         return write_value(value, value_size,
             static_cast<std::int32_t>(socket.peer_srt_version));

--- a/tests/package_consumer/c_consumer.c
+++ b/tests/package_consumer/c_consumer.c
@@ -49,6 +49,18 @@ int main(void)
         return 2;
     }
 
+    int32_t implementation_version = 0;
+    int implementation_size = (int)sizeof(implementation_version);
+    if (srt_getsockflag(socket, SRTO_ROBOTWEAX_VERSION, &implementation_version,
+            &implementation_size)
+            == SRT_ERROR
+        || implementation_size != (int)sizeof(implementation_version)
+        || implementation_version != ROBOTWEAX_SRT_VERSION_VALUE) {
+        (void)srt_close(socket);
+        (void)srt_cleanup();
+        return 10;
+    }
+
 #ifdef ENABLE_AEAD_API_PREVIEW
     int crypto_mode = 2;
     if (srt_setsockflag(

--- a/tests/test_srt_compat.cpp
+++ b/tests/test_srt_compat.cpp
@@ -5270,6 +5270,50 @@ TEST(srt_compat_last_error_is_thread_local)
     REQUIRE_EQ(srt_getlasterror(nullptr), SRT_SUCCESS);
 }
 
+TEST(srt_compat_robotweax_version_identifies_local_implementation)
+{
+    static_assert(SRTO_ROBOTWEAX_VERSION == 0x01000001);
+    const SRTSOCKET socket = srt_create_socket();
+    const SRTSOCKET group = srt_create_group(SRT_GTYPE_BROADCAST);
+    REQUIRE(socket != SRT_INVALID_SOCK);
+    REQUIRE(group != SRT_INVALID_SOCK);
+    for (const SRTSOCKET handle : {socket, group}) {
+        std::int32_t value = -1;
+        int size = sizeof(value);
+        REQUIRE_EQ(
+            srt_getsockflag(handle, SRTO_ROBOTWEAX_VERSION, &value, &size), 0);
+        REQUIRE_EQ(value, ROBOTWEAX_SRT_VERSION_VALUE);
+        REQUIRE_EQ(size, static_cast<int>(sizeof(value)));
+        REQUIRE_EQ(srt_setsockflag(
+                       handle, SRTO_ROBOTWEAX_VERSION, &value, sizeof(value)),
+            SRT_ERROR);
+        size = 1;
+        value = -1;
+        REQUIRE_EQ(
+            srt_getsockflag(handle, SRTO_ROBOTWEAX_VERSION, &value, &size),
+            SRT_ERROR);
+        REQUIRE_EQ(value, -1);
+        REQUIRE_EQ(srt_getlasterror(nullptr), SRT_EINVPARAM);
+        size = sizeof(value);
+        REQUIRE_EQ(
+            srt_getsockflag(handle, SRTO_ROBOTWEAX_VERSION, nullptr, &size),
+            SRT_ERROR);
+        REQUIRE_EQ(
+            srt_getsockflag(handle, SRTO_ROBOTWEAX_VERSION, &value, nullptr),
+            SRT_ERROR);
+    }
+    std::int32_t value = 0;
+    int size = sizeof(value);
+    REQUIRE_EQ(srt_getsockflag(socket, SRTO_VERSION, &value, &size), 0);
+    REQUIRE_EQ(value, SRT_VERSION_VALUE);
+    REQUIRE_EQ(srt_getversion(), static_cast<std::uint32_t>(SRT_VERSION_VALUE));
+    REQUIRE_EQ(srt_close(socket), 0);
+    REQUIRE_EQ(srt_close(group), 0);
+    REQUIRE_EQ(srt_getsockflag(socket, SRTO_ROBOTWEAX_VERSION, &value, &size),
+        SRT_ERROR);
+    REQUIRE_EQ(srt_getlasterror(nullptr), SRT_EINVSOCK);
+}
+
 TEST(srt_compat_message_control_and_helpers_match_public_layout)
 {
     SRT_MSGCTRL control{};


### PR DESCRIPTION
## Summary
Closes #10.

Add ROBOTWEAX_SRT_VERSION_MAJOR/MINOR/PATCH/STRING/VALUE to the public version header and read-only SRTO_ROBOTWEAX_VERSION (0x01000001) for valid sockets and groups. The runtime result is int32_t and identifies the loaded local library, not the peer. Existing SRT compatibility versions, enum values, exported symbols and layouts remain unchanged.

Document unsupported/older-provider behavior and the distinction between header and runtime versions. Add a release-macro consistency test and exercise the runtime option in the installed C consumer.

## Validation
- Focused C++ version test passed, including group, read-only, malformed output and closed socket cases.
- Static AEAD-enabled package consumer and ABI checks passed.
- Fresh default shared Release build: all 18 CTest tests passed across the initial run and a corrected Python-contract rerun (551 Python tests); no test weakened.
- Documentation and pinned changed-line formatting checks passed.

Linux/Windows and repository CI remain required before merge. No release version bump in this PR.