### PR TITLE
Qualify BCrypt and support backend-aware Windows SDK packages

### DIFF
--- a/.github/workflows/windows-sdk.yml
+++ b/.github/workflows/windows-sdk.yml
@@ -1,6 +1,12 @@
 name: Windows SDK candidate
 on:
   workflow_dispatch:
+    inputs:
+      crypto_backend:
+        description: SDK crypto backend
+        type: choice
+        options: [openssl, bcrypt]
+        default: openssl
   pull_request:
     paths:
       - 'packaging/windows/**'
@@ -8,6 +14,27 @@ on:
 permissions:
   contents: read
 jobs:
+  bcrypt-smoke:
+    if: github.event_name == 'pull_request'
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: BCrypt SDK consumers without OpenSSL
+        shell: pwsh
+        run: |
+          $vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          $script = Join-Path $PWD 'packaging\windows\build-ci.ps1'
+          $pwsh = Join-Path $PSHOME 'pwsh.exe'
+          foreach ($configuration in 'Debug','Release') {
+            & cmd /c "`"$vs\VC\Auxiliary\Build\vcvarsall.bat`" amd64 && `"$pwsh`" -NoProfile -File `"$script`" -Platform x64 -Configuration $configuration -CryptoBackend bcrypt"
+            if ($LASTEXITCODE -ne 0) { throw 'BCrypt SDK consumer failed' }
+          }
+      - name: Package validation regression tests
+        shell: pwsh
+        run: ./packaging/windows/test-package.ps1
   build:
     runs-on: windows-latest
     timeout-minutes: 35
@@ -21,6 +48,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/checkout@v7
+        if: github.event_name != 'workflow_dispatch' || inputs.crypto_backend != 'bcrypt'
         with:
           repository: openssl/openssl
           ref: aae016bfd52fcad2bc9657c2c782cfdf73b1ed5f
@@ -31,12 +59,13 @@ jobs:
         env:
           SDK_PLATFORM: ${{ matrix.platform }}
           SDK_CONFIGURATION: ${{ matrix.configuration }}
+          SDK_CRYPTO_BACKEND: ${{ inputs.crypto_backend || 'openssl' }}
         run: |
           $vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
           $arch = @{Win32='x86'; x64='amd64'; Arm64='amd64_arm64'}[$env:SDK_PLATFORM]
           $script = Join-Path $PWD 'packaging\windows\build-ci.ps1'
           $pwsh = Join-Path $PSHOME 'pwsh.exe'
-          & cmd /c "`"$vs\VC\Auxiliary\Build\vcvarsall.bat`" $arch && `"$pwsh`" -NoProfile -File `"$script`" -Platform $env:SDK_PLATFORM -Configuration $env:SDK_CONFIGURATION"
+          & cmd /c "`"$vs\VC\Auxiliary\Build\vcvarsall.bat`" $arch && `"$pwsh`" -NoProfile -File `"$script`" -Platform $env:SDK_PLATFORM -Configuration $env:SDK_CONFIGURATION -CryptoBackend $env:SDK_CRYPTO_BACKEND"
           if ($LASTEXITCODE -ne 0) { throw 'SDK build failed' }
       - uses: actions/upload-artifact@v7
         with:

