### PR TITLE
Build separate OpenSSL and BCrypt Windows SDK installers

### DIFF
--- a/.github/workflows/windows-sdk.yml
+++ b/.github/workflows/windows-sdk.yml
@@ -1,12 +1,8 @@
-name: Windows SDK candidate
+name: Windows SDK installers
 on:
   workflow_dispatch:
-    inputs:
-      crypto_backend:
-        description: SDK crypto backend
-        type: choice
-        options: [openssl, bcrypt]
-        default: openssl
+  push:
+    tags: ['v*']
   pull_request:
     paths:
       - 'packaging/windows/**'
@@ -14,33 +10,30 @@ on:
 permissions:
   contents: read
 jobs:
-  bcrypt-smoke:
-    if: github.event_name == 'pull_request'
+  validate:
     runs-on: windows-latest
-    timeout-minutes: 15
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - name: BCrypt SDK consumers without OpenSSL
+      - name: Validate release tag
+        if: github.ref_type == 'tag'
         shell: pwsh
         run: |
-          $vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
-          $script = Join-Path $PWD 'packaging\windows\build-ci.ps1'
-          $pwsh = Join-Path $PSHOME 'pwsh.exe'
-          foreach ($configuration in 'Debug','Release') {
-            & cmd /c "`"$vs\VC\Auxiliary\Build\vcvarsall.bat`" amd64 && `"$pwsh`" -NoProfile -File `"$script`" -Platform x64 -Configuration $configuration -CryptoBackend bcrypt"
-            if ($LASTEXITCODE -ne 0) { throw 'BCrypt SDK consumer failed' }
-          }
+          $version = [regex]::Match((Get-Content CMakeLists.txt -Raw), 'project\(robotweax_srt VERSION ([0-9.]+)').Groups[1].Value
+          if (!$version -or $env:GITHUB_REF_NAME -cne "v$version") { throw 'Tag must match the CMake project version exactly' }
       - name: Package validation regression tests
         shell: pwsh
         run: ./packaging/windows/test-package.ps1
   build:
+    needs: validate
     runs-on: windows-latest
     timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
+        backend: [openssl, bcrypt]
         platform: [Win32, x64, Arm64]
         configuration: [Debug, Release]
     steps:
@@ -48,7 +41,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/checkout@v7
-        if: github.event_name != 'workflow_dispatch' || inputs.crypto_backend != 'bcrypt'
+        if: matrix.backend == 'openssl'
         with:
           repository: openssl/openssl
           ref: aae016bfd52fcad2bc9657c2c782cfdf73b1ed5f
@@ -59,7 +52,7 @@ jobs:
         env:
           SDK_PLATFORM: ${{ matrix.platform }}
           SDK_CONFIGURATION: ${{ matrix.configuration }}
-          SDK_CRYPTO_BACKEND: ${{ inputs.crypto_backend || 'openssl' }}
+          SDK_CRYPTO_BACKEND: ${{ matrix.backend }}
         run: |
           $vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
           $arch = @{Win32='x86'; x64='amd64'; Arm64='amd64_arm64'}[$env:SDK_PLATFORM]
@@ -69,7 +62,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw 'SDK build failed' }
       - uses: actions/upload-artifact@v7
         with:
-          name: sdk-${{ matrix.configuration }}-${{ matrix.platform }}
+          name: sdk-${{ matrix.backend }}-${{ matrix.configuration }}-${{ matrix.platform }}
           path: output/sdk-${{ matrix.configuration }}-${{ matrix.platform }}/
           if-no-files-found: error
           retention-days: 7
@@ -77,31 +70,38 @@ jobs:
     needs: build
     runs-on: windows-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [openssl, bcrypt]
+    env:
+      SDK_BACKEND: ${{ matrix.backend }}
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - uses: actions/download-artifact@v8
         with:
-          pattern: sdk-*
+          pattern: sdk-${{ matrix.backend }}-*
           path: variants
       - name: Assemble and compile installer candidate
         shell: pwsh
         run: |
-          ./packaging/windows/package.ps1 -Variants variants -Destination sdk
+          ./packaging/windows/package.ps1 -Variants variants -Destination sdk -ArtifactPrefix "sdk-$env:SDK_BACKEND" -ExpectedBackend $env:SDK_BACKEND
           $version = [regex]::Match((Get-Content CMakeLists.txt -Raw), 'project\(robotweax_srt VERSION ([0-9.]+)').Groups[1].Value
           $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
           if (!(Test-Path $iscc)) { throw 'Inno Setup 6 is required' }
