### PR TITLE
Prepare gated Windows SDK preview drafts

### DIFF
--- a/.github/workflows/windows-sdk-preview.yml
+++ b/.github/workflows/windows-sdk-preview.yml
@@ -1,0 +1,39 @@
+name: Prepare Windows SDK preview draft
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: Successful main Windows SDK candidate run ID
+        required: true
+        type: string
+      tag:
+        description: Existing SDK preview tag pointing to the candidate commit
+        required: true
+        type: string
+permissions:
+  contents: read
+concurrency:
+  group: windows-sdk-preview-draft
+  cancel-in-progress: false
+jobs:
+  draft:
+    if: github.ref == 'refs/heads/main'
+    environment: windows-sdk-preview
+    runs-on: windows-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Verify candidate and prepare draft only
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          SDK_RUN_ID: ${{ inputs.run_id }}
+          SDK_TAG: ${{ inputs.tag }}
+          SDK_SIGNER: ${{ vars.WINDOWS_SDK_SIGNER_THUMBPRINT }}
+        run: ./packaging/windows/prepare-preview.ps1

--- a/interop/tests/test_windows_sdk.py
+++ b/interop/tests/test_windows_sdk.py
@@ -7,6 +7,17 @@ ROOT = Path(__file__).resolve().parents[2]
 
 
 class WindowsSdkTests(unittest.TestCase):
