### PR TITLE
Handle macOS/BSD UDP buffer allocation limits

### DIFF
--- a/docs/socket-options.md
+++ b/docs/socket-options.md
@@ -243,6 +243,17 @@ Their effective values are applied to `SO_SNDBUF` and `SO_RCVBUF` before
 explicit listener binding or implicit caller binding; accepted sockets inherit
 the listener values. A getter returns the portable effective SRT value rather
 than an operating-system-specific doubled or clamped kernel value.
+On macOS/BSD, an `ENOBUFS` rejection of a UDP buffer request uses a
+best-effort fallback, for both created and acquired UDP sockets: an existing
+buffer of at least 64,000 bytes is retained; otherwise 64,000 bytes is attempted
+when the request was at least that large. Other errors and failed fallbacks
+remain errors. This applies to explicit settings as well as defaults, matching
+Haivision's best-effort macOS/BSD behavior without shrinking an already useful
+buffer. Explicit bind/acquire and caller setup report requested and actual
+buffer bytes through the socket-management warning logger after releasing
+internal locks. The SRT option getter still reports the configured value, not
+the kernel allocation. Size buffers and validate packet loss under realistic
+traffic; a successful bind alone does not qualify throughput.
 `SRTO_REUSEADDR` is a pre-bind boolean and defaults to `true`. Independent
 IPv4 or IPv6 SRT sockets that bind the same exact address and port with
 matching native UDP buffer settings share one UDP channel and its

--- a/src/compat/srt_api.cpp
+++ b/src/compat/srt_api.cpp
@@ -16,8 +16,46 @@
 #include <algorithm>
 #include <chrono>
 #include <limits>