-          & $iscc "/DSdkRoot=$PWD\sdk" "/DProductVersion=$version" packaging/windows/sdk.iss
+          & $iscc "/DSdkRoot=$PWD\sdk" "/DProductVersion=$version" "/DCryptoBackend=$env:SDK_BACKEND" packaging/windows/sdk.iss
           if ($LASTEXITCODE -ne 0) { throw 'Installer compilation failed' }
       - name: Smoke test silent install and uninstall
         shell: pwsh
         run: |
           $installer = (Get-ChildItem packaging/windows/Output/*.exe).FullName
           $destination = Join-Path $env:RUNNER_TEMP 'Robotweax SDK test'
+          $variable = 'ROBOTWEAX_SRT_' + $env:SDK_BACKEND.ToUpperInvariant()
           $process = Start-Process -Wait -PassThru $installer -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /DIR=`"$destination`""
           if ($process.ExitCode -ne 0) { throw 'Installation failed' }
-          if ([Environment]::GetEnvironmentVariable('ROBOTWEAX_SRT','Machine') -ne $destination) { throw 'SDK environment variable missing' }
+          if ([Environment]::GetEnvironmentVariable($variable,'Machine') -ne $destination) { throw 'SDK environment variable missing' }
           $before = (Get-FileHash "$destination/srt.props").Hash
           $process = Start-Process -Wait -PassThru $installer -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /DIR=`"$destination`""
           if ($process.ExitCode -eq 0) { throw 'Existing installation was not rejected' }
@@ -117,7 +117,7 @@ jobs:
           $process = Start-Process -Wait -PassThru "$destination/unins000.exe" -ArgumentList '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
           if ($process.ExitCode -ne 0) { throw 'Uninstallation failed' }
           if (Test-Path "$destination/srt.props") { throw 'SDK files remained installed' }
-          if ([Environment]::GetEnvironmentVariable('ROBOTWEAX_SRT','Machine') -eq $destination) { throw 'Stale SDK environment variable' }
+          if ([Environment]::GetEnvironmentVariable($variable,'Machine') -eq $destination) { throw 'Stale SDK environment variable' }
           $process = Start-Process -Wait -PassThru $installer -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /DIR=`"$other`""
           if ($process.ExitCode -ne 0) { throw 'Reinstallation after uninstall failed' }
           if (!(Test-Path "$other/include/srt/srt.h")) { throw 'Reinstalled headers missing' }
@@ -125,7 +125,56 @@ jobs:
           if ($process.ExitCode -ne 0) { throw 'Final cleanup failed' }
       - uses: actions/upload-artifact@v7
         with:
-          name: windows-sdk-installer-candidate
+          name: windows-sdk-installer-${{ matrix.backend }}
           path: packaging/windows/Output/*.exe
           if-no-files-found: error
           retention-days: 7
+  coexistence:
+    needs: installer
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: windows-sdk-installer-*
+          path: installers
+          merge-multiple: true
+      - name: Verify side-by-side installation and independent removal
+        shell: pwsh
+        run: ./packaging/windows/test-installers.ps1 -Installers installers
+  release-draft:
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    needs: coexistence
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: windows-sdk-installer-*
+          path: installers
+          merge-multiple: true
+      - name: Attach both installers to a draft only
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        shell: bash
+        working-directory: installers
+        run: |
+          set -euo pipefail
+          openssl="robotweax-srt-${RELEASE_TAG#v}-windows-sdk-openssl.exe"
+          bcrypt="robotweax-srt-${RELEASE_TAG#v}-windows-sdk-bcrypt.exe"
+          test -s "$openssl"
+          test -s "$bcrypt"
+          sha256sum "$openssl" "$bcrypt" > SHA256SUMS
+          if gh release view "$RELEASE_TAG" --json isDraft > release.json; then
+            test "$(jq -r .isDraft release.json)" = true || { echo 'Refusing to modify a published release'; exit 1; }
+          else
+            gh release create "$RELEASE_TAG" --verify-tag --draft --title "Robotweax SRT ${RELEASE_TAG#v}" --notes 'Windows SDK installers: OpenSSL and BCrypt. Unsigned; review qualification and release notes before publishing.'
+          fi
+          gh release upload "$RELEASE_TAG" "$openssl" "$bcrypt" SHA256SUMS

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -3,7 +3,7 @@
 This is an SDK for application developers, not a standalone streaming app.
 It implements the packaging work requested in
 [issue #12](https://github.com/Robotweax/srt/issues/12).
-The candidate defaults to OpenSSL; builders can explicitly select the
+Two separate installers offer OpenSSL and the
 [experimental BCrypt backend](../../docs/windows-bcrypt.md).
 Manual target-machine acceptance and
 release signing remain pending; this is not a qualified release installer.
@@ -30,16 +30,16 @@ checking that shared headers and license files are identical. Each variant's
 files in BCrypt inventories. Distribute `srt-backend.props` alongside `srt.props`;
 it supplies the package's backend-specific link dependencies.
 
-Compile `sdk.iss` with Inno Setup, supplying `/DSdkRoot=...` and
-`/DProductVersion=...`. Do not publish until Windows install/uninstall and all
+Compile `sdk.iss` with Inno Setup, supplying `/DSdkRoot=...`,
+`/DProductVersion=...` and `/DCryptoBackend=openssl` or `bcrypt`.
+The supplied SDK must match this backend. Do not publish until Windows install/uninstall and all
 six consumer link checks pass. This initial packaging work is not a signed or
 qualified release installer. No existing release assets are modified.
 
-The `Windows SDK candidate` workflow builds six variants and uploads short-lived
-candidate artifacts only. Manual runs select `crypto_backend`; the default is
-OpenSSL with a pinned 3.6.3 dependency. BCrypt runs skip that dependency entirely.
-Packaging PRs additionally smoke-test BCrypt x64 Debug/Release consumers and
-package rejection rules without doubling the full installer matrix.
+The `Windows SDK installers` workflow builds six variants per backend and uploads
+short-lived candidate artifacts. OpenSSL uses a pinned 3.6.3 dependency; BCrypt
+skips that dependency entirely. Package regression tests reject mixed or
+incorrectly labelled backend inventories.
 It links a public C consumer for every target and runs it for Win32/x64; ARM64
 execution is not verified by the x64 runner. OpenSSL assembly is enabled using
 NASM for Win32/x64 and the `VC-WIN64-CLANGASM-ARM` target (MSVC C compiler,
@@ -47,21 +47,29 @@ clang-cl assembler) for ARM64. Missing assemblers or disabled assembly fail the
 build; assembler versions and OpenSSL configuration are recorded in CI logs.
 This is **not a performance qualification**; production throughput still needs
 measurement on the target hardware. This workflow runs manually or for
-PRs changing Windows packaging; it does not run on ordinary pushes or
-automatically publish release assets.
+PRs changing Windows packaging, and on `v*` tags, but not ordinary branch pushes.
+Tags must exactly match `v` plus the CMake project version. Only after both
+installers and their side-by-side tests pass are both executables and
+`SHA256SUMS` attached to a draft release. Publishing remains a manual review step;
+an existing published release is never modified. Re-running an upload with
+existing asset names fails rather than replacing them. Manual runs only produce
+CI artifacts and are the qualification path before tagging. No tag is needed
+to test packaging. Installers are currently unsigned.
 
 Interactive installation shows the installer UI. Unattended installation:
 
 ```powershell
-Start-Process -Wait -FilePath .\robotweax-srt-VERSION-windows-sdk.exe -ArgumentList '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+Start-Process -Wait -FilePath .\robotweax-srt-VERSION-windows-sdk-openssl.exe -ArgumentList '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
 ```
 
 Use `/DIR="C:\custom\Robotweax-SRT"` to select another directory. The installer
-sets machine-wide `ROBOTWEAX_SRT`; open a new shell to observe the change.
-Import `$(ROBOTWEAX_SRT)\srt.props` after project compiler settings:
+sets machine-wide `ROBOTWEAX_SRT_OPENSSL` or `ROBOTWEAX_SRT_BCRYPT`; open a new
+shell to observe the change. Default folders are `Robotweax-SRT-openssl` and
+`Robotweax-SRT-bcrypt` under Program Files. Select exactly one backend by importing
+its props after project compiler settings (replace OPENSSL with BCRYPT as needed):
 
 ```xml
-<Import Project="$(ROBOTWEAX_SRT)\srt.props" />
+<Import Project="$(ROBOTWEAX_SRT_OPENSSL)\srt.props" />
 ```
 
 Header includes remain `<srt/srt.h>`; the root is private to this SDK and does
@@ -75,8 +83,16 @@ The candidate workflow also builds the public C consumer through
 combinations. It executes Win32/x64 consumers and deliberately checks that a
 static-CRT profile is rejected. ARM64 remains compile/link-only on this runner.
 
-Upgrades currently require uninstalling the previous SDK first. The installer
-rejects an already registered SDK even when a different destination is selected.
+The installers do not set or change the legacy `ROBOTWEAX_SRT` variable.
+Existing projects may explicitly set that variable to the selected SDK root.
+This does not change the CMake default backend (OpenSSL).
+
+Upgrades currently require uninstalling the previous SDK of the same backend
+first. Legacy, backend-neutral SDK candidates must also be uninstalled first.
+The installer rejects an already registered same-backend SDK even when a
+different destination is selected. Different backends can coexist in distinct
+folders. CI tests both installation orders, rejects cross-backend overwrites,
+and verifies that removing one SDK preserves the other's files and variable.
 CI checks rejection, preservation of the existing props file, uninstall and
 reinstallation into another path. This is not an automatic in-place upgrade test.
 Do not install

--- a/packaging/windows/package.ps1
+++ b/packaging/windows/package.ps1
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
-param([Parameter(Mandatory)][string]$Variants, [Parameter(Mandatory)][string]$Destination)
+param([Parameter(Mandatory)][string]$Variants, [Parameter(Mandatory)][string]$Destination,
+      [string]$ArtifactPrefix = 'sdk', [ValidateSet('openssl','bcrypt')][string]$ExpectedBackend)
 $ErrorActionPreference = 'Stop'
 if (Test-Path $Destination) { throw 'Destination must not exist' }
 New-Item -ItemType Directory $Destination | Out-Null
@@ -7,10 +8,11 @@ $Hashes = @{}
 $Backend = $null
 foreach ($Configuration in @('Debug','Release')) {
     foreach ($Platform in @('Win32','x64','Arm64')) {
-        $Variant = Join-Path $Variants "sdk-$Configuration-$Platform"
+        $Variant = Join-Path $Variants "$ArtifactPrefix-$Configuration-$Platform"
         $MetadataPath = "$Variant/lib/$Configuration-$Platform/build.json"
         $Metadata = Get-Content $MetadataPath -Raw | ConvertFrom-Json
         if ($Metadata.crypto_backend -notin @('openssl','bcrypt')) { throw 'Missing or invalid crypto backend' }
+        if ($ExpectedBackend -and $Metadata.crypto_backend -ne $ExpectedBackend) { throw 'Unexpected crypto backend' }
         if ($Metadata.platform -ne $Platform -or $Metadata.configuration -ne $Configuration) { throw 'Variant metadata mismatch' }
         if ($Backend -and $Backend -ne $Metadata.crypto_backend) { throw 'Mixed crypto backends are not supported' }
         $Backend = $Metadata.crypto_backend

--- a/packaging/windows/sdk.iss
+++ b/packaging/windows/sdk.iss
@@ -5,29 +5,40 @@
 #ifndef ProductVersion
   #error ProductVersion is required
 #endif
+#ifndef CryptoBackend
+  #error CryptoBackend is required
+#endif
+#if CryptoBackend == "openssl"
+  #define BackendEnvironment "ROBOTWEAX_SRT_OPENSSL"
+#elif CryptoBackend == "bcrypt"
+  #define BackendEnvironment "ROBOTWEAX_SRT_BCRYPT"
+#else
+  #error Invalid CryptoBackend
+#endif
 [Setup]
-AppId=Robotweax.SRT.SDK
-AppName=Robotweax SRT SDK
+AppId=Robotweax.SRT.SDK.{#CryptoBackend}
+AppName=Robotweax SRT SDK ({#CryptoBackend})
 AppVersion={#ProductVersion}
 AppPublisher=Robotweax GmbH
-DefaultDirName={autopf}\Robotweax-SRT
+DefaultDirName={autopf}\Robotweax-SRT-{#CryptoBackend}
 DisableProgramGroupPage=yes
 PrivilegesRequired=admin
 ChangesEnvironment=yes
-OutputBaseFilename=robotweax-srt-{#ProductVersion}-windows-sdk
+OutputBaseFilename=robotweax-srt-{#ProductVersion}-windows-sdk-{#CryptoBackend}
 Compression=lzma2
 SolidCompression=yes
 LicenseFile={#SdkRoot}\LICENSE.txt
-UninstallDisplayName=Robotweax SRT SDK
+UninstallDisplayName=Robotweax SRT SDK ({#CryptoBackend})
 [Files]
 Source: "{#SdkRoot}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 [Registry]
-Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: expandsz; ValueName: "ROBOTWEAX_SRT"; ValueData: "{app}"
+Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: expandsz; ValueName: "{#BackendEnvironment}"; ValueData: "{app}"
 [Code]
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 begin
   Result := '';
   if RegKeyExists(HKLM, 'Software\Microsoft\Windows\CurrentVersion\Uninstall\Robotweax.SRT.SDK_is1')
+     or RegKeyExists(HKLM, 'Software\Microsoft\Windows\CurrentVersion\Uninstall\Robotweax.SRT.SDK.{#CryptoBackend}_is1')
      or FileExists(ExpandConstant('{app}\unins000.exe')) then
     Result := 'Uninstall the previous Robotweax SRT SDK before installing this candidate.';
 end;
@@ -36,7 +47,7 @@ procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
 var Current: String;
 begin
   if CurUninstallStep = usUninstall then
-    if RegQueryStringValue(HKLM, 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', 'ROBOTWEAX_SRT', Current) then
+    if RegQueryStringValue(HKLM, 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', '{#BackendEnvironment}', Current) then
       if CompareText(Current, ExpandConstant('{app}')) = 0 then
-        RegDeleteValue(HKLM, 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', 'ROBOTWEAX_SRT');
+        RegDeleteValue(HKLM, 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', '{#BackendEnvironment}');
 end;

--- a/packaging/windows/test-installers.ps1
+++ b/packaging/windows/test-installers.ps1
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MIT
+param([Parameter(Mandatory)][string]$Installers)
+$ErrorActionPreference = 'Stop'
+$Root = Join-Path $env:RUNNER_TEMP ('SDK coexistence ' + [guid]::NewGuid())
+$Legacy = [Environment]::GetEnvironmentVariable('ROBOTWEAX_SRT','Machine')
+$Paths = @{}
+$Executables = @{}
+$VS = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+if (!$VS) { throw 'Visual Studio C++ tools are required' }
+$MSBuild = Join-Path $VS 'MSBuild/Current/Bin/MSBuild.exe'
+function Run-Installer([string]$Executable, [string]$Arguments, [bool]$Reject = $false) {
+    $Process = Start-Process -Wait -PassThru $Executable -ArgumentList $Arguments
+    if ($Reject) {
+        if ($Process.ExitCode -eq 0) { throw 'Conflicting installation was accepted' }
+    } elseif ($Process.ExitCode -ne 0) { throw "Installer failed: $($Process.ExitCode)" }
+}
+try {
+    foreach ($Backend in 'openssl','bcrypt') {
+        $Matches = @(Get-ChildItem "$Installers/*-windows-sdk-$Backend.exe")
+        if ($Matches.Count -ne 1) { throw "Expected one $Backend installer" }
+        $Executables[$Backend] = $Matches[0].FullName
+        $Paths[$Backend] = Join-Path $Root $Backend
+    }
+    foreach ($First in 'openssl','bcrypt') {
+        $Second = if ($First -eq 'openssl') { 'bcrypt' } else { 'openssl' }
+        foreach ($Backend in $First,$Second) {
+            $Destination = $Paths[$Backend]
+            Run-Installer $Executables[$Backend] "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /DIR=`"$Destination`""
+            $Variable = 'ROBOTWEAX_SRT_' + $Backend.ToUpperInvariant()
+            if ([Environment]::GetEnvironmentVariable($Variable,'Machine') -ne $Destination) { throw 'Incorrect SDK root' }
+            [xml]$Props = Get-Content "$Destination/srt-backend.props" -Raw
+            if ($Props.Project.PropertyGroup.RobotweaxSrtCryptoBackend -ne $Backend) { throw 'Incorrect installed backend' }
+        }
+        foreach ($Backend in $First,$Second) {
+            # Rebuild through the installed props: no staged SDK or implicit backend selection.
+            & $MSBuild "$PSScriptRoot/consumer/consumer.vcxproj" /nologo /t:Rebuild /p:Configuration=Release /p:Platform=x64 "/p:ROBOTWEAX_SRT=$($Paths[$Backend])"
+            if ($LASTEXITCODE -ne 0) { throw 'Installed SDK consumer build failed' }
+            & "$PSScriptRoot/consumer/out/Release-x64/sdk-consumer.exe"
+            if ($LASTEXITCODE -ne 0) { throw 'Installed SDK consumer failed' }
+        }
+        $Hash = (Get-FileHash "$($Paths[$First])/srt.props").Hash
+        Run-Installer "$($Paths[$Second])/unins000.exe" '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+        # Different backend must not overwrite the remaining SDK's directory.
+        Run-Installer $Executables[$Second] "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /DIR=`"$($Paths[$First])`"" $true
+        if ((Get-FileHash "$($Paths[$First])/srt.props").Hash -ne $Hash) { throw 'Remaining SDK changed' }
+        $Variable = 'ROBOTWEAX_SRT_' + $First.ToUpperInvariant()
+        if ([Environment]::GetEnvironmentVariable($Variable,'Machine') -ne $Paths[$First]) { throw 'Remaining SDK variable changed' }
+        Run-Installer "$($Paths[$First])/unins000.exe" '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+        foreach ($Backend in 'openssl','bcrypt') {
+            $Variable = 'ROBOTWEAX_SRT_' + $Backend.ToUpperInvariant()
+            if ([Environment]::GetEnvironmentVariable($Variable,'Machine')) { throw 'Stale backend environment variable' }
+        }
+    }
+    if ([Environment]::GetEnvironmentVariable('ROBOTWEAX_SRT','Machine') -ne $Legacy) { throw 'Legacy SDK selection modified' }
+    Write-Output 'Both installation orders and independent uninstall passed'
+} finally {
+    foreach ($Path in $Paths.Values) {
+        if (Test-Path "$Path/unins000.exe") {
+            Run-Installer "$Path/unins000.exe" '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+        }
+    }
+}

--- a/packaging/windows/test-package.ps1
+++ b/packaging/windows/test-package.ps1
@@ -25,6 +25,21 @@ try {
             }
         }
         & "$PSScriptRoot/package.ps1" -Variants $Variants -Destination "$Root/valid-$Backend"
+        $Rejected = $false
+        $Other = if ($Backend -eq 'openssl') { 'bcrypt' } else { 'openssl' }
+        try { & "$PSScriptRoot/package.ps1" -Variants $Variants -Destination "$Root/wrong-$Backend" -ExpectedBackend $Other }
+        catch {
+            if ($_.Exception.Message -notmatch 'Unexpected crypto backend') { throw }
+            $Rejected = $true
+        }
+        if (!$Rejected) { throw 'Incorrect installer backend accepted' }
+        foreach ($Variant in Get-ChildItem $Variants -Directory) {
+            Rename-Item $Variant.FullName ($Variant.Name -replace '^sdk-', "sdk-$Backend-")
+        }
+        & "$PSScriptRoot/package.ps1" -Variants $Variants -Destination "$Root/prefixed-$Backend" -ArtifactPrefix "sdk-$Backend" -ExpectedBackend $Backend
+        foreach ($Variant in Get-ChildItem $Variants -Directory) {
+            Rename-Item $Variant.FullName ($Variant.Name -replace "^sdk-$Backend-", 'sdk-')
+        }
     }
     function Expect-Rejection([string]$Name, [string]$Pattern) {
         $Rejected = $false


### PR DESCRIPTION
## Summary
- Build Debug/Release SDKs for Win32, x64 and ARM64 with both OpenSSL and BCrypt.
- Separate installer identities, directories, filenames and backend-specific environment variables; preserve the OpenSSL CMake default.
- Verify backend inventories, installation/reinstallation, both coexistence orders, cross-backend overwrite rejection and installed x64 consumers.
- On version-matching v* tags, attach both installers plus SHA256SUMS to a draft only after packaging tests pass. Never modify a published release or replace existing assets.
- Keep manual/PR builds as candidates; no release or tag created by this PR. Installers remain unsigned and ARM64 runtime acceptance remains outstanding.

## Validation
- YAML parse and matrix sanity: passed locally.
- git diff --check: passed.
- Windows PowerShell, Inno Setup, consumer and install tests: awaiting PR CI.

## CI cost
The old extra BCrypt x64 smoke job is replaced by the full dual-backend packaging matrix. Packaging workflow runs only for packaging PRs, manual dispatches and version tags, not ordinary branch pushes.