--- a/docs/windows-bcrypt.md
+++ b/docs/windows-bcrypt.md
@@ -18,12 +18,13 @@ and pkg-config metadata reflect the selected provider.
 The **experimental Windows SDK installer for application developers** is the
 separate packaging work requested in [issue #12](https://github.com/Robotweax/srt/issues/12),
 not a standalone streaming application. It bundles public headers, static
-Robotweax SRT and OpenSSL Crypto libraries for Debug/Release on Win32, x64 and
+Robotweax SRT libraries for Debug/Release on Win32, x64 and
 ARM64, and an MSBuild property sheet. See the
 [Windows SDK packaging documentation](https://github.com/Robotweax/srt/blob/main/packaging/windows/README.md).
-The installer candidate remains OpenSSL-based and is not yet a signed,
-qualified release installer. The optional BCrypt backend is available in
-`main`; it does not switch the installer packaging or the default backend.
+The installer candidate defaults to OpenSSL and is not yet a signed,
+qualified release installer. SDK builders can explicitly choose BCrypt without
+bundling OpenSSL, or retain OpenSSL and its dependency/license. This does not
+change the library's default backend or qualify the installer for release.
 
 ## Implementation boundary
 

--- a/docs/windows-bcrypt.md
+++ b/docs/windows-bcrypt.md
@@ -98,6 +98,32 @@ Before recommending or making this the Windows default, complete:
    no speedup is claimed from the historical numbers in issue #13.
 5. Native ARM64 execution and a focused cryptographic implementation review.
 
+## Planned Windows-default transition
+
+The transition is not enabled yet. Qualification must precede changing the
+default; a successful retry of a setup timeout does not explain its cause.
+The provider comparison also checks invalid GCM nonce/tag lengths, short
+output buffers and failed authentication, comparing both errors and output
+storage against OpenSSL. These checks do not inject CNG failures.
+
+Implementation acceptance criteria:
+
+- Select BCrypt only for fresh Windows configurations. Preserve explicit
+  `ROBOTWEAX_SRT_CRYPTO_BACKEND=openssl` and existing cache selections; never
+  silently fall back between providers. Other platforms retain OpenSSL.
+- Exercise the implicit Windows default with OpenSSL discovery disabled,
+  including installed static/shared consumers. Keep a smaller explicit OpenSSL
+  compatibility job and the cross-provider interoperability tests.
+- Make SDK construction, MSBuild properties and package validation backend-aware.
+  BCrypt bundles must neither require nor ship `libcrypto.lib`; OpenSSL bundles
+  retain their exact dependency and license. Record the backend in build metadata
+  and reject mixed-backend variant bundles.
+- Keep the installer candidate designation until installer qualification is
+  complete. A backend-default change alone does not qualify the installer.
+- Record native ARM64 execution, failure-injection and performance evidence
+  separately. Compile/link success is not runtime validation, and no performance
+  advantage over OpenSSL is assumed.
+
 References: [Issue #13](https://github.com/Robotweax/srt/issues/13),
 [BCryptEncrypt](https://learn.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptencrypt),
 [CNG key ownership](https://learn.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptgeneratesymmetrickey).

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -3,28 +3,43 @@
 This is an SDK for application developers, not a standalone streaming app.
 It implements the packaging work requested in
 [issue #12](https://github.com/Robotweax/srt/issues/12).
-The candidate remains OpenSSL-based; the separately available
-[experimental BCrypt backend](../../docs/windows-bcrypt.md) does not change
-this installer or the default backend. Manual target-machine acceptance and
+The candidate defaults to OpenSSL; builders can explicitly select the
+[experimental BCrypt backend](../../docs/windows-bcrypt.md).
+Manual target-machine acceptance and
 release signing remain pending; this is not a qualified release installer.
-The intended bundle contains static Robotweax SRT and static OpenSSL Crypto for
+The intended bundle contains static Robotweax SRT for
 Debug/Release × Win32/x64/Arm64. Consumers use `/MDd` for Debug and `/MD` for
 Release. Debug binaries are development-only; applications must deploy the
 appropriate Microsoft runtime for Release. AES-GCM preview is not enabled.
 
 Build each variant using `build-sdk.ps1` in the corresponding Visual Studio
-developer environment, supplying matching static OpenSSL headers/library and
-its `LICENSE.txt`. Do not mix architectures or CRT profiles. The script refuses
+developer environment. The default `-CryptoBackend openssl` requires
+`-OpenSSLRoot` with matching static OpenSSL headers/library and its `LICENSE.txt`.
+Use `-CryptoBackend bcrypt` without `-OpenSSLRoot` for a native Windows package;
+this disables OpenSSL discovery and ships no OpenSSL library or license file.
+For example, from a matching x64 developer shell:
+
+```powershell
+./packaging/windows/build-sdk.ps1 -Platform x64 -Configuration Release -CryptoBackend bcrypt -OutputRoot C:/srt-sdk-bcrypt
+```
+
+Do not mix architectures or CRT profiles. The script refuses
 existing build/stage directories. Combine the six SDK variants only after
-checking that shared headers and license files are identical.
+checking that shared headers and license files are identical. Each variant's
+`build.json` records its backend; `package.ps1` rejects mixed backends and OpenSSL
+files in BCrypt inventories. Distribute `srt-backend.props` alongside `srt.props`;
+it supplies the package's backend-specific link dependencies.
 
 Compile `sdk.iss` with Inno Setup, supplying `/DSdkRoot=...` and
 `/DProductVersion=...`. Do not publish until Windows install/uninstall and all
 six consumer link checks pass. This initial packaging work is not a signed or
 qualified release installer. No existing release assets are modified.
 
-The `Windows SDK candidate` workflow builds the six variants from a
-pinned OpenSSL 3.6.3 revision and uploads short-lived candidate artifacts only.
+The `Windows SDK candidate` workflow builds six variants and uploads short-lived
+candidate artifacts only. Manual runs select `crypto_backend`; the default is
+OpenSSL with a pinned 3.6.3 dependency. BCrypt runs skip that dependency entirely.
+Packaging PRs additionally smoke-test BCrypt x64 Debug/Release consumers and
+package rejection rules without doubling the full installer matrix.
 It links a public C consumer for every target and runs it for Win32/x64; ARM64
 execution is not verified by the x64 runner. OpenSSL assembly is enabled using
 NASM for Win32/x64 and the `VC-WIN64-CLANGASM-ARM` target (MSVC C compiler,
@@ -50,9 +65,10 @@ Import `$(ROBOTWEAX_SRT)\srt.props` after project compiler settings:
 ```
 
 Header includes remain `<srt/srt.h>`; the root is private to this SDK and does
-not install over a system Haivision installation. OpenSSL Crypto is an explicit
+not install over a system Haivision installation. For OpenSSL packages, Crypto is an explicit
 static link dependency. Applications with another OpenSSL dependency must resolve
 version/link compatibility; static linkage does not remove symbol conflicts.
+BCrypt packages instead link the Windows `bcrypt.lib` system import library.
 
 The candidate workflow also builds the public C consumer through
 `consumer/consumer.vcxproj`, importing the staged `srt.props` for all six

--- a/packaging/windows/build-ci.ps1
+++ b/packaging/windows/build-ci.ps1
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: MIT
-param([string]$Platform, [string]$Configuration)
+param([string]$Platform, [string]$Configuration,
+    [ValidateSet('openssl','bcrypt')][string]$CryptoBackend = 'openssl')
 $ErrorActionPreference = 'Stop'
 function Run([string]$Program, [string[]]$Arguments) {
     & $Program @Arguments
     if ($LASTEXITCODE -ne 0) { throw "$Program failed: $LASTEXITCODE" }
 }
 $Root = (Get-Location).Path
+if ($CryptoBackend -eq 'openssl') {
 $Target = @{Win32='VC-WIN32';x64='VC-WIN64A';Arm64='VC-WIN64-CLANGASM-ARM'}[$Platform]
 if (!$Target) { throw 'Invalid platform' }
 $Assembler = if ($Platform -eq 'Arm64') { 'clang-cl.exe' } else { 'nasm.exe' }
@@ -38,13 +40,18 @@ try {
     Run nmake @('install_dev')
 } finally { Pop-Location }
 Copy-Item "$Root/openssl-source/LICENSE.txt" "$Prefix/LICENSE.txt"
-& "$PSScriptRoot/build-sdk.ps1" -Platform $Platform -Configuration $Configuration -OpenSSLRoot $Prefix -OutputRoot "$Root/output"
+}
+$SdkOptions = @{Platform=$Platform; Configuration=$Configuration; CryptoBackend=$CryptoBackend; OutputRoot="$Root/output"}
+if ($CryptoBackend -eq 'openssl') { $SdkOptions.OpenSSLRoot = $Prefix }
+& "$PSScriptRoot/build-sdk.ps1" @SdkOptions
 if (!$?) { throw 'SDK build failed' }
 $Sdk = "$Root/output/sdk-$Configuration-$Platform"
 $Runtime = if ($Configuration -eq 'Debug') { '/MDd' } else { '/MD' }
 # Link every architecture; execute only architectures supported by this runner.
 Run cl @('/nologo','/std:c11',$Runtime,"/I$Sdk/include",'/c',"$Root/tests/package_consumer/c_consumer.c",'/Foconsumer.obj')
-Run link @('/nologo','consumer.obj',"/LIBPATH:$Sdk/lib/$Configuration-$Platform",'robotweax-srt.lib','libcrypto.lib','ws2_32.lib','crypt32.lib','advapi32.lib','user32.lib','bcrypt.lib','/OUT:consumer.exe')
+$Libraries = @('robotweax-srt.lib','ws2_32.lib','bcrypt.lib')
+if ($CryptoBackend -eq 'openssl') { $Libraries += @('libcrypto.lib','crypt32.lib','advapi32.lib','user32.lib') }
+Run link (@('/nologo','consumer.obj',"/LIBPATH:$Sdk/lib/$Configuration-$Platform",'/OUT:consumer.exe') + $Libraries)
 if ($Platform -ne 'Arm64') { Run "$Root/consumer.exe" @() }
 
 # Exercise the shipped props rather than duplicating its linker settings.

--- a/packaging/windows/build-sdk.ps1
+++ b/packaging/windows/build-sdk.ps1
@@ -3,7 +3,8 @@
 param(
     [Parameter(Mandatory)][ValidateSet('Win32','x64','Arm64')][string]$Platform,
     [Parameter(Mandatory)][ValidateSet('Debug','Release')][string]$Configuration,
-    [Parameter(Mandatory)][string]$OpenSSLRoot,
+    [ValidateSet('openssl','bcrypt')][string]$CryptoBackend = 'openssl',
+    [string]$OpenSSLRoot,
     [Parameter(Mandatory)][string]$OutputRoot
 )
 $ErrorActionPreference = 'Stop'
@@ -12,25 +13,34 @@ function Invoke-Checked([string]$Program, [string[]]$Arguments) {
     if ($LASTEXITCODE -ne 0) { throw "$Program failed: $LASTEXITCODE" }
 }
 $Source = (Resolve-Path "$PSScriptRoot/../..").Path
-$Crypto = (Resolve-Path "$OpenSSLRoot/lib/libcrypto.lib").Path
+$Crypto = $null
+if ($CryptoBackend -eq 'openssl') {
+    if (!$OpenSSLRoot) { throw 'OpenSSLRoot is required for the OpenSSL backend' }
+    $Crypto = (Resolve-Path "$OpenSSLRoot/lib/libcrypto.lib").Path
+} elseif ($OpenSSLRoot) { throw 'OpenSSLRoot must not be supplied for BCrypt' }
 $OutputRoot = [IO.Path]::GetFullPath($OutputRoot)
 $Build = Join-Path $OutputRoot "build-$Configuration-$Platform"
 $Stage = Join-Path $OutputRoot "sdk-$Configuration-$Platform"
 if ((Test-Path $Build) -or (Test-Path $Stage)) { throw 'Use a fresh output directory; existing files are never deleted.' }
 $Runtime = if ($Configuration -eq 'Debug') { 'MultiThreadedDebugDLL' } else { 'MultiThreadedDLL' }
-Invoke-Checked cmake @('-S',$Source,'-B',$Build,'-G','Ninja',
+$Options = @('-S',$Source,'-B',$Build,'-G','Ninja',
     "-DCMAKE_BUILD_TYPE=$Configuration","-DCMAKE_MSVC_RUNTIME_LIBRARY=$Runtime",
     '-DBUILD_SHARED_LIBS=OFF','-DROBOTWEAX_SRT_BUILD_TESTS=OFF',
     '-DROBOTWEAX_SRT_BUILD_TOOLS=OFF','-DROBOTWEAX_SRT_BUILD_BENCHMARKS=OFF',
     '-DROBOTWEAX_SRT_BUILD_EXAMPLES=OFF','-DROBOTWEAX_SRT_INSTALL_LAYOUT=namespaced',
+    "-DROBOTWEAX_SRT_CRYPTO_BACKEND=$CryptoBackend")
+if ($CryptoBackend -eq 'openssl') {
+    $Options += @(
     '-DOPENSSL_USE_STATIC_LIBS=ON',"-DOPENSSL_ROOT_DIR=$OpenSSLRoot",
     "-DOPENSSL_INCLUDE_DIR=$OpenSSLRoot/include",
     "-DOPENSSL_CRYPTO_LIBRARY=$Crypto",
     "-DLIB_EAY_DEBUG:FILEPATH=$Crypto","-DLIB_EAY_RELEASE:FILEPATH=$Crypto")
+} else { $Options += '-DCMAKE_DISABLE_FIND_PACKAGE_OpenSSL=ON' }
+Invoke-Checked cmake $Options
 # FindOpenSSL on MSVC derives its imported target from LIB_EAY_DEBUG/RELEASE,
 # not just OPENSSL_CRYPTO_LIBRARY. Fail before compilation if that pin changes.
 $Cache = Get-Content "$Build/CMakeCache.txt"
-foreach ($Name in @('LIB_EAY_DEBUG', 'LIB_EAY_RELEASE')) {
+foreach ($Name in $(if ($CryptoBackend -eq 'openssl') { @('LIB_EAY_DEBUG', 'LIB_EAY_RELEASE') } else { @() })) {
     $Entry = @($Cache | Where-Object { $_ -like "${Name}:FILEPATH=*" })
     if ($Entry.Count -ne 1) { throw "Missing pinned $Name" }
     $Selected = $Entry[0].Substring($Entry[0].IndexOf('=') + 1)
@@ -41,7 +51,7 @@ foreach ($Name in @('LIB_EAY_DEBUG', 'LIB_EAY_RELEASE')) {
 Invoke-Checked cmake @('--build',$Build,'--parallel','2','--target','robotweax_srt')
 New-Item -ItemType Directory -Path "$Stage/lib/$Configuration-$Platform" -Force | Out-Null
 Copy-Item "$Build/robotweax-srt.lib" "$Stage/lib/$Configuration-$Platform/"
-Copy-Item $Crypto "$Stage/lib/$Configuration-$Platform/"
+if ($Crypto) { Copy-Item $Crypto "$Stage/lib/$Configuration-$Platform/" }
 New-Item -ItemType Directory -Path "$Stage/include/srt" -Force | Out-Null
 Copy-Item "$Source/include/srt.h","$Source/include/robotweax_srt.h" "$Stage/include/"
 Copy-Item "$Source/include/srt/*.h" "$Stage/include/srt/"
@@ -50,7 +60,17 @@ Copy-Item "$Source/THIRD_PARTY.md" "$Stage/THIRD_PARTY.md"
 Copy-Item "$PSScriptRoot/srt.props" "$Stage/srt.props"
 Copy-Item "$PSScriptRoot/README.md" "$Stage/README.md"
 # The producer must supply the exact dependency license next to its build.
-Copy-Item "$OpenSSLRoot/LICENSE.txt" "$Stage/OpenSSL-LICENSE.txt"
+if ($Crypto) { Copy-Item "$OpenSSLRoot/LICENSE.txt" "$Stage/OpenSSL-LICENSE.txt" }
+$Dependencies = if ($CryptoBackend -eq 'openssl') { 'libcrypto.lib;crypt32.lib;advapi32.lib;user32.lib;bcrypt.lib' } else { 'bcrypt.lib' }
+@"
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <RobotweaxSrtCryptoBackend>$CryptoBackend</RobotweaxSrtCryptoBackend>
+    <RobotweaxSrtCryptoDependencies>$Dependencies</RobotweaxSrtCryptoDependencies>
+  </PropertyGroup>
+</Project>
+"@ | Set-Content "$Stage/srt-backend.props"
 @{platform=$Platform; configuration=$Configuration; runtime=$Runtime;
-  source=(git -C $Source rev-parse HEAD); crypto_sha256=(Get-FileHash $Crypto).Hash
+  source=(git -C $Source rev-parse HEAD); crypto_backend=$CryptoBackend;
+  crypto_sha256=$(if ($Crypto) { (Get-FileHash $Crypto).Hash } else { $null })
 } | ConvertTo-Json | Set-Content "$Stage/lib/$Configuration-$Platform/build.json"

--- a/packaging/windows/package.ps1
+++ b/packaging/windows/package.ps1
@@ -4,12 +4,27 @@ $ErrorActionPreference = 'Stop'
 if (Test-Path $Destination) { throw 'Destination must not exist' }
 New-Item -ItemType Directory $Destination | Out-Null
 $Hashes = @{}
+$Backend = $null
 foreach ($Configuration in @('Debug','Release')) {
     foreach ($Platform in @('Win32','x64','Arm64')) {
         $Variant = Join-Path $Variants "sdk-$Configuration-$Platform"
-        foreach ($Required in @("lib/$Configuration-$Platform/robotweax-srt.lib", "lib/$Configuration-$Platform/libcrypto.lib", 'include/srt/srt.h','LICENSE.txt','OpenSSL-LICENSE.txt','srt.props')) {
+        $MetadataPath = "$Variant/lib/$Configuration-$Platform/build.json"
+        $Metadata = Get-Content $MetadataPath -Raw | ConvertFrom-Json
+        if ($Metadata.crypto_backend -notin @('openssl','bcrypt')) { throw 'Missing or invalid crypto backend' }
+        if ($Metadata.platform -ne $Platform -or $Metadata.configuration -ne $Configuration) { throw 'Variant metadata mismatch' }
+        if ($Backend -and $Backend -ne $Metadata.crypto_backend) { throw 'Mixed crypto backends are not supported' }
+        $Backend = $Metadata.crypto_backend
+        $RequiredFiles = @("lib/$Configuration-$Platform/robotweax-srt.lib", 'include/srt/srt.h','LICENSE.txt','srt.props','srt-backend.props')
+        if ($Backend -eq 'openssl') {
+            $RequiredFiles += @("lib/$Configuration-$Platform/libcrypto.lib", 'OpenSSL-LICENSE.txt')
+        } elseif (@(Get-ChildItem $Variant -Recurse -File | Where-Object { $_.Name -match '(?i)libcrypto|openssl' }).Count) {
+            throw 'BCrypt SDK must not contain OpenSSL files'
+        }
+        foreach ($Required in $RequiredFiles) {
             if (!(Test-Path "$Variant/$Required")) { throw "Missing $Variant/$Required" }
         }
+        [xml]$Props = Get-Content "$Variant/srt-backend.props" -Raw
+        if ($Props.Project.PropertyGroup.RobotweaxSrtCryptoBackend -ne $Backend) { throw 'Backend props mismatch' }
         foreach ($File in Get-ChildItem $Variant -Recurse -File) {
             $Relative = $File.FullName.Substring((Resolve-Path $Variant).Path.Length + 1)
             $Hash = (Get-FileHash $File.FullName).Hash

--- a/packaging/windows/srt.props
+++ b/packaging/windows/srt.props
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildThisFileDirectory)srt-backend.props" />
   <PropertyGroup>
     <RobotweaxSrtRoot>$(MSBuildThisFileDirectory)</RobotweaxSrtRoot>
     <RobotweaxSrtLibDir>$(RobotweaxSrtRoot)lib\$(Configuration)-$(Platform)</RobotweaxSrtLibDir>
@@ -11,7 +12,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(RobotweaxSrtLibDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>robotweax-srt.lib;libcrypto.lib;ws2_32.lib;crypt32.lib;advapi32.lib;user32.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>robotweax-srt.lib;ws2_32.lib;$(RobotweaxSrtCryptoDependencies);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Target Name="ValidateRobotweaxSrtSdk" BeforeTargets="ClCompile">

--- a/packaging/windows/test-package.ps1
+++ b/packaging/windows/test-package.ps1
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: MIT
+# Synthetic inventories exercise validation, not binary/architecture correctness.
+$ErrorActionPreference = 'Stop'
+$Root = Join-Path ([IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString())
+New-Item -ItemType Directory $Root | Out-Null
+try {
+    foreach ($Backend in 'openssl','bcrypt') {
+        $Variants = Join-Path $Root $Backend
+        foreach ($Configuration in 'Debug','Release') {
+            foreach ($Platform in 'Win32','x64','Arm64') {
+                $Variant = "$Variants/sdk-$Configuration-$Platform"
+                $Lib = "$Variant/lib/$Configuration-$Platform"
+                New-Item -ItemType Directory $Lib,"$Variant/include/srt" -Force | Out-Null
+                foreach ($File in @("$Lib/robotweax-srt.lib", "$Variant/include/srt/srt.h", "$Variant/LICENSE.txt", "$Variant/srt.props")) {
+                    'fixture' | Set-Content $File
+                }
+                @{platform=$Platform; configuration=$Configuration; crypto_backend=$Backend} |
+                    ConvertTo-Json | Set-Content "$Lib/build.json"
+                "<Project><PropertyGroup><RobotweaxSrtCryptoBackend>$Backend</RobotweaxSrtCryptoBackend></PropertyGroup></Project>" |
+                    Set-Content "$Variant/srt-backend.props"
+                if ($Backend -eq 'openssl') {
+                    'fixture' | Set-Content "$Lib/libcrypto.lib"
+                    'fixture' | Set-Content "$Variant/OpenSSL-LICENSE.txt"
+                }
+            }
+        }
+        & "$PSScriptRoot/package.ps1" -Variants $Variants -Destination "$Root/valid-$Backend"
+    }
+    function Expect-Rejection([string]$Name, [string]$Pattern) {
+        $Rejected = $false
+        try { & "$PSScriptRoot/package.ps1" -Variants "$Root/bcrypt" -Destination "$Root/$Name" }
+        catch {
+            if ($_.Exception.Message -notmatch $Pattern) { throw }
+            $Rejected = $true
+        }
+        if (!$Rejected) { throw "Invalid package accepted: $Name" }
+    }
+    $MetadataPath = "$Root/bcrypt/sdk-Release-Arm64/lib/Release-Arm64/build.json"
+    $Original = Get-Content $MetadataPath -Raw
+    $Metadata = $Original | ConvertFrom-Json
+    $Metadata.crypto_backend = 'openssl'
+    $Metadata | ConvertTo-Json | Set-Content $MetadataPath
+    Expect-Rejection 'mixed' 'Mixed crypto backends'
+    $Original | Set-Content $MetadataPath
+    'unexpected' | Set-Content "$Root/bcrypt/sdk-Release-Arm64/lib/Release-Arm64/libcrypto.lib"
+    Expect-Rejection 'contaminated' 'must not contain OpenSSL'
+    Write-Output 'Package validation tests passed'
+} finally {
+    # Only this invocation's generated temporary fixtures are removed.
+    Remove-Item -Recurse -Force $Root
+}

--- a/tests/crypto_provider_comparison/main.cpp
+++ b/tests/crypto_provider_comparison/main.cpp
@@ -50,6 +50,41 @@ int main()
             require(oracle.make_aes_ctr_cipher(key, ctr_b) == Error::none);
             require(native.make_aes_gcm_cipher(key, gcm_a) == Error::none);
             require(oracle.make_aes_gcm_cipher(key, gcm_b) == Error::none);
+            // Compare failure semantics, including whether caller storage is
+            // erased or preserved. Success vectors alone cannot establish this.
+            for (int fault = 0; fault < 4; ++fault) {
+                std::array<std::byte, 12> nonce {};
+                std::array<std::byte, 16> tag {};
+                std::array<std::byte, 17> input {};
+                std::array<std::byte, 17> a, b;
+                a.fill(std::byte {0x5a});
+                b = a;
+                const auto iv = std::span<const std::byte>(nonce).first(
+                    fault == 0 ? 11 : 12);
+                const auto auth_tag =
+                    std::span<const std::byte>(tag).first(fault == 1 ? 15 : 16);
+                auto out_a =
+                    std::span<std::byte>(a).first(fault == 2 ? 16 : 17);
+                auto out_b =
+                    std::span<std::byte>(b).first(fault == 2 ? 16 : 17);
+                const auto result =
+                    gcm_a->open(iv, key, input, auth_tag, out_a);
+                require(result != Error::none);
+                require(result == gcm_b->open(iv, key, input, auth_tag, out_b));
+                require(a == b);
+            }
+            {
+                std::array<std::byte, 16> iv {};
+                std::array<std::byte, 17> input {};
+                std::array<std::byte, 16> a, b;
+                a.fill(std::byte {0x5a});
+                b = a;
+                require(
+                    ctr_a->transform(iv, input, a) == Error::buffer_too_small);
+                require(
+                    ctr_b->transform(iv, input, b) == Error::buffer_too_small);
+                require(a == b);
+            }
             for (const std::size_t size :
                 {0U, 1U, 15U, 16U, 17U, 1023U, 1024U, 1025U, 1316U, 4097U}) {
                 std::vector<std::byte> plain(size, std::byte {0x29}), a(size),


### PR DESCRIPTION
Preparation for a future Windows BCrypt default; OpenSSL remains the default. Adds provider failure parity checks, explicit SDK backend selection, backend-specific MSBuild dependencies and metadata, rejection of mixed/contaminated packages, and synthetic package validation tests. Packaging CI retains the six-variant OpenSSL default and adds serial x64 Debug/Release BCrypt consumer smoke tests. Manual SDK workflow runs can select either backend for the full installer matrix. Local YAML/XML parsing and diff checks passed; PowerShell, MSBuild and installer execution require Windows CI. Native ARM64 execution and other qualification gaps remain documented. No release publication or default switch.