### PR TITLE
Expose compatible C++ logging level names

### DIFF
--- a/include/srt/logging_api.h
+++ b/include/srt/logging_api.h
@@ -37,6 +37,21 @@
 #define SRT_LOG_LEVEL_MIN LOG_CRIT
 #define SRT_LOG_LEVEL_MAX LOG_DEBUG
 
+#ifdef __cplusplus
+/** C++ source-compatible names for the public syslog severity levels. */
+namespace srt_logging {
+namespace LogLevel {
+enum type {
+    fatal = LOG_CRIT,
+    error = LOG_ERR,
+    warning = LOG_WARNING,
+    note = LOG_NOTICE,
+    debug = LOG_DEBUG
+};
+} // namespace LogLevel
+} // namespace srt_logging
+#endif
+
 #define SRT_LOGF_DISABLE_TIME 1
 #define SRT_LOGF_DISABLE_THREADNAME 2
 #define SRT_LOGF_DISABLE_SEVERITY 4

--- a/tests/package_consumer/cpp_consumer.cpp
+++ b/tests/package_consumer/cpp_consumer.cpp
@@ -5,6 +5,11 @@
 #error "access_control.h must come from the Robotweax installation"
 #endif
 static_assert(SRT_REJX_OVERLOAD == 1402);
+static_assert(srt_logging::LogLevel::fatal == LOG_CRIT);
+static_assert(srt_logging::LogLevel::error == LOG_ERR);
+static_assert(srt_logging::LogLevel::warning == LOG_WARNING);
+static_assert(srt_logging::LogLevel::note == LOG_NOTICE);
+static_assert(srt_logging::LogLevel::debug == LOG_DEBUG);
 
 #include <cstdint>
 #include <stdexcept>
@@ -44,6 +49,8 @@ public:
 int main()
 {
     Runtime runtime;
+    const srt_logging::LogLevel::type level = srt_logging::LogLevel::note;
+    srt_setloglevel(level);
     const SRTSOCKET socket = srt_socket(AF_INET, SOCK_DGRAM, 0);
     if (socket == SRT_INVALID_SOCK) {
         return 1;


### PR DESCRIPTION
Fix Multi Streamer source compatibility for srt_setloglevel(srt_logging::LogLevel::note). Add C++-only LogLevel::type and the five syslog-compatible names; preserve C headers and existing ABI/behavior. Installed C++ package consumer checks every value and calls the API using the enum. Local C11 and C++20 syntax checks, linked C++ consumer execution, and diff checks passed. Independent of the BCrypt work.