### PR TITLE
Prepare Windows SDK installer candidates

### DIFF
--- a/.github/workflows/windows-sdk.yml
+++ b/.github/workflows/windows-sdk.yml
@@ -1,0 +1,89 @@
+name: Windows SDK candidate
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'packaging/windows/**'
+      - '.github/workflows/windows-sdk.yml'
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [Win32, x64, Arm64]
+        configuration: [Debug, Release]
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/checkout@v7
+        with:
+          repository: openssl/openssl
+          ref: aae016bfd52fcad2bc9657c2c782cfdf73b1ed5f
+          path: openssl-source
+          persist-credentials: false
+      - name: Build dependency and SDK in target environment
+        shell: pwsh
+        env:
+          SDK_PLATFORM: ${{ matrix.platform }}
+          SDK_CONFIGURATION: ${{ matrix.configuration }}
+        run: |
+          $vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          $arch = @{Win32='x86'; x64='amd64'; Arm64='amd64_arm64'}[$env:SDK_PLATFORM]
+          $script = Join-Path $PWD 'packaging\windows\build-ci.ps1'
+          & cmd /c "`"$vs\VC\Auxiliary\Build\vcvarsall.bat`" $arch && powershell -NoProfile -ExecutionPolicy Bypass -File `"$script`" -Platform $env:SDK_PLATFORM -Configuration $env:SDK_CONFIGURATION"
+          if ($LASTEXITCODE -ne 0) { throw 'SDK build failed' }
+      - uses: actions/upload-artifact@v7
+        with:
+          name: sdk-${{ matrix.configuration }}-${{ matrix.platform }}
+          path: output/sdk-${{ matrix.configuration }}-${{ matrix.platform }}/
+          if-no-files-found: error
+          retention-days: 7
+  installer:
+    needs: build
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: sdk-*
+          path: variants
+      - name: Assemble and compile installer candidate
+        shell: pwsh
+        run: |
+          ./packaging/windows/package.ps1 -Variants variants -Destination sdk
+          $version = [regex]::Match((Get-Content CMakeLists.txt -Raw), 'project\(robotweax_srt VERSION ([0-9.]+)').Groups[1].Value
+          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          if (!(Test-Path $iscc)) { throw 'Inno Setup 6 is required' }
+          & $iscc "/DSdkRoot=$PWD\sdk" "/DProductVersion=$version" packaging/windows/sdk.iss
+          if ($LASTEXITCODE -ne 0) { throw 'Installer compilation failed' }
+      - name: Smoke test silent install and uninstall
+        shell: pwsh
+        run: |
+          $installer = (Get-ChildItem packaging/windows/Output/*.exe).FullName
+          $destination = Join-Path $env:RUNNER_TEMP 'Robotweax SDK test'
+          $process = Start-Process -Wait -PassThru $installer -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /DIR=`"$destination`""
+          if ($process.ExitCode -ne 0) { throw 'Installation failed' }
+          if ([Environment]::GetEnvironmentVariable('ROBOTWEAX_SRT','Machine') -ne $destination) { throw 'SDK environment variable missing' }
+          foreach ($config in 'Debug','Release') {
+            foreach ($platform in 'Win32','x64','Arm64') {
+              if (!(Test-Path "$destination/lib/$config-$platform/robotweax-srt.lib")) { throw 'Missing installed variant' }
+            }
+          }
+          $process = Start-Process -Wait -PassThru "$destination/unins000.exe" -ArgumentList '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+          if ($process.ExitCode -ne 0) { throw 'Uninstallation failed' }
+          if (Test-Path "$destination/srt.props") { throw 'SDK files remained installed' }
+          if ([Environment]::GetEnvironmentVariable('ROBOTWEAX_SRT','Machine') -eq $destination) { throw 'Stale SDK environment variable' }
+      - uses: actions/upload-artifact@v7
+        with:
+          name: windows-sdk-installer-candidate
+          path: packaging/windows/Output/*.exe
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/windows-sdk.yml
+++ b/.github/workflows/windows-sdk.yml
@@ -73,6 +73,13 @@ jobs:
           $process = Start-Process -Wait -PassThru $installer -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /DIR=`"$destination`""
           if ($process.ExitCode -ne 0) { throw 'Installation failed' }
           if ([Environment]::GetEnvironmentVariable('ROBOTWEAX_SRT','Machine') -ne $destination) { throw 'SDK environment variable missing' }
+          $before = (Get-FileHash "$destination/srt.props").Hash
+          $process = Start-Process -Wait -PassThru $installer -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /DIR=`"$destination`""
+          if ($process.ExitCode -eq 0) { throw 'Existing installation was not rejected' }
+          $other = Join-Path $env:RUNNER_TEMP 'Robotweax SDK alternate'
+          $process = Start-Process -Wait -PassThru $installer -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /DIR=`"$other`""
+          if ($process.ExitCode -eq 0) { throw 'Parallel installation was not rejected' }
+          if ((Get-FileHash "$destination/srt.props").Hash -ne $before) { throw 'Rejected installation changed existing SDK' }
           foreach ($config in 'Debug','Release') {
             foreach ($platform in 'Win32','x64','Arm64') {
               if (!(Test-Path "$destination/lib/$config-$platform/robotweax-srt.lib")) { throw 'Missing installed variant' }
@@ -82,6 +89,11 @@ jobs:
           if ($process.ExitCode -ne 0) { throw 'Uninstallation failed' }
           if (Test-Path "$destination/srt.props") { throw 'SDK files remained installed' }
           if ([Environment]::GetEnvironmentVariable('ROBOTWEAX_SRT','Machine') -eq $destination) { throw 'Stale SDK environment variable' }
+          $process = Start-Process -Wait -PassThru $installer -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /DIR=`"$other`""
+          if ($process.ExitCode -ne 0) { throw 'Reinstallation after uninstall failed' }
+          if (!(Test-Path "$other/include/srt/srt.h")) { throw 'Reinstalled headers missing' }
+          $process = Start-Process -Wait -PassThru "$other/unins000.exe" -ArgumentList '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+          if ($process.ExitCode -ne 0) { throw 'Final cleanup failed' }
       - uses: actions/upload-artifact@v7
         with:
           name: windows-sdk-installer-candidate

--- a/.github/workflows/windows-sdk.yml
+++ b/.github/workflows/windows-sdk.yml
@@ -35,7 +35,8 @@ jobs:
           $vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
           $arch = @{Win32='x86'; x64='amd64'; Arm64='amd64_arm64'}[$env:SDK_PLATFORM]
           $script = Join-Path $PWD 'packaging\windows\build-ci.ps1'
-          & cmd /c "`"$vs\VC\Auxiliary\Build\vcvarsall.bat`" $arch && powershell -NoProfile -ExecutionPolicy Bypass -File `"$script`" -Platform $env:SDK_PLATFORM -Configuration $env:SDK_CONFIGURATION"
+          $pwsh = Join-Path $PSHOME 'pwsh.exe'
+          & cmd /c "`"$vs\VC\Auxiliary\Build\vcvarsall.bat`" $arch && `"$pwsh`" -NoProfile -File `"$script`" -Platform $env:SDK_PLATFORM -Configuration $env:SDK_CONFIGURATION"
           if ($LASTEXITCODE -ne 0) { throw 'SDK build failed' }
       - uses: actions/upload-artifact@v7
         with:

--- a/interop/tests/test_windows_sdk.py
+++ b/interop/tests/test_windows_sdk.py
@@ -1,11 +1,24 @@
 """Static guardrails for the Windows-only SDK build workflow."""
 from pathlib import Path
 import unittest
+import xml.etree.ElementTree as ET
 
 ROOT = Path(__file__).resolve().parents[2]
 
 
 class WindowsSdkTests(unittest.TestCase):
+    def test_msbuild_probe_imports_shipped_props(self):
+        project = ET.parse(ROOT / 'packaging/windows/consumer/consumer.vcxproj')
+        namespace = {'m': 'http://schemas.microsoft.com/developer/msbuild/2003'}
+        imports = [entry.attrib['Project'] for entry in project.findall('m:Import', namespace)]
+        self.assertIn('$(ROBOTWEAX_SRT)\\srt.props', imports)
+        ET.parse(ROOT / 'packaging/windows/srt.props')
+
+    def test_existing_install_is_guarded_independent_of_destination(self):
+        script = (ROOT / 'packaging/windows/sdk.iss').read_text()
+        self.assertIn('RegKeyExists(HKLM,', script)
+        self.assertIn('Robotweax.SRT.SDK_is1', script)
+
     def test_public_c_consumer_uses_c11(self):
         script = (ROOT / 'packaging/windows/build-ci.ps1').read_text()
         self.assertIn("Run cl @('/nologo','/std:c11'", script)

--- a/interop/tests/test_windows_sdk.py
+++ b/interop/tests/test_windows_sdk.py
@@ -7,6 +7,16 @@ ROOT = Path(__file__).resolve().parents[2]
 
 
 class WindowsSdkTests(unittest.TestCase):
+    def test_crypto_assembly_is_required_for_every_target(self):
+        script = (ROOT / 'packaging/windows/build-ci.ps1').read_text()
+        self.assertNotIn("'no-asm'", script)
+        self.assertIn('VC-WIN64-CLANGASM-ARM', script)
+        self.assertIn('nasm.exe', script)
+        self.assertIn('clang-cl.exe', script)
+        self.assertIn('Required assembler missing', script)
+        self.assertIn('$configdata::disabled{asm}', script)
+        self.assertIn('$configdata::target{asm_arch}', script)
+
     def test_msbuild_probe_imports_shipped_props(self):
         project = ET.parse(ROOT / 'packaging/windows/consumer/consumer.vcxproj')
         namespace = {'m': 'http://schemas.microsoft.com/developer/msbuild/2003'}

--- a/interop/tests/test_windows_sdk.py
+++ b/interop/tests/test_windows_sdk.py
@@ -1,0 +1,18 @@
+"""Static guardrails for the Windows-only SDK build workflow."""
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class WindowsSdkTests(unittest.TestCase):
+    def test_msvc_crypto_configurations_are_explicit(self):
+        script = (ROOT / 'packaging/windows/build-sdk.ps1').read_text()
+        for config in ('DEBUG', 'RELEASE'):
+            self.assertIn(f'-DLIB_EAY_{config}:FILEPATH=$Crypto', script)
+        self.assertIn('Unexpected OpenSSL selection', script)
+
+    def test_child_shell_uses_same_powershell_runtime(self):
+        workflow = (ROOT / '.github/workflows/windows-sdk.yml').read_text()
+        self.assertIn("Join-Path $PSHOME 'pwsh.exe'", workflow)
+        self.assertNotIn('&& powershell ', workflow)

--- a/interop/tests/test_windows_sdk.py
+++ b/interop/tests/test_windows_sdk.py
@@ -6,6 +6,10 @@ ROOT = Path(__file__).resolve().parents[2]
 
 
 class WindowsSdkTests(unittest.TestCase):
+    def test_public_c_consumer_uses_c11(self):
+        script = (ROOT / 'packaging/windows/build-ci.ps1').read_text()
+        self.assertIn("Run cl @('/nologo','/std:c11'", script)
+
     def test_msvc_crypto_configurations_are_explicit(self):
         script = (ROOT / 'packaging/windows/build-sdk.ps1').read_text()
         for config in ('DEBUG', 'RELEASE'):

--- a/interop/tests/test_windows_sdk.py
+++ b/interop/tests/test_windows_sdk.py
@@ -12,6 +12,9 @@ class WindowsSdkTests(unittest.TestCase):
         namespace = {'m': 'http://schemas.microsoft.com/developer/msbuild/2003'}
         imports = [entry.attrib['Project'] for entry in project.findall('m:Import', namespace)]
         self.assertIn('$(ROBOTWEAX_SRT)\\srt.props', imports)
+        toolset = project.find('m:PropertyGroup[@Label="Configuration"]/m:PlatformToolset', namespace)
+        self.assertIsNotNone(toolset)
+        self.assertEqual(toolset.text, '$(DefaultPlatformToolset)')
         ET.parse(ROOT / 'packaging/windows/srt.props')
 
     def test_existing_install_is_guarded_independent_of_destination(self):

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -46,7 +46,16 @@ not install over a system Haivision installation. OpenSSL Crypto is an explicit
 static link dependency. Applications with another OpenSSL dependency must resolve
 version/link compatibility; static linkage does not remove symbol conflicts.
 
-Upgrades currently require uninstalling the previous SDK first. Do not install
+The candidate workflow also builds the public C consumer through
+`consumer/consumer.vcxproj`, importing the staged `srt.props` for all six
+combinations. It executes Win32/x64 consumers and deliberately checks that a
+static-CRT profile is rejected. ARM64 remains compile/link-only on this runner.
+
+Upgrades currently require uninstalling the previous SDK first. The installer
+rejects an already registered SDK even when a different destination is selected.
+CI checks rejection, preservation of the existing props file, uninstall and
+reinstallation into another path. This is not an automatic in-place upgrade test.
+Do not install
 over an older SDK with a different file inventory. Uninstall removes the
 environment variable only when it still points to this installation.
 

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -20,10 +20,12 @@ qualified release installer. No existing release assets are modified.
 The `Windows SDK candidate` workflow builds the six variants from a
 pinned OpenSSL 3.6.3 revision and uploads short-lived candidate artifacts only.
 It links a public C consumer for every target and runs it for Win32/x64; ARM64
-execution is not verified by the x64 runner. The dependency baseline uses
-`no-asm` for initial reproducibility across the targets and is **not a performance
-qualification**. Optimized dependency builds must be addressed before recommending
-these candidates for production throughput. This workflow runs manually or for
+execution is not verified by the x64 runner. OpenSSL assembly is enabled using
+NASM for Win32/x64 and the `VC-WIN64-CLANGASM-ARM` target (MSVC C compiler,
+clang-cl assembler) for ARM64. Missing assemblers or disabled assembly fail the
+build; assembler versions and OpenSSL configuration are recorded in CI logs.
+This is **not a performance qualification**; production throughput still needs
+measurement on the target hardware. This workflow runs manually or for
 PRs changing Windows packaging; it does not run on ordinary pushes or
 automatically publish release assets.
 

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -1,0 +1,54 @@
+# Windows SDK installer (experimental)
+
+This is an SDK for application developers, not a standalone streaming app.
+The intended bundle contains static Robotweax SRT and static OpenSSL Crypto for
+Debug/Release × Win32/x64/Arm64. Consumers use `/MDd` for Debug and `/MD` for
+Release. Debug binaries are development-only; applications must deploy the
+appropriate Microsoft runtime for Release. AES-GCM preview is not enabled.
+
+Build each variant using `build-sdk.ps1` in the corresponding Visual Studio
+developer environment, supplying matching static OpenSSL headers/library and
+its `LICENSE.txt`. Do not mix architectures or CRT profiles. The script refuses
+existing build/stage directories. Combine the six SDK variants only after
+checking that shared headers and license files are identical.
+
+Compile `sdk.iss` with Inno Setup, supplying `/DSdkRoot=...` and
+`/DProductVersion=...`. Do not publish until Windows install/uninstall and all
+six consumer link checks pass. This initial packaging work is not a signed or
+qualified release installer. No existing release assets are modified.
+
+The `Windows SDK candidate` workflow builds the six variants from a
+pinned OpenSSL 3.6.3 revision and uploads short-lived candidate artifacts only.
+It links a public C consumer for every target and runs it for Win32/x64; ARM64
+execution is not verified by the x64 runner. The dependency baseline uses
+`no-asm` for initial reproducibility across the targets and is **not a performance
+qualification**. Optimized dependency builds must be addressed before recommending
+these candidates for production throughput. This workflow runs manually or for
+PRs changing Windows packaging; it does not run on ordinary pushes or
+automatically publish release assets.
+
+Interactive installation shows the installer UI. Unattended installation:
+
+```powershell
+Start-Process -Wait -FilePath .\robotweax-srt-VERSION-windows-sdk.exe -ArgumentList '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+```
+
+Use `/DIR="C:\custom\Robotweax-SRT"` to select another directory. The installer
+sets machine-wide `ROBOTWEAX_SRT`; open a new shell to observe the change.
+Import `$(ROBOTWEAX_SRT)\srt.props` after project compiler settings:
+
+```xml
+<Import Project="$(ROBOTWEAX_SRT)\srt.props" />
+```
+
+Header includes remain `<srt/srt.h>`; the root is private to this SDK and does
+not install over a system Haivision installation. OpenSSL Crypto is an explicit
+static link dependency. Applications with another OpenSSL dependency must resolve
+version/link compatibility; static linkage does not remove symbol conflicts.
+
+Upgrades currently require uninstalling the previous SDK first. Do not install
+over an older SDK with a different file inventory. Uninstall removes the
+environment variable only when it still points to this installation.
+
+References: [Inno Setup command-line options](https://jrsoftware.org/ishelp/topic_setupcmdline.htm),
+[OpenSSL Windows build notes](https://github.com/openssl/openssl/blob/openssl-3.6.3/NOTES-WINDOWS.md).

--- a/packaging/windows/build-ci.ps1
+++ b/packaging/windows/build-ci.ps1
@@ -27,3 +27,16 @@ $Runtime = if ($Configuration -eq 'Debug') { '/MDd' } else { '/MD' }
 Run cl @('/nologo','/std:c11',$Runtime,"/I$Sdk/include",'/c',"$Root/tests/package_consumer/c_consumer.c",'/Foconsumer.obj')
 Run link @('/nologo','consumer.obj',"/LIBPATH:$Sdk/lib/$Configuration-$Platform",'robotweax-srt.lib','libcrypto.lib','ws2_32.lib','crypt32.lib','advapi32.lib','user32.lib','bcrypt.lib','/OUT:consumer.exe')
 if ($Platform -ne 'Arm64') { Run "$Root/consumer.exe" @() }
+
+# Exercise the shipped props rather than duplicating its linker settings.
+$Project = "$PSScriptRoot/consumer/consumer.vcxproj"
+$Properties = @("/p:Configuration=$Configuration", "/p:Platform=$Platform", "/p:ROBOTWEAX_SRT=$Sdk")
+Run msbuild (@($Project,'/nologo','/t:Rebuild') + $Properties)
+if ($Platform -ne 'Arm64') {
+    Run "$PSScriptRoot/consumer/out/$Configuration-$Platform/sdk-consumer.exe" @()
+}
+$WrongRuntime = if ($Configuration -eq 'Debug') { 'MultiThreadedDebug' } else { 'MultiThreaded' }
+$FailureOutput = & msbuild $Project /nologo /t:Rebuild @Properties "/p:SdkTestRuntime=$WrongRuntime" 2>&1
+if ($LASTEXITCODE -eq 0 -or ($FailureOutput -join "`n") -notmatch 'SDK requires /MD') {
+    throw 'MSBuild props did not reject the incompatible CRT profile as expected'
+}

--- a/packaging/windows/build-ci.ps1
+++ b/packaging/windows/build-ci.ps1
@@ -24,6 +24,6 @@ if (!$?) { throw 'SDK build failed' }
 $Sdk = "$Root/output/sdk-$Configuration-$Platform"
 $Runtime = if ($Configuration -eq 'Debug') { '/MDd' } else { '/MD' }
 # Link every architecture; execute only architectures supported by this runner.
-Run cl @('/nologo',$Runtime,"/I$Sdk/include",'/c',"$Root/tests/package_consumer/c_consumer.c",'/Foconsumer.obj')
+Run cl @('/nologo','/std:c11',$Runtime,"/I$Sdk/include",'/c',"$Root/tests/package_consumer/c_consumer.c",'/Foconsumer.obj')
 Run link @('/nologo','consumer.obj',"/LIBPATH:$Sdk/lib/$Configuration-$Platform",'robotweax-srt.lib','libcrypto.lib','ws2_32.lib','crypt32.lib','advapi32.lib','user32.lib','bcrypt.lib','/OUT:consumer.exe')
 if ($Platform -ne 'Arm64') { Run "$Root/consumer.exe" @() }

--- a/packaging/windows/build-ci.ps1
+++ b/packaging/windows/build-ci.ps1
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MIT
+param([string]$Platform, [string]$Configuration)
+$ErrorActionPreference = 'Stop'
+function Run([string]$Program, [string[]]$Arguments) {
+    & $Program @Arguments
+    if ($LASTEXITCODE -ne 0) { throw "$Program failed: $LASTEXITCODE" }
+}
+$Root = (Get-Location).Path
+$Target = @{Win32='VC-WIN32';x64='VC-WIN64A';Arm64='VC-WIN64-ARM'}[$Platform]
+if (!$Target) { throw 'Invalid platform' }
+$Prefix = "$Root/crypto-install"
+New-Item -ItemType Directory crypto-build | Out-Null
+Push-Location crypto-build
+try {
+    $Options = @("$Root/openssl-source/Configure",$Target,'no-shared','no-tests','no-asm',"--prefix=$Prefix",'--libdir=lib')
+    if ($Configuration -eq 'Debug') { $Options += '--debug' }
+    Run perl $Options
+    Run nmake @()
+    Run nmake @('install_dev')
+} finally { Pop-Location }
+Copy-Item "$Root/openssl-source/LICENSE.txt" "$Prefix/LICENSE.txt"
+& "$PSScriptRoot/build-sdk.ps1" -Platform $Platform -Configuration $Configuration -OpenSSLRoot $Prefix -OutputRoot "$Root/output"
+if (!$?) { throw 'SDK build failed' }
+$Sdk = "$Root/output/sdk-$Configuration-$Platform"
+$Runtime = if ($Configuration -eq 'Debug') { '/MDd' } else { '/MD' }
+# Link every architecture; execute only architectures supported by this runner.
+Run cl @('/nologo',$Runtime,"/I$Sdk/include",'/c',"$Root/tests/package_consumer/c_consumer.c",'/Foconsumer.obj')
+Run link @('/nologo','consumer.obj',"/LIBPATH:$Sdk/lib/$Configuration-$Platform",'robotweax-srt.lib','libcrypto.lib','ws2_32.lib','crypt32.lib','advapi32.lib','user32.lib','bcrypt.lib','/OUT:consumer.exe')
+if ($Platform -ne 'Arm64') { Run "$Root/consumer.exe" @() }

--- a/packaging/windows/build-ci.ps1
+++ b/packaging/windows/build-ci.ps1
@@ -6,15 +6,34 @@ function Run([string]$Program, [string[]]$Arguments) {
     if ($LASTEXITCODE -ne 0) { throw "$Program failed: $LASTEXITCODE" }
 }
 $Root = (Get-Location).Path
-$Target = @{Win32='VC-WIN32';x64='VC-WIN64A';Arm64='VC-WIN64-ARM'}[$Platform]
+$Target = @{Win32='VC-WIN32';x64='VC-WIN64A';Arm64='VC-WIN64-CLANGASM-ARM'}[$Platform]
 if (!$Target) { throw 'Invalid platform' }
+$Assembler = if ($Platform -eq 'Arm64') { 'clang-cl.exe' } else { 'nasm.exe' }
+$Candidates = if ($Platform -eq 'Arm64') {
+    @("${env:VSINSTALLDIR}VC\Tools\Llvm\bin", "${env:ProgramFiles}\LLVM\bin")
+} else {
+    @("${env:ProgramFiles}\NASM", "${env:ProgramFiles(x86)}\NASM")
+}
+if (!(Get-Command $Assembler -ErrorAction SilentlyContinue)) {
+    foreach ($Directory in $Candidates) {
+        if (Test-Path (Join-Path $Directory $Assembler)) {
+            $env:PATH = "$Directory;$env:PATH"
+            break
+        }
+    }
+}
+if (!(Get-Command $Assembler -ErrorAction SilentlyContinue)) { throw "Required assembler missing: $Assembler" }
+Run $Assembler @('--version')
 $Prefix = "$Root/crypto-install"
 New-Item -ItemType Directory crypto-build | Out-Null
 Push-Location crypto-build
 try {
-    $Options = @("$Root/openssl-source/Configure",$Target,'no-shared','no-tests','no-asm',"--prefix=$Prefix",'--libdir=lib')
+    $Options = @("$Root/openssl-source/Configure",$Target,'no-shared','no-tests',"--prefix=$Prefix",'--libdir=lib')
     if ($Configuration -eq 'Debug') { $Options += '--debug' }
     Run perl $Options
+    # Fail closed if Configure disables assembly; retain its full configuration.
+    Run perl @('-I.','-Mconfigdata','-e','die "OpenSSL assembly disabled" if exists $configdata::disabled{asm}; die "Missing assembly architecture" unless $configdata::target{asm_arch};')
+    Run perl @('configdata.pm','--dump')
     Run nmake @()
     Run nmake @('install_dev')
 } finally { Pop-Location }

--- a/packaging/windows/build-sdk.ps1
+++ b/packaging/windows/build-sdk.ps1
@@ -23,8 +23,21 @@ Invoke-Checked cmake @('-S',$Source,'-B',$Build,'-G','Ninja',
     '-DBUILD_SHARED_LIBS=OFF','-DROBOTWEAX_SRT_BUILD_TESTS=OFF',
     '-DROBOTWEAX_SRT_BUILD_TOOLS=OFF','-DROBOTWEAX_SRT_BUILD_BENCHMARKS=OFF',
     '-DROBOTWEAX_SRT_BUILD_EXAMPLES=OFF','-DROBOTWEAX_SRT_INSTALL_LAYOUT=namespaced',
-    '-DOPENSSL_USE_STATIC_LIBS=ON',"-DOPENSSL_INCLUDE_DIR=$OpenSSLRoot/include",
-    "-DOPENSSL_CRYPTO_LIBRARY=$Crypto")
+    '-DOPENSSL_USE_STATIC_LIBS=ON',"-DOPENSSL_ROOT_DIR=$OpenSSLRoot",
+    "-DOPENSSL_INCLUDE_DIR=$OpenSSLRoot/include",
+    "-DOPENSSL_CRYPTO_LIBRARY=$Crypto",
+    "-DLIB_EAY_DEBUG:FILEPATH=$Crypto","-DLIB_EAY_RELEASE:FILEPATH=$Crypto")
+# FindOpenSSL on MSVC derives its imported target from LIB_EAY_DEBUG/RELEASE,
+# not just OPENSSL_CRYPTO_LIBRARY. Fail before compilation if that pin changes.
+$Cache = Get-Content "$Build/CMakeCache.txt"
+foreach ($Name in @('LIB_EAY_DEBUG', 'LIB_EAY_RELEASE')) {
+    $Entry = @($Cache | Where-Object { $_ -like "${Name}:FILEPATH=*" })
+    if ($Entry.Count -ne 1) { throw "Missing pinned $Name" }
+    $Selected = $Entry[0].Substring($Entry[0].IndexOf('=') + 1)
+    if ([IO.Path]::GetFullPath($Selected) -ne [IO.Path]::GetFullPath($Crypto)) {
+        throw "Unexpected OpenSSL selection: $Selected"
+    }
+}
 Invoke-Checked cmake @('--build',$Build,'--parallel','2','--target','robotweax_srt')
 New-Item -ItemType Directory -Path "$Stage/lib/$Configuration-$Platform" -Force | Out-Null
 Copy-Item "$Build/robotweax-srt.lib" "$Stage/lib/$Configuration-$Platform/"

--- a/packaging/windows/build-sdk.ps1
+++ b/packaging/windows/build-sdk.ps1
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MIT
+# Run in a matching Visual Studio developer environment.
+param(
+    [Parameter(Mandatory)][ValidateSet('Win32','x64','Arm64')][string]$Platform,
+    [Parameter(Mandatory)][ValidateSet('Debug','Release')][string]$Configuration,
+    [Parameter(Mandatory)][string]$OpenSSLRoot,
+    [Parameter(Mandatory)][string]$OutputRoot
+)
+$ErrorActionPreference = 'Stop'
+function Invoke-Checked([string]$Program, [string[]]$Arguments) {
+    & $Program @Arguments
+    if ($LASTEXITCODE -ne 0) { throw "$Program failed: $LASTEXITCODE" }
+}
+$Source = (Resolve-Path "$PSScriptRoot/../..").Path
+$Crypto = (Resolve-Path "$OpenSSLRoot/lib/libcrypto.lib").Path
+$OutputRoot = [IO.Path]::GetFullPath($OutputRoot)
+$Build = Join-Path $OutputRoot "build-$Configuration-$Platform"
+$Stage = Join-Path $OutputRoot "sdk-$Configuration-$Platform"
+if ((Test-Path $Build) -or (Test-Path $Stage)) { throw 'Use a fresh output directory; existing files are never deleted.' }
+$Runtime = if ($Configuration -eq 'Debug') { 'MultiThreadedDebugDLL' } else { 'MultiThreadedDLL' }
+Invoke-Checked cmake @('-S',$Source,'-B',$Build,'-G','Ninja',
+    "-DCMAKE_BUILD_TYPE=$Configuration","-DCMAKE_MSVC_RUNTIME_LIBRARY=$Runtime",
+    '-DBUILD_SHARED_LIBS=OFF','-DROBOTWEAX_SRT_BUILD_TESTS=OFF',
+    '-DROBOTWEAX_SRT_BUILD_TOOLS=OFF','-DROBOTWEAX_SRT_BUILD_BENCHMARKS=OFF',
+    '-DROBOTWEAX_SRT_BUILD_EXAMPLES=OFF','-DROBOTWEAX_SRT_INSTALL_LAYOUT=namespaced',
+    '-DOPENSSL_USE_STATIC_LIBS=ON',"-DOPENSSL_INCLUDE_DIR=$OpenSSLRoot/include",
+    "-DOPENSSL_CRYPTO_LIBRARY=$Crypto")
+Invoke-Checked cmake @('--build',$Build,'--parallel','2','--target','robotweax_srt')
+New-Item -ItemType Directory -Path "$Stage/lib/$Configuration-$Platform" -Force | Out-Null
+Copy-Item "$Build/robotweax-srt.lib" "$Stage/lib/$Configuration-$Platform/"
+Copy-Item $Crypto "$Stage/lib/$Configuration-$Platform/"
+New-Item -ItemType Directory -Path "$Stage/include/srt" -Force | Out-Null
+Copy-Item "$Source/include/srt.h","$Source/include/robotweax_srt.h" "$Stage/include/"
+Copy-Item "$Source/include/srt/*.h" "$Stage/include/srt/"
+Copy-Item "$Source/LICENSE" "$Stage/LICENSE.txt"
+Copy-Item "$Source/THIRD_PARTY.md" "$Stage/THIRD_PARTY.md"
+Copy-Item "$PSScriptRoot/srt.props" "$Stage/srt.props"
+Copy-Item "$PSScriptRoot/README.md" "$Stage/README.md"
+# The producer must supply the exact dependency license next to its build.
+Copy-Item "$OpenSSLRoot/LICENSE.txt" "$Stage/OpenSSL-LICENSE.txt"
+@{platform=$Platform; configuration=$Configuration; runtime=$Runtime;
+  source=(git -C $Source rev-parse HEAD); crypto_sha256=(Get-FileHash $Crypto).Hash
+} | ConvertTo-Json | Set-Content "$Stage/lib/$Configuration-$Platform/build.json"

--- a/packaging/windows/consumer/consumer.vcxproj
+++ b/packaging/windows/consumer/consumer.vcxproj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="$(Configuration)|$(Platform)">
+      <Configuration>$(Configuration)</Configuration>
+      <Platform>$(Platform)</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{953FAF3A-CA21-46C8-BC69-1AA60B3FEEB5}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries Condition="'$(Configuration)' == 'Debug'">true</UseDebugLibraries>
+    <UseDebugLibraries Condition="'$(Configuration)' != 'Debug'">false</UseDebugLibraries>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <PropertyGroup>
+    <OutDir>$(MSBuildThisFileDirectory)out\$(Configuration)-$(Platform)\</OutDir>
+    <IntDir>$(OutDir)obj\</IntDir>
+    <TargetName>sdk-consumer</TargetName>
+    <SdkTestRuntime Condition="'$(SdkTestRuntime)' == '' and '$(Configuration)' == 'Debug'">MultiThreadedDebugDLL</SdkTestRuntime>
+    <SdkTestRuntime Condition="'$(SdkTestRuntime)' == ''">MultiThreadedDLL</SdkTestRuntime>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <RuntimeLibrary>$(SdkTestRuntime)</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Import Project="$(ROBOTWEAX_SRT)\srt.props" />
+  <ItemGroup>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\package_consumer\c_consumer.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/packaging/windows/consumer/consumer.vcxproj
+++ b/packaging/windows/consumer/consumer.vcxproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries Condition="'$(Configuration)' == 'Debug'">true</UseDebugLibraries>
     <UseDebugLibraries Condition="'$(Configuration)' != 'Debug'">false</UseDebugLibraries>

--- a/packaging/windows/package.ps1
+++ b/packaging/windows/package.ps1
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+param([Parameter(Mandatory)][string]$Variants, [Parameter(Mandatory)][string]$Destination)
+$ErrorActionPreference = 'Stop'
+if (Test-Path $Destination) { throw 'Destination must not exist' }
+New-Item -ItemType Directory $Destination | Out-Null
+$Hashes = @{}
+foreach ($Configuration in @('Debug','Release')) {
+    foreach ($Platform in @('Win32','x64','Arm64')) {
+        $Variant = Join-Path $Variants "sdk-$Configuration-$Platform"
+        foreach ($Required in @("lib/$Configuration-$Platform/robotweax-srt.lib", "lib/$Configuration-$Platform/libcrypto.lib", 'include/srt/srt.h','LICENSE.txt','OpenSSL-LICENSE.txt','srt.props')) {
+            if (!(Test-Path "$Variant/$Required")) { throw "Missing $Variant/$Required" }
+        }
+        foreach ($File in Get-ChildItem $Variant -Recurse -File) {
+            $Relative = $File.FullName.Substring((Resolve-Path $Variant).Path.Length + 1)
+            $Hash = (Get-FileHash $File.FullName).Hash
+            if ($Hashes.ContainsKey($Relative) -and $Hashes[$Relative] -ne $Hash) { throw "Conflicting shared file $Relative" }
+            $Hashes[$Relative] = $Hash
+            $Target = Join-Path $Destination $Relative
+            New-Item -ItemType Directory (Split-Path $Target) -Force | Out-Null
+            Copy-Item $File.FullName $Target
+        }
+    }
+}
+$Hashes | ConvertTo-Json | Set-Content "$Destination/checksums.json"

--- a/packaging/windows/sdk.iss
+++ b/packaging/windows/sdk.iss
@@ -1,0 +1,41 @@
+; SPDX-License-Identifier: MIT
+#ifndef SdkRoot
+  #error SdkRoot is required
+#endif
+#ifndef ProductVersion
+  #error ProductVersion is required
+#endif
+[Setup]
+AppId=Robotweax.SRT.SDK
+AppName=Robotweax SRT SDK
+AppVersion={#ProductVersion}
+AppPublisher=Robotweax GmbH
+DefaultDirName={autopf}\Robotweax-SRT
+DisableProgramGroupPage=yes
+PrivilegesRequired=admin
+ChangesEnvironment=yes
+OutputBaseFilename=robotweax-srt-{#ProductVersion}-windows-sdk
+Compression=lzma2
+SolidCompression=yes
+LicenseFile={#SdkRoot}\LICENSE.txt
+UninstallDisplayName=Robotweax SRT SDK
+[Files]
+Source: "{#SdkRoot}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+[Registry]
+Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: expandsz; ValueName: "ROBOTWEAX_SRT"; ValueData: "{app}"
+[Code]
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+begin
+  Result := '';
+  if FileExists(ExpandConstant('{app}\unins000.exe')) then
+    Result := 'Uninstall the previous Robotweax SRT SDK before installing this candidate.';
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+var Current: String;
+begin
+  if CurUninstallStep = usUninstall then
+    if RegQueryStringValue(HKLM, 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', 'ROBOTWEAX_SRT', Current) then
+      if CompareText(Current, ExpandConstant('{app}')) = 0 then
+        RegDeleteValue(HKLM, 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', 'ROBOTWEAX_SRT');
+end;

--- a/packaging/windows/sdk.iss
+++ b/packaging/windows/sdk.iss
@@ -27,7 +27,8 @@ Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environmen
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 begin
   Result := '';
-  if FileExists(ExpandConstant('{app}\unins000.exe')) then
+  if RegKeyExists(HKLM, 'Software\Microsoft\Windows\CurrentVersion\Uninstall\Robotweax.SRT.SDK_is1')
+     or FileExists(ExpandConstant('{app}\unins000.exe')) then
     Result := 'Uninstall the previous Robotweax SRT SDK before installing this candidate.';
 end;
 

--- a/packaging/windows/srt.props
+++ b/packaging/windows/srt.props
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <RobotweaxSrtRoot>$(MSBuildThisFileDirectory)</RobotweaxSrtRoot>
+    <RobotweaxSrtLibDir>$(RobotweaxSrtRoot)lib\$(Configuration)-$(Platform)</RobotweaxSrtLibDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(RobotweaxSrtRoot)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(RobotweaxSrtLibDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>robotweax-srt.lib;libcrypto.lib;ws2_32.lib;crypt32.lib;advapi32.lib;user32.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Target Name="ValidateRobotweaxSrtSdk" BeforeTargets="ClCompile">
+    <Error Condition="!Exists('$(RobotweaxSrtLibDir)\robotweax-srt.lib')" Text="Robotweax SRT SDK does not contain $(Configuration)-$(Platform)." />
+    <Error Condition="'$(Configuration)' == 'Debug' and '%(ClCompile.RuntimeLibrary)' != 'MultiThreadedDebugDLL'" Text="Robotweax SRT Debug SDK requires /MDd." />
+    <Error Condition="'$(Configuration)' == 'Release' and '%(ClCompile.RuntimeLibrary)' != 'MultiThreadedDLL'" Text="Robotweax SRT Release SDK requires /MD." />
+  </Target>
+</Project>

--- a/src/compat/statistics.cpp
+++ b/src/compat/statistics.cpp
@@ -405,11 +405,10 @@ void RuntimeStatisticsState::apply_average_buffers(
 {
     values.sender_buffer_packets =
         sender_buffer_average_.packets();
-    values.sender_buffer_bytes = saturated_add(
-        sender_buffer_average_.payload_bytes(),
-        saturated_multiply(
-            values.sender_buffer_packets,
-            packet_header_bytes_));
+    values.sender_buffer_bytes = narrowed<std::size_t>(
+        saturated_add(sender_buffer_average_.payload_bytes(),
+            saturated_multiply(
+                values.sender_buffer_packets, packet_header_bytes_)));
     values.sender_buffer_milliseconds =
         sender_buffer_average_.milliseconds();
     values.receiver_buffer_packets =

--- a/tests/test_statistics.cpp
+++ b/tests/test_statistics.cpp
@@ -9,6 +9,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <span>
 
@@ -143,6 +144,20 @@ TEST(statistics_snapshot_maps_totals_interval_and_clear_semantics)
     REQUIRE_EQ(
         public_after_clear.pktRcvAvgBelatedTime, 12.0);
     REQUIRE_EQ(public_after_clear.byteSent, 0U);
+}
+
+TEST(statistics_buffer_average_saturates_at_size_t_limit)
+{
+    RuntimeStatisticsState state {1'000};
+    state.sample_buffers(1'000,
+        {
+            .sender_packets = 1,
+            .sender_payload_bytes = std::numeric_limits<std::size_t>::max(),
+        });
+    RuntimeStatisticsInstantaneous values {};
+    state.apply_average_buffers(values);
+    REQUIRE_EQ(
+        values.sender_buffer_bytes, std::numeric_limits<std::size_t>::max());
 }
 
 TEST(statistics_buffer_average_uses_reference_time_weighting)


### PR DESCRIPTION
Work in progress for #12; not ready for release or merge.

Prepare static Debug/Release SDK variants for Win32/x64/Arm64, matching public headers, bundled OpenSSL Crypto and licenses, MSBuild props, and an Inno Setup candidate. Packaging checks shared-file consistency. Windows workflow links consumers and tests silent installation/uninstallation. It runs only manually or for packaging PR changes and never publishes a release.

Validation limitations: this work was prepared on macOS; Windows scripts and installer require the new CI run. ARM64 is link-only on the x64 runner. OpenSSL is pinned to 3.6.3 and initially no-asm, so candidate performance is not qualified. Signing, optimized crypto, upgrade qualification and MSBuild consumer coverage remain before production publication. No existing release assets changed.