### PR TITLE
Clarify Windows SDK installer status and BCrypt scope

### DIFF
--- a/docs/windows-bcrypt.md
+++ b/docs/windows-bcrypt.md
@@ -13,8 +13,17 @@ cmake --build build-bcrypt --config Release --parallel 2
 Use a separate build directory for each backend. BCrypt is rejected on non-Windows
 platforms and unknown backend values are errors. BCrypt builds link the native
 `bcrypt` system library and do not discover or require OpenSSL. Installed CMake
-and pkg-config metadata reflect the selected provider. The Windows SDK installer
-remains OpenSSL-based; its packaging is not switched by this change.
+and pkg-config metadata reflect the selected provider.
+
+The **experimental Windows SDK installer for application developers** is the
+separate packaging work requested in [issue #12](https://github.com/Robotweax/srt/issues/12),
+not a standalone streaming application. It bundles public headers, static
+Robotweax SRT and OpenSSL Crypto libraries for Debug/Release on Win32, x64 and
+ARM64, and an MSBuild property sheet. See the
+[Windows SDK packaging documentation](../packaging/windows/README.md).
+The installer candidate remains OpenSSL-based and is not yet a signed,
+qualified release installer. The optional BCrypt backend is available in
+`main`; it does not switch the installer packaging or the default backend.
 
 ## Implementation boundary
 

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -1,6 +1,12 @@
 # Windows SDK installer (experimental)
 
 This is an SDK for application developers, not a standalone streaming app.
+It implements the packaging work requested in
+[issue #12](https://github.com/Robotweax/srt/issues/12).
+The candidate remains OpenSSL-based; the separately available
+[experimental BCrypt backend](../../docs/windows-bcrypt.md) does not change
+this installer or the default backend. Manual target-machine acceptance and
+release signing remain pending; this is not a qualified release installer.
 The intended bundle contains static Robotweax SRT and static OpenSSL Crypto for
 Debug/Release × Win32/x64/Arm64. Consumers use `/MDd` for Debug and `/MD` for
 Release. Debug binaries are development-only; applications must deploy the


### PR DESCRIPTION
Documentation-only clarification following the question on issue #13. Link the Windows SDK candidate to issue #12 and the packaging instructions, distinguish it from the optional BCrypt backend, and explicitly retain the unsigned/unqualified candidate status. No code or packaging changes. Validation: git diff --check.