+#include <cstdio>
+#include "udp_buffer_policy.hpp"
 
 namespace {
+
+// Emit only after internal socket locks have been released. Logging callbacks
+// are application code and may call back into the socket API.
+struct UdpBufferLogScope {
+    bool owner = !robotweax::srt::detail::collect_udp_buffer_notices;
+    UdpBufferLogScope()
+    {
+        if (!owner)
+            return;
+        robotweax::srt::detail::udp_buffer_notice_count = 0;
+        robotweax::srt::detail::collect_udp_buffer_notices = true;
+    }
+    ~UdpBufferLogScope()
+    {
+        if (!owner)
+            return;
+        const auto saved_error = robotweax::srt::compat::last_error();
+        using namespace robotweax::srt::detail;
+        const auto notices = udp_buffer_notices;
+        const auto count = udp_buffer_notice_count;
+        collect_udp_buffer_notices = false;
+        udp_buffer_notice_count = 0;
+        for (unsigned i = 0; i < count; ++i) {
+            char message[160];
+            std::snprintf(message, sizeof(message),
+                "UDP buffer request rejected by OS; requested=%d effective=%d "
+                "bytes",
+                static_cast<int>(notices[i].requested),
+                static_cast<int>(notices[i].effective));
+            ROBOTWEAX_SRT_COMPAT_LOG(
+                LOG_WARNING, SRT_LOGFA_SOCKMGMT, "W", "socket", message);
+        }
+        robotweax::srt::compat::set_last_error(
+            saved_error.code, saved_error.system_error);
+    }
+};
 
 [[nodiscard]] bool stateful_api_available() noexcept
 {
@@ -135,6 +173,7 @@ SRTSOCKET srt_create_socket(void)
 
 int srt_bind(SRTSOCKET socket, const sockaddr* name, int name_size)
 {
+    const UdpBufferLogScope buffer_log;
     if (!stateful_api_available()) {
         return SRT_ERROR;
     }
@@ -147,6 +186,7 @@ int srt_bind(SRTSOCKET socket, const sockaddr* name, int name_size)
 int srt_bind_acquire(
     SRTSOCKET socket, UDPSOCKET native_socket)
 {
+    const UdpBufferLogScope buffer_log;
     if (!stateful_api_available()) {
         return SRT_ERROR;
     }
@@ -221,6 +261,7 @@ int srt_connect_callback(
 int srt_connect(
     SRTSOCKET socket, const sockaddr* name, int name_size)
 {
+    const UdpBufferLogScope buffer_log;
     if (!stateful_api_available()) {
         return SRT_ERROR;
     }
@@ -244,6 +285,7 @@ int srt_connect_debug(
     SRTSOCKET socket, const sockaddr* name, int name_size,
     int forced_initial_sequence)
 {
+    const UdpBufferLogScope buffer_log;
     if (!stateful_api_available()) {
         return SRT_ERROR;
     }
@@ -263,6 +305,7 @@ int srt_connect_bind(
     const sockaddr* target,
     int name_size)
 {
+    const UdpBufferLogScope buffer_log;
     if (!stateful_api_available()) {
         return SRT_ERROR;
     }

--- a/src/udp.cpp
+++ b/src/udp.cpp
@@ -1,4 +1,5 @@
 #include "robotweax/srt/udp.hpp"
+#include "udp_buffer_policy.hpp"
 
 #include "compat/platform_networking.hpp"
 
@@ -338,11 +339,36 @@ Error UdpSocket::set_send_buffer_size(std::int32_t bytes) noexcept
     const int result = ::setsockopt(to_native(native_), SOL_SOCKET, SO_SNDBUF,
         reinterpret_cast<const char*>(&bytes), static_cast<int>(sizeof(bytes)));
 #else
-    const int result = ::setsockopt(to_native(native_), SOL_SOCKET, SO_SNDBUF,
-        &bytes, static_cast<SocketLength>(sizeof(bytes)));
+    const int error = detail::configure_udp_buffer(
+        bytes,
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)         \
+    || defined(__NetBSD__) || defined(__DragonFly__)
+        true,
+#else
+        false,
 #endif
+        [&](std::int32_t value) {
+            return ::setsockopt(to_native(native_), SOL_SOCKET, SO_SNDBUF,
+                       &value, sizeof(value))
+                    == 0
+                ? 0
+                : last_socket_error();
+        },
+        [&](std::int32_t& value) {
+            SocketLength size = sizeof(value);
+            return ::getsockopt(
+                       to_native(native_), SOL_SOCKET, SO_SNDBUF, &value, &size)
+                    == 0
+                ? 0
+                : last_socket_error();
+        });
+    last_system_error_ = error;
+    return error == 0 ? Error::none : Error::io_error;
+#endif
+#if defined(_WIN32)
     last_system_error_ = result == 0 ? 0 : last_socket_error();
     return result == 0 ? Error::none : Error::io_error;
+#endif
 }
 
 Error UdpSocket::set_receive_buffer_size(std::int32_t bytes) noexcept
@@ -359,11 +385,36 @@ Error UdpSocket::set_receive_buffer_size(std::int32_t bytes) noexcept
     const int result = ::setsockopt(to_native(native_), SOL_SOCKET, SO_RCVBUF,
         reinterpret_cast<const char*>(&bytes), static_cast<int>(sizeof(bytes)));
 #else
-    const int result = ::setsockopt(to_native(native_), SOL_SOCKET, SO_RCVBUF,
-        &bytes, static_cast<SocketLength>(sizeof(bytes)));
+    const int error = detail::configure_udp_buffer(
+        bytes,
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)         \
+    || defined(__NetBSD__) || defined(__DragonFly__)
+        true,
+#else
+        false,
 #endif
+        [&](std::int32_t value) {
+            return ::setsockopt(to_native(native_), SOL_SOCKET, SO_RCVBUF,
+                       &value, sizeof(value))
+                    == 0
+                ? 0
+                : last_socket_error();
+        },
+        [&](std::int32_t& value) {
+            SocketLength size = sizeof(value);
+            return ::getsockopt(
+                       to_native(native_), SOL_SOCKET, SO_RCVBUF, &value, &size)
+                    == 0
+                ? 0
+                : last_socket_error();
+        });
+    last_system_error_ = error;
+    return error == 0 ? Error::none : Error::io_error;
+#endif
+#if defined(_WIN32)
     last_system_error_ = result == 0 ? 0 : last_socket_error();
     return result == 0 ? Error::none : Error::io_error;
+#endif
 }
 
 Error UdpSocket::set_ipv6_only(bool enabled) noexcept

--- a/src/udp_buffer_policy.hpp
+++ b/src/udp_buffer_policy.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <cerrno>
+#include <cstdint>
+#include <array>
+
+namespace robotweax::srt::detail {
+
+struct UdpBufferNotice {
+    std::int32_t requested = 0;
+    std::int32_t effective = 0;
+};
+inline thread_local bool collect_udp_buffer_notices = false;
+inline thread_local std::array<UdpBufferNotice, 2> udp_buffer_notices {};
+inline thread_local unsigned udp_buffer_notice_count = 0;
+
+inline void note_udp_buffer(std::int32_t requested, std::int32_t effective)
+{
+    if (collect_udp_buffer_notices
+        && udp_buffer_notice_count < udp_buffer_notices.size()) {
+        udp_buffer_notices[udp_buffer_notice_count++] = {requested, effective};
+    }
+}
+
+// Set/Get return a system error (zero on success). Keep the policy injectable
+// so a restrictive BSD kernel can be tested without changing host sysctls.
+template <class Set, class Get>
+int configure_udp_buffer(std::int32_t requested, bool bsd, Set set, Get get)
+{
+    const int error = set(requested);
+    if (error == 0 || !bsd || error != ENOBUFS) {
+        return error;
+    }
+    std::int32_t current = 0;
+    const int read_error = get(current);
+    if (read_error != 0) {
+        return read_error;
+    }
+    // An acquired socket may already have a useful, application-selected
+    // buffer. Never shrink it to Haivision's 64,000-byte fallback.
+    if (current >= 64'000) {
+        note_udp_buffer(requested, current);
+        return 0;
+    }
+    // Do not turn a small explicit request into a larger allocation.
+    if (requested < 64'000) {
+        return error;
+    }
+    const int fallback_error = set(64'000);
+    if (fallback_error != 0) {
+        return fallback_error;
+    }
+    const int effective_error = get(current);
+    if (effective_error != 0) {
+        return effective_error;
+    }
+    note_udp_buffer(requested, current);
+    return 0;
+}
+
+} // namespace robotweax::srt::detail

--- a/tests/test_udp.cpp
+++ b/tests/test_udp.cpp
@@ -4,6 +4,7 @@
 #include "robotweax/srt/handshake.hpp"
 #include "robotweax/srt/handshake_extensions.hpp"
 #include "robotweax/srt/udp.hpp"
+#include "udp_buffer_policy.hpp"
 
 #include <algorithm>
 #include <array>
@@ -12,6 +13,114 @@
 #include <thread>
 
 using namespace robotweax::srt;
+
+TEST(udp_buffer_fallback_preserves_existing_buffer)
+{
+    int calls = 0;
+    REQUIRE_EQ(detail::configure_udp_buffer(
+                   12'288'000, true,
+                   [&](std::int32_t) {
+                       ++calls;
+                       return ENOBUFS;
+                   },
+                   [](std::int32_t& value) {
+                       value = 262'144;
+                       return 0;
+                   }),
+        0);
+    REQUIRE_EQ(calls, 1);
+}
+
+TEST(udp_buffer_fallback_retries_small_buffer)
+{
+    int calls = 0;
+    REQUIRE_EQ(detail::configure_udp_buffer(
+                   12'288'000, true,
+                   [&](std::int32_t value) {
+                       ++calls;
+                       return value == 64'000 ? 0 : ENOBUFS;
+                   },
+                   [](std::int32_t& value) {
+                       value = 8192;
+                       return 0;
+                   }),
+        0);
+    REQUIRE_EQ(calls, 2);
+}
+
+TEST(udp_buffer_fallback_does_not_hide_other_errors)
+{
+    for (const int error : {EBADF, EINVAL, EACCES}) {
+        REQUIRE_EQ(detail::configure_udp_buffer(
+                       262'144, true,
+                       [=](std::int32_t) {
+                           return error;
+                       },
+                       [](std::int32_t&) {
+                           return 0;
+                       }),
+            error);
+    }
+    REQUIRE_EQ(detail::configure_udp_buffer(
+                   262'144, false,
+                   [](std::int32_t) {
+                       return ENOBUFS;
+                   },
+                   [](std::int32_t&) {
+                       return 0;
+                   }),
+        ENOBUFS);
+    REQUIRE_EQ(detail::configure_udp_buffer(
+                   262'144, true,
+                   [](std::int32_t) {
+                       return ENOBUFS;
+                   },
+                   [](std::int32_t&) {
+                       return EBADF;
+                   }),
+        EBADF);
+    REQUIRE_EQ(detail::configure_udp_buffer(
+                   262'144, true,
+                   [](std::int32_t) {
+                       return ENOBUFS;
+                   },
+                   [](std::int32_t& value) {
+                       value = 8192;
+                       return 0;
+                   }),
+        ENOBUFS);
+}
+
+TEST(udp_buffer_fallback_records_actual_size_and_respects_small_requests)
+{
+    detail::collect_udp_buffer_notices = true;
+    detail::udp_buffer_notice_count = 0;
+    const int result = detail::configure_udp_buffer(
+        12'288'000, true,
+        [](std::int32_t) {
+            return ENOBUFS;
+        },
+        [](std::int32_t& value) {
+            value = 262'144;
+            return 0;
+        });
+    detail::collect_udp_buffer_notices = false;
+    REQUIRE_EQ(result, 0);
+    REQUIRE_EQ(detail::udp_buffer_notice_count, 1U);
+    REQUIRE_EQ(detail::udp_buffer_notices[0].requested, 12'288'000);
+    REQUIRE_EQ(detail::udp_buffer_notices[0].effective, 262'144);
+    detail::udp_buffer_notice_count = 0;
+    REQUIRE_EQ(detail::configure_udp_buffer(
+                   4096, true,
+                   [](std::int32_t) {
+                       return ENOBUFS;
+                   },
+                   [](std::int32_t& value) {
+                       value = 8192;
+                       return 0;
+                   }),
+        ENOBUFS);
+}
 
 namespace {
 


### PR DESCRIPTION
## Summary
- Handle ENOBUFS on macOS/BSD with a best-effort UDP send/receive buffer fallback.
- Preserve existing buffers of at least 64000 bytes instead of shrinking acquired sockets; retain other errors.
- Emit requested/effective buffer warnings after socket locks are released and preserve API error state.
- Document explicit/default buffer behavior without changing public ABI or getter semantics.

## Validation
- Clean macOS Release build passed.
- 18/18 selected UDP tests passed, including acquired IPv4/IPv6 socket ownership and rejection paths.
- Deterministic policy tests cover allocation rejection, existing-buffer preservation, fallback failure, non-BSD behavior, and diagnostic sizes.
- Changed-line format check passed.
- Cross-platform CI and confirmation on the affected Mac remain pending.

Independent of experimental BCrypt PR #19.