+    def test_preview_is_manual_signed_and_draft_only(self):
+        workflow = (ROOT / '.github/workflows/windows-sdk-preview.yml').read_text()
+        self.assertIn('workflow_dispatch:', workflow)
+        self.assertNotIn('pull_request:', workflow)
+        self.assertIn('environment: windows-sdk-preview', workflow)
+        script = (ROOT / 'packaging/windows/prepare-preview.ps1').read_text()
+        for guard in ('Get-AuthenticodeSignature', 'TimeStamperCertificate',
+                      '$commit.sha -ne $run.head_sha', "'--verify-tag','--draft','--prerelease'",
+                      "$run.head_branch -ne 'main'", 'Approved signer is not configured'):
+            self.assertIn(guard, script)
+
     def test_crypto_assembly_is_required_for_every_target(self):
         script = (ROOT / 'packaging/windows/build-ci.ps1').read_text()
         self.assertNotIn("'no-asm'", script)

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -63,3 +63,33 @@ environment variable only when it still points to this installation.
 
 References: [Inno Setup command-line options](https://jrsoftware.org/ishelp/topic_setupcmdline.htm),
 [OpenSSL Windows build notes](https://github.com/openssl/openssl/blob/openssl-3.6.3/NOTES-WINDOWS.md).
+
+## Preview release preparation (blocked until signing is configured)
+
+`Prepare Windows SDK preview draft` is manual-only and accepts an existing
+`windows-sdk-vX.Y.Z-preview.N` tag and a successful manually dispatched **main**
+`Windows SDK candidate` run. The tag must resolve to the exact candidate commit.
+It does not rebuild the six variants and never publishes a release automatically.
+It creates a new draft prerelease containing only the installer and SHA-256 file;
+existing releases are not overwritten. No Haivision binaries are included.
+
+Before enabling this process, maintainers must:
+
+1. Select and integrate the Robotweax code-signing service into the candidate
+   build, including a trusted timestamp. This integration is **not implemented**
+   yet; today's unsigned candidates are deliberately rejected.
+2. Configure the `windows-sdk-preview` GitHub environment with required reviewer
+   approval and main-only deployment restrictions. Set its variable
+   `WINDOWS_SDK_SIGNER_THUMBPRINT` to the approved certificate's 40 hex digits.
+   No private signing key belongs in a repository or build artifact.
+3. Run the signed candidate workflow on main. Record a clean Windows installation,
+   Visual Studio consumer build/run, and uninstall test before public release.
+4. Explicitly create the preview tag at that run's commit, then dispatch the draft
+   workflow with its run ID and tag before artifacts expire (seven days).
+5. Review draft assets, signature, checksums, license bundle, evidence and limitations.
+   Publishing the draft requires a separate human decision. Do not attach these
+   previews to an existing stable protocol release.
+
+The draft workflow itself verifies the installer signature, timestamp presence and
+approved signer. It does not execute the downloaded installer. ARM64 execution,
+throughput qualification and signing-service integration remain open work.

--- a/packaging/windows/prepare-preview.ps1
+++ b/packaging/windows/prepare-preview.ps1
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: MIT
+$ErrorActionPreference = 'Stop'
+function Gh([string[]]$Arguments) {
+    $result = & gh @Arguments
+    if ($LASTEXITCODE -ne 0) { throw 'GitHub request failed' }
+    return $result
+}
+if ($env:SDK_RUN_ID -notmatch '^\d+$') { throw 'Invalid run ID' }
+if ($env:SDK_TAG -notmatch '^windows-sdk-v\d+\.\d+\.\d+-preview\.\d+$') { throw 'Invalid preview tag' }
+if ($env:SDK_SIGNER -notmatch '^[A-Fa-f0-9]{40}$') { throw 'Approved signer is not configured' }
+$run = (Gh @('api',"repos/$env:GH_REPO/actions/runs/$env:SDK_RUN_ID")) | ConvertFrom-Json
+if ($run.conclusion -ne 'success' -or $run.status -ne 'completed' -or
+    $run.head_branch -ne 'main' -or $run.event -ne 'workflow_dispatch' -or
+    $run.path -ne '.github/workflows/windows-sdk.yml' -or
+    $run.head_repository.full_name -ne $env:GH_REPO) { throw 'Not a successful trusted main SDK run' }
+$commit = (Gh @('api',"repos/$env:GH_REPO/commits/$env:SDK_TAG")) | ConvertFrom-Json
+if ($commit.sha -ne $run.head_sha) { throw 'Preview tag does not match candidate commit' }
+# A commit lookup also accepts branches: require an actual existing tag.
+$null = Gh @('api',"repos/$env:GH_REPO/git/ref/tags/$env:SDK_TAG")
+$directory = Join-Path $env:RUNNER_TEMP "sdk-preview-$([guid]::NewGuid())"
+$null = Gh @('run','download',$env:SDK_RUN_ID,'--name','windows-sdk-installer-candidate','--dir',$directory)
+$files = @(Get-ChildItem $directory -File -Recurse)
+if ($files.Count -ne 1 -or $files[0].Extension -ne '.exe') { throw 'Expected exactly one installer' }
+$installer = $files[0]
+$signature = Get-AuthenticodeSignature $installer.FullName
+if ($signature.Status -ne 'Valid' -or $signature.SignerCertificate.Thumbprint -ne $env:SDK_SIGNER -or
+    !$signature.TimeStamperCertificate) { throw 'Installer requires approved, valid, timestamped signature' }
+$checksum = Join-Path $directory 'SHA256SUMS.txt'
+"$((Get-FileHash $installer.FullName -Algorithm SHA256).Hash.ToLower())  $($installer.Name)" | Set-Content $checksum -Encoding ascii
+$notes = Join-Path $directory 'preview-notes.md'
+@"
+Experimental Windows SDK preview. Not a production qualification.
+
+Source: $($run.head_sha)
+Build evidence: $($run.html_url)
+Signer thumbprint: $env:SDK_SIGNER
+
+Static Debug/Release libraries for Win32, x64 and ARM64. Use /MDd or /MD respectively.
+ARM64 is build/link-tested only. No throughput qualification. AES-GCM preview is disabled.
+Uninstall the previous SDK before installing. No in-place upgrade support.
+See packaging/windows/README.md at the source revision for integration instructions.
+"@ | Set-Content $notes -Encoding utf8
+# create fails for an existing release; never upload --clobber or publish here.
+$null = Gh @('release','create',$env:SDK_TAG,$installer.FullName,$checksum,
+    '--verify-tag','--draft','--prerelease','--title',"Windows SDK $env:SDK_TAG",'--notes-file',$notes)


### PR DESCRIPTION
Prepare a manual, main-only workflow that validates a successful SDK candidate run, exact existing preview tag, and approved timestamped Authenticode signature before creating a draft prerelease. Never publishes automatically or overwrites existing releases. Document signing and clean-Windows qualification prerequisites. Current unsigned candidates are deliberately rejected. Validation: seven local Windows SDK guardrail tests and git diff --check passed; PowerShell execution requires Windows CI. Signing service and protected environment configuration remain pending.