### PR TITLE
Improve idle receive readiness and preserve Lite-ACK window credit

### DIFF
--- a/.github/workflows/timing-diagnostics.yml
+++ b/.github/workflows/timing-diagnostics.yml
@@ -13,6 +13,9 @@ on:
           - group-matrix-context
           - group-receive-stack
           - group-strace-stack
+          - throughput-baseline
+          - throughput-cpu
+          - throughput-scheduler
         default: timing
   pull_request:
     paths:
@@ -29,6 +32,98 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  throughput:
+    if: github.event_name == 'workflow_dispatch' && startsWith(inputs.investigation, 'throughput-')
+    name: Linux serial throughput profiling (${{ inputs.investigation }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          path: source
+      - name: Fetch exact reference (runner-local only)
+        uses: actions/checkout@v7
+        with:
+          repository: Haivision/srt
+          ref: 899348d8318eb9a3c5a5b6ec43c4a1114288773a
+          path: reference
+          persist-credentials: false
+      - name: Install build and profiling tools
+        env:
+          INVESTIGATION: ${{ inputs.investigation }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y libssl-dev pkg-config
+          if [[ "$INVESTIGATION" != throughput-baseline ]]; then
+            sudo apt-get install --no-install-recommends -y linux-tools-common linux-tools-generic
+            # Hosted kernels do not always match the distribution perf wrapper.
+            for candidate in /usr/lib/linux-tools/*/perf /usr/lib/linux-tools-*/perf; do
+              if [[ -x "$candidate" ]]; then
+                dirname "$candidate" >> "$GITHUB_PATH"
+                break
+              fi
+            done
+          fi
+      - name: Build Release with symbols, without changing Release optimization
+        run: |
+          python3 source/benchmarks/prepare_throughput.py \
+            --robotweax-source source --reference-source reference \
+            --output-directory "$RUNNER_TEMP/throughput-build" --jobs 2
+      - name: Serial controls or one separately instrumented transfer per direction
+        env:
+          INVESTIGATION: ${{ inputs.investigation }}
+        run: |
+          set -euo pipefail
+          mkdir -p throughput-metadata
+          uname -a > throughput-metadata/kernel.txt
+          lscpu > throughput-metadata/cpu.txt
+          old_rmem="$(sysctl -n net.core.rmem_max)"
+          old_wmem="$(sysctl -n net.core.wmem_max)"
+          printf '%s\n' "$old_rmem" > throughput-metadata/original-rmem-max.txt
+          printf '%s\n' "$old_wmem" > throughput-metadata/original-wmem-max.txt
+          trap 'sudo sysctl -w net.core.rmem_max="$old_rmem" net.core.wmem_max="$old_wmem"' EXIT
+          # Only this ephemeral diagnostic runner is changed, never a user host.
+          sudo sysctl -w net.core.rmem_max=33554432 net.core.wmem_max=33554432
+          capture=none
+          extra=()
+          prefix=()
+          if [[ "$INVESTIGATION" != throughput-baseline ]]; then
+            perf --version > throughput-metadata/perf-version.txt
+            capture="${INVESTIGATION#throughput-}"
+            prefix=(sudo env "PATH=$PATH")
+          fi
+          if [[ "$capture" == scheduler ]]; then
+            extra=(--allow-system-wide)
+          fi
+          "${prefix[@]}" python3 source/benchmarks/throughput_diagnostics.py \
+            --build-manifest "$RUNNER_TEMP/throughput-build/build-manifest.json" \
+            --output-directory "$GITHUB_WORKSPACE/throughput-results" \
+            --capture "$capture" --cooldown-seconds 30 "${extra[@]}"
+      - name: Collect build metadata, never libraries or executables
+        if: always()
+        run: |
+          mkdir -p throughput-metadata
+          for evidence in "$RUNNER_TEMP/throughput-build/"*.json \
+                          "$RUNNER_TEMP/throughput-build/"*.txt \
+                          "$RUNNER_TEMP/throughput-build/"*.log; do
+            if [[ -f "$evidence" ]]; then cp "$evidence" throughput-metadata/; fi
+          done
+      - name: Preserve text evidence including failed transfers and captures
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: throughput-${{ inputs.investigation }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            throughput-results/**/*.json
+            throughput-results/**/*.txt
+            throughput-results/**/*.stdout
+            throughput-results/**/*.stderr
+            throughput-results/**/*.log
+            throughput-metadata/
+          retention-days: 14
+          if-no-files-found: warn
+
   linux:
     if: github.event_name != 'workflow_dispatch' || inputs.investigation == 'timing'
     name: Linux serial timing investigation

--- a/benchmarks/diagnostics/transport_trace.hpp
+++ b/benchmarks/diagnostics/transport_trace.hpp
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Robotweax GmbH
+#pragma once
+
+// Diagnostic overlay only: NOT included by normal library builds. One bounded
+// buffer per participating thread; no file writes, locks or allocation per
+// event. Flush after thread exit (after the measured transfer). Missing files,
+// truncated files and overflow invalidate analysis, never transport behavior.
+#include <atomic>
+#include <chrono>
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <new>
+#include <unistd.h>
+
+namespace robotweax::srt::diagnostics {
+struct TraceEvent {
+    std::uint64_t ns, object;
+    const char* kind;
+    std::uint64_t a, b, c, d;
+};
+
+inline std::atomic<unsigned> trace_thread_counter {0};
+
+class TransportTrace {
+public:
+    TransportTrace() noexcept
+    {
+        const char* directory = std::getenv("ROBOTWEAX_TRANSPORT_TRACE_DIR");
+        if (directory == nullptr || *directory == '\0') {
+            return;
+        }
+        char path[4096];
+        const int length = std::snprintf(path, sizeof(path), "%s/%ld-%u.jsonl",
+            directory, static_cast<long>(getpid()), trace_thread_counter++);
+        if (length < 0 || static_cast<std::size_t>(length) >= sizeof(path)) {
+            return;
+        }
+        file_ = std::fopen(path, "wx");
+        if (file_ == nullptr) {
+            return;
+        }
+        events_.reset(new (std::nothrow) TraceEvent[capacity]);
+        std::fprintf(file_, "{\"schema\":1,\"pid\":%ld,\"capacity\":%zu}\n",
+            static_cast<long>(getpid()), capacity);
+        std::fflush(file_);
+    }
+
+    ~TransportTrace()
+    {
+        if (file_ == nullptr) {
+            return;
+        }
+        for (std::size_t i = 0; i < size_; ++i) {
+            const auto& e = events_[i];
+            std::fprintf(file_,
+                "{\"ns\":%" PRIu64 ",\"object\":%" PRIu64 ",\"kind\":\"%s\","
+                "\"a\":%" PRIu64 ",\"b\":%" PRIu64 ",\"c\":%" PRIu64
+                ",\"d\":%" PRIu64 "}\n",
+                e.ns, e.object, e.kind, e.a, e.b, e.c, e.d);
+        }
+        std::fprintf(file_,
+            "{\"end\":true,\"events\":%zu,\"dropped\":%" PRIu64 "}\n", size_,
+            dropped_);
+        std::fclose(file_);
+    }
+
+    void record(const char* kind, const void* object, std::uint64_t a,
+        std::uint64_t b, std::uint64_t c, std::uint64_t d) noexcept
+    {
+        if (file_ == nullptr) {
+            return;
+        }
+        if (events_ == nullptr || size_ == capacity) {
+            ++dropped_;
+            return;
+        }
+        const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now().time_since_epoch())
+                            .count();
+        events_[size_++] = {static_cast<std::uint64_t>(ns),
+            reinterpret_cast<std::uintptr_t>(object), kind, a, b, c, d};
+    }
+
+private:
+    static constexpr std::size_t capacity = 524288; // 32 MiB per active thread
+    std::unique_ptr<TraceEvent[]> events_;
+    std::FILE* file_ = nullptr;
+    std::size_t size_ = 0;
+    std::uint64_t dropped_ = 0;
+};
+
+inline TransportTrace& thread_trace() noexcept
+{
+    static thread_local TransportTrace buffer;
+    return buffer;
+}
+inline void trace(const char* kind, const void* object, std::uint64_t a = 0,
+    std::uint64_t b = 0, std::uint64_t c = 0, std::uint64_t d = 0) noexcept
+{
+    thread_trace().record(kind, object, a, b, c, d);
+}
+} // namespace robotweax::srt::diagnostics
+
+#define RWX_TRACE(...) ::robotweax::srt::diagnostics::trace(__VA_ARGS__)

--- a/benchmarks/prepare_throughput.py
+++ b/benchmarks/prepare_throughput.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Build identical public-API peers against clean, identified SRT sources.
+
+No downloads, installation, sysctl changes or shared build caches. Reference
+libraries stay local and must not be included in diagnostic artifacts.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+import scalability_scorecard as sc
+
+REFERENCE_REVISION = "899348d8318eb9a3c5a5b6ec43c4a1114288773a"
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def source_identity(path: Path, *, allow_dirty: bool = False) -> dict:
+    revision = subprocess.check_output(
+        ["git", "-C", str(path), "rev-parse", "HEAD"], text=True
+    ).strip()
+    status = subprocess.check_output(
+        ["git", "-C", str(path), "status", "--porcelain"], text=True
+    )
+    if status and not allow_dirty:
+        raise ValueError(f"source tree is dirty: {path}; use a clean worktree")
+    return {"path": str(path), "revision": revision, "dirty": bool(status), "status": status}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--robotweax-source", type=Path, default=ROOT)
+    parser.add_argument("--reference-source", type=Path, required=True)
+    parser.add_argument("--output-directory", type=Path, required=True)
+    parser.add_argument("--linkage", choices=("static", "shared"), default="static")
+    parser.add_argument("--cxx", default=os.environ.get("CXX", "c++"))
+    parser.add_argument("--jobs", type=int, default=2, choices=range(1, 9))
+    parser.add_argument("--allow-dirty-robotweax", action="store_true",
+                        help="development smoke only, recorded in manifest")
+    args = parser.parse_args(argv)
+    if platform.system() not in ("Linux", "Darwin"):
+        parser.error("this diagnostic builder currently supports Linux and macOS")
+    compiler = shutil.which(args.cxx)
+    if not compiler:
+        parser.error("C++ compiler not found")
+    sources = {
+        "robotweax": args.robotweax_source.resolve(strict=True),
+        "haivision": args.reference_source.resolve(strict=True),
+    }
+    identities = {
+        name: source_identity(path, allow_dirty=(name == "robotweax" and args.allow_dirty_robotweax))
+        for name, path in sources.items()
+    }
+    if identities["haivision"]["revision"] != REFERENCE_REVISION:
+        parser.error(f"reference must be the exact Haivision 1.5.7 commit {REFERENCE_REVISION}")
+    out = args.output_directory.resolve()
+    out.mkdir(parents=True, exist_ok=False)
+    manifest = {
+        "schema_version": 1, "complete": False, "sources": identities,
+        "platform": platform.platform(), "architecture": platform.machine(),
+        "linkage": args.linkage, "crypto": "openssl", "commands": [],
+        "harness_source": sc.program_identity(ROOT / "benchmarks/scalability_peer.cpp"),
+        "harness_checkout": source_identity(ROOT, allow_dirty=True),
+        "programs": {}, "libraries": {},
+    }
+
+    def run(command: list[str], label: str) -> str:
+        manifest["commands"].append(command)
+        sc.write_report(out / "build-manifest.json", manifest)
+        with (out / f"{label}.log").open("w") as log:
+            subprocess.run(command, stdout=log, stderr=subprocess.STDOUT, check=True)
+        return (out / f"{label}.log").read_text()
+
+    try:
+        run([compiler, "--version"], "compiler")
+        run(["cmake", "--version"], "cmake")
+        crypto_flags = shlex.split(run(["pkg-config", "--cflags", "--libs", "libcrypto"], "crypto-flags"))
+        run(["openssl", "version", "-a"], "openssl")
+        shared = args.linkage == "shared"
+        suffix = (".dylib" if platform.system() == "Darwin" else ".so") if shared else ".a"
+        for name, source in sources.items():
+            build = out / f"{name}-build"
+            flags = ["-DCMAKE_BUILD_TYPE=Release", "-DCMAKE_CXX_FLAGS=-g",
+                     "-DCMAKE_C_FLAGS=-g", f"-DCMAKE_CXX_COMPILER={compiler}"]
+            if name == "robotweax":
+                flags += [f"-DBUILD_SHARED_LIBS={'ON' if shared else 'OFF'}",
+                          "-DROBOTWEAX_SRT_CRYPTO_BACKEND=openssl",
+                          "-DROBOTWEAX_SRT_BUILD_TESTS=OFF",
+                          "-DROBOTWEAX_SRT_BUILD_TOOLS=OFF",
+                          "-DROBOTWEAX_SRT_BUILD_BENCHMARKS=OFF",
+                          "-DROBOTWEAX_SRT_BUILD_EXAMPLES=OFF"]
+                includes = [source / "include", build]
+                library = build / f"librobotweax-srt{suffix}"
+                program = out / "rwx-capacity"
+            else:
+                flags += [f"-DENABLE_SHARED={'ON' if shared else 'OFF'}",
+                          f"-DENABLE_STATIC={'OFF' if shared else 'ON'}",
+                          "-DENABLE_ENCRYPTION=ON", "-DUSE_ENCLIB=openssl",
+                          "-DENABLE_BONDING=ON", "-DENABLE_APPS=OFF", "-DENABLE_TESTING=OFF"]
+                includes = [source / "srtcore", build]
+                library = build / f"libsrt{suffix}"
+                program = out / "hvs-capacity"
+            run(["cmake", "-S", str(source), "-B", str(build), *flags], f"{name}-configure")
+            run(["cmake", "--build", str(build), "--parallel", str(args.jobs)], f"{name}-build")
+            shutil.copyfile(build / "CMakeCache.txt", out / f"{name}-cache.txt")
+            command = [compiler, "-std=c++17", "-O2", "-g", "-Wall", "-Wextra", "-Werror",
+                       str(ROOT / "benchmarks/scalability_peer.cpp"),
+                       *[f"-I{path}" for path in includes], str(library), *crypto_flags, "-pthread"]
+            if platform.system() == "Linux":
+                command += ["-ldl"]
+            if shared:
+                command += [f"-Wl,-rpath,{build}"]
+            run([*command, "-o", str(program)], f"{name}-peer")
+            manifest["programs"][name] = sc.program_identity(program)
+            manifest["libraries"][name] = sc.program_identity(library)
+            loader = ["otool", "-L"] if platform.system() == "Darwin" else ["ldd"]
+            run([*loader, str(program)], f"{name}-loader")
+        manifest["complete"] = True
+        print(json.dumps({"build_manifest": str(out / "build-manifest.json"), "complete": True}))
+        return 0
+    finally:
+        sc.write_report(out / "build-manifest.json", manifest)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/prepare_throughput.py
+++ b/benchmarks/prepare_throughput.py
@@ -16,6 +16,7 @@ import subprocess
 from pathlib import Path
 
 import scalability_scorecard as sc
+import retransmission_trace as rt
 
 REFERENCE_REVISION = "899348d8318eb9a3c5a5b6ec43c4a1114288773a"
 ROOT = Path(__file__).resolve().parents[1]
@@ -43,9 +44,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--jobs", type=int, default=2, choices=range(1, 9))
     parser.add_argument("--allow-dirty-robotweax", action="store_true",
                         help="development smoke only, recorded in manifest")
+    parser.add_argument("--transport-trace", action="store_true",
+                        help="instrument a fresh committed-source export; never a capacity result")
     args = parser.parse_args(argv)
     if platform.system() not in ("Linux", "Darwin"):
         parser.error("this diagnostic builder currently supports Linux and macOS")
+    if args.transport_trace and args.allow_dirty_robotweax:
+        parser.error("transport overlay requires a clean committed Robotweax source")
     compiler = shutil.which(args.cxx)
     if not compiler:
         parser.error("C++ compiler not found")
@@ -78,6 +83,11 @@ def main(argv: list[str] | None = None) -> int:
         return (out / f"{label}.log").read_text()
 
     try:
+        if args.transport_trace:
+            exported = out / "robotweax-traced-source"
+            manifest["transport_trace"] = rt.export_overlay(
+                sources["robotweax"], identities["robotweax"]["revision"], exported)
+            sources["robotweax"] = exported
         run([compiler, "--version"], "compiler")
         run(["cmake", "--version"], "cmake")
         crypto_flags = shlex.split(run(["pkg-config", "--cflags", "--libs", "libcrypto"], "crypto-flags"))

--- a/benchmarks/retransmission_trace.py
+++ b/benchmarks/retransmission_trace.py
@@ -37,7 +37,16 @@ HOOKS = {
         ("    , peer_socket_id_(configuration.peer_socket_id)\n{\n",
          '    , peer_socket_id_(configuration.peer_socket_id)\n{\n'
          '    RWX_TRACE("bind", this, reinterpret_cast<std::uintptr_t>(&send_buffer_),\n'
-         '        configuration.local_initial_sequence.value(), peer_socket_id_);\n'),
+         '        configuration.local_initial_sequence.value(), peer_socket_id_,\n'
+         '        reinterpret_cast<std::uintptr_t>(&receive_buffer_));\n'),
+        ("        const auto inserted = receive_buffer_.insert(packet);\n",
+         '        RWX_TRACE("rx_window", this, packet.data.sequence.value(),\n'
+         '            receive_buffer_.first_stored_sequence().value(),\n'
+         '            receive_buffer_.occupied(), receive_buffer_.capacity());\n'
+         "        const auto inserted = receive_buffer_.insert(packet);\n"
+         '        RWX_TRACE("rx_insert", this, packet.data.sequence.value(),\n'
+         '            static_cast<std::uint64_t>(inserted.status),\n'
+         '            static_cast<std::uint64_t>(inserted.error), packet.data.retransmitted);\n'),
         ("        // Repeated ACKs can update the receive window while a lost flight\n",
          '        RWX_TRACE("ack_state", this, decoded.acknowledgement.next_sequence.value(),\n'
          '            send_buffer_.packets_in_flight(), acknowledgement_progress > 0, now_microseconds);\n'
@@ -67,6 +76,16 @@ HOOKS = {
          '        periodic_nak_enabled_);\n'
          "    // A periodic NAK can select only a gap exposed by later DATA. It cannot\n"),
     ],
+    "src/receive_buffer.cpp": [
+        ("    return {\n        .bytes_written = written,\n        .message_number = message_number,\n        .first_sequence = message_first_sequence,\n",
+         '    RWX_TRACE("rx_pop", this, first_stored_sequence_.value(), occupied_,\n'
+         '        next_ack_sequence_.value(), written);\n'
+         "    return {\n        .bytes_written = written,\n        .message_number = message_number,\n        .first_sequence = message_first_sequence,\n"),
+        ("    return {\n        .bytes_written = written,\n        .message_number = message_number,\n        .first_sequence = first_sequence,\n",
+         '    RWX_TRACE("rx_pop", this, first_stored_sequence_.value(), occupied_,\n'
+         '        next_ack_sequence_.value(), written);\n'
+         "    return {\n        .bytes_written = written,\n        .message_number = message_number,\n        .first_sequence = first_sequence,\n"),
+    ],
     "src/compat/transport_runtime.cpp": [
         ("    const std::size_t application_payload_size = authenticated_data\n",
          '    RWX_TRACE("wire_send", &session_, packet.header.sequence.value(),\n'
@@ -78,6 +97,13 @@ HOOKS = {
          '        RWX_TRACE("data_receive", &session_, clear_packet.data.sequence.value(),\n'
          '            clear_packet.data.retransmitted, static_cast<std::uint64_t>(processed.error), now);\n'
          '    }\n'),
+        ("    if (packet.kind == PacketKind::data) {\n        sample_receiver_buffer_statistics(now);\n",
+         '    if (clear_packet.kind == PacketKind::control\n'
+         '        && clear_packet.control.type == ControlType::acknowledgement) {\n'
+         '        RWX_TRACE("tx_window", &session_, session_.send_buffer().first_sequence().value(),\n'
+         '            flow_window_packets_, session_.send_buffer().packets_in_flight(), now);\n'
+         '    }\n'
+         "    if (packet.kind == PacketKind::data) {\n        sample_receiver_buffer_statistics(now);\n"),
     ],
 }
 
@@ -138,11 +164,47 @@ def read_events(directory: Path) -> list[dict]:
     return sorted(events, key=lambda e: (e["ns"], e["file"], e["index"]))
 
 
+def receive_evidence(events: list[dict], receiver_pid: int) -> tuple[dict, dict]:
+    """Insertion status is evidence of acceptance; Error::none alone is not."""
+    statuses = ("accepted_in_order", "accepted_out_of_order", "duplicate",
+                "older_than_window", "beyond_window")
+    windows, insertions, accepted = {}, {}, set()
+    counts, errors, pop_count, popped_bytes = Counter(), [], 0, 0
+    buffers = {e["d"] for e in events if e["pid"] == receiver_pid and e["kind"] == "bind" and e["d"]}
+    for e in events:
+        if e["pid"] != receiver_pid:
+            continue
+        key = (e["object"], e["a"])
+        if e["kind"] == "rx_window":
+            windows[key] = e
+        elif e["kind"] == "rx_insert":
+            window = windows.pop(key, None)
+            if window is None:
+                errors.append("receive insertion without pre-insert window")
+            status = statuses[e["b"]] if 0 <= e["b"] < len(statuses) else "unknown"
+            if status == "unknown":
+                errors.append("unknown receive insertion status")
+            counts[status if e["c"] == 0 else "error"] += 1
+            if e["c"] == 0 and e["b"] in (0, 1):
+                accepted.add(key)
+            insertions.setdefault(e["a"], []).append({"event": e, "status": status, "window_before": window})
+        elif e["kind"] == "rx_pop":
+            if e["object"] not in buffers:
+                errors.append("unmapped receive-buffer pop")
+            pop_count += 1
+            popped_bytes += e["d"]
+    if windows:
+        errors.append("receive window without insertion outcome")
+    return {"available": bool(insertions), "errors": sorted(set(errors)),
+            "insert_status_counts": dict(counts), "accepted_unique_sequences": len(accepted),
+            "pop_events": pop_count, "popped_bytes": popped_bytes}, insertions
+
+
 def analyze_events(events: list[dict], sender_pid: int, expected_originals: int,
                    expected_retransmissions: int) -> dict:
     mapping = {(e["pid"], e["a"]): e["object"] for e in events if e["kind"] == "bind"}
     causes, pending, selected, originals, latest_ack, latest_timer = {}, {}, {}, {}, {}, {}
-    latest_nak, latest_ack_state = {}, {}
+    latest_nak, latest_ack_state, latest_window = {}, {}, {}
     rows, errors = [], []
     counts = Counter()
     wire_originals = []
@@ -178,6 +240,8 @@ def analyze_events(events: list[dict], sender_pid: int, expected_originals: int,
             latest_ack[session] = e
         elif kind == "ack_state":
             latest_ack_state[session] = e
+        elif kind == "tx_window":
+            latest_window[session] = e
         elif kind == "nak":
             latest_nak[session] = e
         elif kind == "timer":
@@ -192,7 +256,8 @@ def analyze_events(events: list[dict], sender_pid: int, expected_originals: int,
                     errors.append("retransmission without original/request/selection")
                 rows.append({"sequence": e["a"], "session": session, "send": e,
                              "original": originals.get(key), "lineage": lineage,
-                             "latest_ack": latest_ack.get(session), "ack_state": latest_ack_state.get(session)})
+                             "latest_ack": latest_ack.get(session), "ack_state": latest_ack_state.get(session),
+                             "applied_send_window": latest_window.get(session)})
     if len(wire_originals) != expected_originals:
         errors.append(f"original coverage {len(wire_originals)} != {expected_originals}")
     if len(rows) != expected_retransmissions:
@@ -226,10 +291,19 @@ def analyze_case(directory: Path, result: dict) -> dict:
         analysis = analyze_events(events, sender_pid, stats["pktSentUniqueTotal"], stats["pktRetransTotal"])
         receiver_pid = result["peer_process_resources"]["receiver"]["pid"]
         if result["receiver_implementation"] == "robotweax":
-            receiver_events = [e for e in events if e["pid"] == receiver_pid and e["kind"] == "data_receive" and e["c"] == 0]
-            if len({e["a"] for e in receiver_events}) != result["messages_per_connection"]:
-                analysis["errors"].append("incomplete Robotweax receive-sequence coverage")
-                analysis["valid"] = False
+            evidence, insertions = receive_evidence(events, receiver_pid)
+            analysis["receiver_evidence"] = evidence
+            analysis["errors"].extend(evidence["errors"])
+            if not evidence["available"] or evidence["accepted_unique_sequences"] != result["messages_per_connection"]:
+                analysis["errors"].append("incomplete Robotweax accepted receive-sequence coverage")
+            if evidence["popped_bytes"] != result["messages_per_connection"] * result["message_size_bytes"]:
+                analysis["errors"].append("incomplete Robotweax application-pop coverage")
+            for row in analysis["retransmissions"]:
+                row["receiver_insertions"] = insertions.get(row["sequence"], [])
+        if not analysis["counts"].get("tx_window"):
+            analysis["errors"].append("missing applied sender-window evidence")
+        analysis["valid"] = not analysis["errors"]
+        analysis["receiver_observations_semantics"] = "legacy data_receive/Error::none is processing, not proof of insertion"
         sc.write_report(directory / "retransmissions.json", analysis)
         return {key: value for key, value in analysis.items() if key != "retransmissions"}
     except (ValueError, KeyError, OSError, StopIteration) as error:

--- a/benchmarks/retransmission_trace.py
+++ b/benchmarks/retransmission_trace.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Private, bounded transport diagnostic overlay and fail-closed trace analysis.
+
+Normal sources/ABI are untouched. The builder exports an exact clean revision
+and instruments only that fresh copy, recording original/patched hashes. Never
+compare its throughput with an uninstrumented build as a performance result.
+"""
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import zipfile
+from collections import Counter
+from pathlib import Path
+
+import scalability_scorecard as sc
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Exact, unique anchors: fail rather than silently instrument a different path.
+HOOKS = {
+    "src/send_buffer.cpp": [
+        ("    slot->retransmission_queued = true;\n",
+         '    slot->retransmission_queued = true;\n    RWX_TRACE("queued", this, sequence.value());\n'),
+        ("        header.retransmitted = true;\n",
+         '        header.retransmitted = true;\n        RWX_TRACE("selected", this, sequence.value());\n'),
+        ("    const Error validation = validate_retransmission_range(range);\n",
+         '    RWX_TRACE("request_nak", this, range.first.value(), range.last.value());\n'
+         "    const Error validation = validate_retransmission_range(range);\n"),
+        ("bool SendBuffer::request_retransmission_of_last_sent() noexcept\n{\n",
+         'bool SendBuffer::request_retransmission_of_last_sent() noexcept\n{\n    RWX_TRACE("request_tail", this);\n'),
+        ("std::size_t SendBuffer::request_retransmission_of_all_sent() noexcept\n{\n",
+         'std::size_t SendBuffer::request_retransmission_of_all_sent() noexcept\n{\n    RWX_TRACE("request_all", this);\n'),
+    ],
+    "src/session.cpp": [
+        ("    , peer_socket_id_(configuration.peer_socket_id)\n{\n",
+         '    , peer_socket_id_(configuration.peer_socket_id)\n{\n'
+         '    RWX_TRACE("bind", this, reinterpret_cast<std::uintptr_t>(&send_buffer_),\n'
+         '        configuration.local_initial_sequence.value(), peer_socket_id_);\n'),
+        ("        // Repeated ACKs can update the receive window while a lost flight\n",
+         '        RWX_TRACE("ack_state", this, decoded.acknowledgement.next_sequence.value(),\n'
+         '            send_buffer_.packets_in_flight(), acknowledgement_progress > 0, now_microseconds);\n'
+         "        // Repeated ACKs can update the receive window while a lost flight\n"),
+        ("        return result;\n    }\n    case ControlType::negative_acknowledgement: {\n",
+         '        RWX_TRACE("ack", this, decoded.acknowledgement.next_sequence.value(),\n'
+         '            static_cast<std::uint64_t>(decoded.acknowledgement.kind),\n'
+         '            rtt_.smoothed_microseconds(), rtt_.variation_microseconds());\n'
+         '        RWX_TRACE("ack_peer", this, decoded.acknowledgement.next_sequence.value(),\n'
+         '            decoded.acknowledgement.round_trip_time_microseconds,\n'
+         '            decoded.acknowledgement.round_trip_time_variance_microseconds,\n'
+         '            decoded.acknowledgement.available_receive_buffer_packets);\n'
+         "        return result;\n    }\n    case ControlType::negative_acknowledgement: {\n"),
+        ("            std::size_t newly_queued_packets = 0;\n",
+         '            RWX_TRACE("nak", this, loss.range.first.value(), loss.range.last.value(),\n'
+         '                send_buffer_.first_sequence().value(), now_microseconds);\n'
+         "            std::size_t newly_queued_packets = 0;\n"),
+        ("    if (!sender_retransmission_timer_.poll(\n",
+         '    const auto diagnostic_deadline = sender_retransmission_timer_.next_deadline(\n'
+         '        rtt_.smoothed_microseconds(), rtt_.variation_microseconds());\n'
+         "    if (!sender_retransmission_timer_.poll(\n"),
+        ("    // A periodic NAK can select only a gap exposed by later DATA. It cannot\n",
+         '    RWX_TRACE("timer", this, diagnostic_deadline.value_or(0), now_microseconds,\n'
+         '        rtt_.smoothed_microseconds(), rtt_.variation_microseconds());\n'
+         '    RWX_TRACE("timer_state", this, send_buffer_.first_sequence().value(),\n'
+         '        send_buffer_.packets_in_flight(), sender_retransmission_timer_.timeout_multiplier(),\n'
+         '        periodic_nak_enabled_);\n'
+         "    // A periodic NAK can select only a gap exposed by later DATA. It cannot\n"),
+    ],
+    "src/compat/transport_runtime.cpp": [
+        ("    const std::size_t application_payload_size = authenticated_data\n",
+         '    RWX_TRACE("wire_send", &session_, packet.header.sequence.value(),\n'
+         '        packet.header.retransmitted, packet.payload.size(), now);\n'
+         "    const std::size_t application_payload_size = authenticated_data\n"),
+        ("    const auto processed = session_.receive(\n        clear_packet, now, context);\n",
+         "    const auto processed = session_.receive(\n        clear_packet, now, context);\n"
+         '    if (clear_packet.kind == PacketKind::data) {\n'
+         '        RWX_TRACE("data_receive", &session_, clear_packet.data.sequence.value(),\n'
+         '            clear_packet.data.retransmitted, static_cast<std::uint64_t>(processed.error), now);\n'
+         '    }\n'),
+    ],
+}
+
+
+def instrument(text: str, hooks: list[tuple[str, str]]) -> str:
+    if "RWX_TRACE" in text:
+        raise ValueError("source already instrumented")
+    for before, after in hooks:
+        if text.count(before) != 1:
+            raise ValueError(f"diagnostic anchor missing or ambiguous: {before!r}")
+        text = text.replace(before, after, 1)
+    return text
+
+
+def export_overlay(source: Path, revision: str, destination: Path) -> dict:
+    """Export committed files only; never patch the user's checkout."""
+    archive = subprocess.check_output(["git", "-C", str(source), "archive", "--format=zip", revision])
+    destination.mkdir(exist_ok=False)
+    with zipfile.ZipFile(io.BytesIO(archive)) as files:
+        for item in files.infolist():
+            path = Path(item.filename)
+            if path.is_absolute() or ".." in path.parts or (item.external_attr >> 16) & 0o170000 == 0o120000:
+                raise ValueError("unexpected path or symlink in source export")
+        files.extractall(destination)
+        for item in files.infolist():
+            if not item.is_dir():
+                (destination / item.filename).chmod(((item.external_attr >> 16) & 0o777) or 0o644)
+    changes = {}
+    for relative, hooks in HOOKS.items():
+        path = destination / relative
+        before = sc.file_sha256(path)
+        prefix = "../" if "/compat/" in relative else ""
+        text = f'#include "{prefix}diagnostic_transport_trace.hpp"\n' + instrument(path.read_text(), hooks)
+        path.write_text(text)
+        changes[relative] = {"original_sha256": before, "patched_sha256": sc.file_sha256(path)}
+    header = ROOT / "benchmarks/diagnostics/transport_trace.hpp"
+    (destination / "src/diagnostic_transport_trace.hpp").write_bytes(header.read_bytes())
+    return {"enabled": True, "source_revision": revision, "source_export": str(destination),
+            "changes": changes, "overlay_script": sc.program_identity(Path(__file__).resolve()),
+            "collector_header": sc.program_identity(header), "capacity_per_thread": 524288}
+
+
+def read_events(directory: Path) -> list[dict]:
+    events = []
+    paths = sorted(directory.glob("*.jsonl"))
+    if not paths:
+        raise ValueError("no transport trace files")
+    for path in paths:
+        lines = [json.loads(line) for line in path.read_text().splitlines()]
+        if len(lines) < 2 or lines[0].get("schema") != 1 or lines[-1].get("end") is not True:
+            raise ValueError(f"missing trace header/trailer: {path.name}")
+        if lines[-1].get("dropped") != 0 or lines[-1].get("events") != len(lines) - 2:
+            raise ValueError(f"overflow or incomplete trace: {path.name}")
+        for index, event in enumerate(lines[1:-1]):
+            if not all(isinstance(event.get(key), int) for key in ("ns", "object", "a", "b", "c", "d")):
+                raise ValueError("invalid transport trace event")
+            events.append({**event, "pid": lines[0]["pid"], "file": path.name, "index": index})
+    return sorted(events, key=lambda e: (e["ns"], e["file"], e["index"]))
+
+
+def analyze_events(events: list[dict], sender_pid: int, expected_originals: int,
+                   expected_retransmissions: int) -> dict:
+    mapping = {(e["pid"], e["a"]): e["object"] for e in events if e["kind"] == "bind"}
+    causes, pending, selected, originals, latest_ack, latest_timer = {}, {}, {}, {}, {}, {}
+    latest_nak, latest_ack_state = {}, {}
+    rows, errors = [], []
+    counts = Counter()
+    wire_originals = []
+    received = {}
+    for e in events:
+        if e["kind"] == "data_receive" and e["pid"] != sender_pid and e["c"] == 0:
+            received.setdefault(e["a"], []).append(e)
+        if e["pid"] != sender_pid:
+            continue
+        kind = e["kind"]
+        buffer_event = kind.startswith("request_") or kind in ("queued", "selected")
+        session = mapping.get((sender_pid, e["object"])) if buffer_event else e["object"]
+        if session is None:
+            errors.append("unmapped send buffer")
+            continue
+        key = (session, e["a"])
+        counts[kind] += 1
+        if kind.startswith("request_"):
+            causes[session] = e
+        elif kind == "queued":
+            # Only a newly inserted queue entry has this event. Repeated NAKs
+            # must NOT overwrite the first enqueue cause of a pending packet.
+            cause = causes.get(session)
+            if cause is None:
+                errors.append("queue entry without request")
+            trigger = latest_nak.get(session) if cause and cause["kind"] == "request_nak" else latest_timer.get(session)
+            if trigger is None:
+                errors.append("queue request without accepted NAK or elapsed timer")
+            pending[key] = {"request": cause, "queued": e, "trigger": trigger}
+        elif kind == "selected":
+            selected[key] = pending.pop(key, None)
+        elif kind == "ack":
+            latest_ack[session] = e
+        elif kind == "ack_state":
+            latest_ack_state[session] = e
+        elif kind == "nak":
+            latest_nak[session] = e
+        elif kind == "timer":
+            latest_timer[session] = e
+        elif kind == "wire_send":
+            if not e["b"]:
+                originals[key] = e
+                wire_originals.append(e)
+            else:
+                lineage = selected.pop(key, None)
+                if not lineage or not lineage.get("request") or key not in originals:
+                    errors.append("retransmission without original/request/selection")
+                rows.append({"sequence": e["a"], "session": session, "send": e,
+                             "original": originals.get(key), "lineage": lineage,
+                             "latest_ack": latest_ack.get(session), "ack_state": latest_ack_state.get(session)})
+    if len(wire_originals) != expected_originals:
+        errors.append(f"original coverage {len(wire_originals)} != {expected_originals}")
+    if len(rows) != expected_retransmissions:
+        errors.append(f"retransmission coverage {len(rows)} != {expected_retransmissions}")
+    if not latest_ack:
+        errors.append("no accepted sender ACKs")
+    reasons = Counter()
+    for row in rows:
+        request = (row["lineage"] or {}).get("request")
+        reason = request["kind"].removeprefix("request_") if request else "unknown"
+        reasons[reason] += 1
+        row["reason"] = reason
+        row["receiver_observations"] = received.get(row["sequence"], [])
+        ack = row["latest_ack"]
+        row["ack_age_us"] = (row["send"]["ns"] - ack["ns"]) / 1000 if ack else None
+        original = row["original"]
+        row["original_age_us"] = (row["send"]["ns"] - original["ns"]) / 1000 if original else None
+    return {"valid": not errors, "errors": sorted(set(errors)), "counts": dict(counts),
+            "retransmission_reasons": dict(reasons), "retransmissions": rows,
+            "original_packets": len(wire_originals), "retransmitted_packets": len(rows),
+            "scope": "single cleartext connection; successful userspace UDP sends, not a network loss rate; Haivision receiver internals uninstrumented"}
+
+
+def analyze_case(directory: Path, result: dict) -> dict:
+    try:
+        events = read_events(directory / "transport-trace")
+        sender_pid = result["peer_process_resources"]["sender"]["pid"]
+        caller = next(e for e in sc.parse_json_events(sc.read_output(directory / "many-socket-caller.stdout"))
+                      if e.get("event") == "complete")
+        stats = caller["stats"]
+        analysis = analyze_events(events, sender_pid, stats["pktSentUniqueTotal"], stats["pktRetransTotal"])
+        receiver_pid = result["peer_process_resources"]["receiver"]["pid"]
+        if result["receiver_implementation"] == "robotweax":
+            receiver_events = [e for e in events if e["pid"] == receiver_pid and e["kind"] == "data_receive" and e["c"] == 0]
+            if len({e["a"] for e in receiver_events}) != result["messages_per_connection"]:
+                analysis["errors"].append("incomplete Robotweax receive-sequence coverage")
+                analysis["valid"] = False
+        sc.write_report(directory / "retransmissions.json", analysis)
+        return {key: value for key, value in analysis.items() if key != "retransmissions"}
+    except (ValueError, KeyError, OSError, StopIteration) as error:
+        return {"valid": False, "error": str(error)}

--- a/benchmarks/run_plain_capacity_ab.py
+++ b/benchmarks/run_plain_capacity_ab.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Fixed-pin, uninstrumented Linux ARM64 ABBA after the Lite-ACK correction.
+
+Forty serial transfers, no builds, sysctl changes, retries or automatic
+performance/release approval. Preserve failed blocks and their raw evidence.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import platform
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+import prepare_throughput as build
+import scalability_scorecard as sc
+import throughput_diagnostics as diag
+
+REVISIONS = {
+    "baseline": "a5c428b725b5373651041b0e30678406b2d5c38c",
+    "candidate": "09c852b40374d21e60e68b8aadaaabb5aa7294b8",
+}
+PEER_SHA256 = "faf487b34f5661e4dc602130628ed216b8054a2ab364abcc275bdda1d826d2ae"
+PROFILES = ["robotweax-self", "robotweax-to-haivision"]
+ARGUMENTS = {
+    "capture": "none", "repetitions": 3, "warmups": 1,
+    "bytes_per_connection": 128 * 1024**2, "target_bps": 0,
+    "pacing_burst_packets": 0, "pending_packets": 8192,
+    "udp_buffer": 8 * 1024**2, "timeout_seconds": 45, "cooldown_seconds": 30,
+}
+UDP_ERRORS = ("InErrors", "RcvbufErrors", "SndbufErrors", "InCsumErrors")
+
+
+def plan() -> list[str]:
+    return ["baseline", "candidate", "candidate", "baseline"]
+
+
+def cases() -> list[dict]:
+    return diag.case_plan(PROFILES, 3, 1, True, "none")
+
+
+def validate_manifests(manifests: dict, harness: dict, environment: dict) -> None:
+    if set(manifests) != set(REVISIONS):
+        raise ValueError("exactly two plain build manifests are required")
+    if harness.get("dirty") is not False:
+        raise ValueError("run from a clean committed harness checkout")
+    for variant, manifest in manifests.items():
+        if manifest.get("complete") is not True:
+            raise ValueError("incomplete build")
+        for library, revision in (("robotweax", REVISIONS[variant]),
+                                  ("haivision", build.REFERENCE_REVISION)):
+            source = manifest["sources"][library]
+            if source.get("dirty") is not False or source.get("revision") != revision:
+                raise ValueError(f"unexpected/dirty {variant} {library} source")
+        if manifest.get("transport_trace", {}).get("enabled", False) is not False:
+            raise ValueError("instrumented builds cannot produce plain capacity evidence")
+        if manifest.get("crypto") != "openssl" or manifest.get("linkage") != "static":
+            raise ValueError("this follow-up requires the original static OpenSSL build profile")
+        if any(manifest.get(key) != environment[key] for key in ("platform", "architecture")):
+            raise ValueError("build and measurement platform mismatch")
+        checkout = manifest["harness_checkout"]
+        if checkout.get("dirty") is not False or checkout.get("revision") != harness["revision"]:
+            raise ValueError("both builds and runner must use the same clean harness revision")
+        if manifest["harness_source"]["sha256"] != PEER_SHA256:
+            raise ValueError("public peer differs from the previously measured harness")
+        if any(set(manifest[key]) != {"robotweax", "haivision"} for key in ("programs", "libraries")):
+            raise ValueError("both peers and libraries are required")
+
+
+def validate_build_files(paths: dict, manifests: dict) -> dict:
+    """Check binaries now (diagnostics rechecks per block) and toolchain evidence."""
+    signatures = {}
+    for variant, path in paths.items():
+        manifest = manifests[variant]
+        for identity in [*manifest["programs"].values(), *manifest["libraries"].values()]:
+            if sc.file_sha256(Path(identity["path"])) != identity["sha256"]:
+                raise ValueError("peer/library changed since build")
+        root = path.parent
+        signatures[variant] = {name: sc.file_sha256(root / name) for name in
+                               ("compiler.log", "cmake.log", "openssl.log", "crypto-flags.log")}
+        for library in ("robotweax", "haivision"):
+            cache = {}
+            for line in (root / f"{library}-cache.txt").read_text().splitlines():
+                if "=" in line and ":" in line and not line.startswith(("//", "#")):
+                    key, value = line.split("=", 1)
+                    cache[key.split(":", 1)[0]] = value
+            expected = {"CMAKE_BUILD_TYPE": "Release", "CMAKE_C_FLAGS": "-g", "CMAKE_CXX_FLAGS": "-g",
+                        "CMAKE_C_FLAGS_RELEASE": "-O3 -DNDEBUG", "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG"}
+            if any(cache.get(key) != value for key, value in expected.items()):
+                raise ValueError("unexpected Release flags; retain evidence and review the build")
+            signatures[variant][f"{library}-compilers"] = [cache.get(f"CMAKE_{language}_COMPILER")
+                                                         for language in ("C", "CXX")]
+            if not all(signatures[variant][f"{library}-compilers"]):
+                raise ValueError("missing compiler identity in CMake cache")
+    if signatures["baseline"] != signatures["candidate"]:
+        raise ValueError("A/B compiler or OpenSSL configuration differs")
+    return signatures
+
+
+def number(value, *, integer: bool = False, positive: bool = False) -> bool:
+    return (type(value) in ((int,) if integer else (int, float))
+            and math.isfinite(value) and value >= (1 if positive else 0))
+
+
+def analyze_block(report: dict, manifest: dict, exit_code: int) -> dict:
+    """Missing/partial evidence is a failure, never an inferred zero count."""
+    errors, rows = [], []
+    if exit_code != 0 or report.get("finished") is not True or report.get("all_transfers_pass") is not True:
+        errors.append("diagnostic block did not finish successfully")
+    if report.get("capture") != "none" or report.get("udp_capacity_controlled") is not True:
+        errors.append("not an uninstrumented UDP-capacity-controlled block")
+    arguments = report.get("arguments", {})
+    if (any(arguments.get(key) != value for key, value in ARGUMENTS.items())
+            or arguments.get("profile") != PROFILES
+            or arguments.get("allow_small_udp_buffers") is not False):
+        errors.append("measurement arguments changed")
+    if report.get("build_manifest") != manifest:
+        errors.append("reported build differs from preflight manifest")
+    runs = report.get("runs", [])
+    if len(runs) != len(cases()):
+        errors.append("missing or extra transfers")
+    packets = math.ceil(ARGUMENTS["bytes_per_connection"] / 1316)
+    for index, entry in enumerate(runs):
+        problems = []
+        if index >= len(cases()) or any(entry.get(key) != value for key, value in cases()[index].items()):
+            problems.append("unexpected case order/profile/kind")
+        if entry.get("index") != index or entry.get("exit_code") != 0 or entry.get("transfer_pass") is not True:
+            problems.append("failed/incomplete transfer")
+        result = entry.get("result", {})
+        integrity = result.get("integrity", {})
+        if (integrity.get("deterministic_payload_verified") is not True
+                or integrity.get("verified_connections") != 1
+                or result.get("connections") != 1 or result.get("message_size_bytes") != 1316
+                or result.get("requested_bytes_per_connection") != ARGUMENTS["bytes_per_connection"]
+                or result.get("messages_per_connection") != packets
+                or result.get("bytes_per_connection") != packets * 1316):
+            problems.append("payload/transfer contract not proven")
+        wire = result.get("wire_statistics", {})
+        repeats = wire.get("retransmitted_packets")
+        original = wire.get("sender_packets_unique")
+        if (not number(repeats, integer=True) or not number(original, integer=True, positive=True)
+                or original != packets or wire.get("receiver_packets_unique") != packets
+                or wire.get("sender_packets_total") != original + repeats):
+            problems.append("missing/inconsistent public packet counters")
+        elif repeats != 0:
+            problems.append("nonzero retransmissions: retain and investigate")
+        udp = entry.get("system_udp_delta", {})
+        if any(type(udp.get(key)) is not int or udp[key] != 0 for key in UDP_ERRORS):
+            problems.append("missing/nonzero host UDP error deltas")
+        for role in ("caller", "listener"):
+            options = result.get("capacity_options", {}).get(role, [])
+            expected = {"encryption": "none", "tlpktdrop": False, "pending_packets": 8192,
+                        "requested_maxbw_bytes_per_second": 1250000000, "target_bits_per_second": 0,
+                        "api_fc": 16384, "api_udp_rcvbuf": ARGUMENTS["udp_buffer"],
+                        "api_udp_sndbuf": ARGUMENTS["udp_buffer"]}
+            if len(options) != 1 or any(options[0].get(key) != value for key, value in expected.items()):
+                problems.append(f"{role} capacity-option contract missing/changed")
+        rate = result.get("rates", {}).get("useful_bits_per_second")
+        cpu = result.get("peer_process_resources", {}).get("sender") or {}
+        user, system = cpu.get("user_cpu_us"), cpu.get("system_cpu_us")
+        if not number(rate, positive=True) or not number(user) or not number(system):
+            problems.append("missing/nonfinite throughput or sender CPU observation")
+        row = {"index": index, "kind": entry.get("kind"), "profile": entry.get("profile"),
+               "transfer_pass": entry.get("transfer_pass") is True and entry.get("exit_code") == 0,
+               "mbps": rate / 1e6 if number(rate, positive=True) else None,
+               "sender_cpu_seconds": (user + system) / 1e6 if number(user) and number(system) else None,
+               "original_packets": original, "retransmitted_packets": repeats,
+               "retransmission_ratio": repeats / original if number(repeats, integer=True) and number(original, integer=True, positive=True) else None,
+               "system_udp_delta": udp, "errors": problems}
+        rows.append(row)
+        errors.extend(f"case {index}: {problem}" for problem in problems)
+    summaries = []
+    for profile in PROFILES:
+        selected = [row for row in rows if row["kind"] == "measurement" and row["profile"] == profile]
+        summary = {"profile": profile, "attempts": len(selected),
+                   "transfer_successes": sum(row["transfer_pass"] for row in selected),
+                   "evidence_passes": sum(not row["errors"] for row in selected),
+                   "conditional_on_complete_observations": True}
+        for metric in ("mbps", "sender_cpu_seconds"):
+            # Keep successful transfers even if they fail the zero-repeat gate.
+            # Never promote warmups/controls or retry replacements into samples.
+            values = [row[metric] for row in selected if row["transfer_pass"] and row[metric] is not None]
+            summary[metric] = {"samples": len(values), "median": statistics.median(values) if values else None,
+                               "mean": statistics.mean(values) if values else None,
+                               "p95": sc.percentile(values, .95) if values else None}
+        summaries.append(summary)
+    return {"measurement_contract_pass": not errors, "errors": errors, "cases": rows, "summary": summaries}
+
+
+def run_blocks(paths: dict, manifests: dict, out: Path, report: dict) -> int:
+    out.mkdir(parents=True, exist_ok=False)
+    report.update(complete=False, plan=plan(), blocks=[], performance_decision_requires_review=True)
+    try:
+        for index, variant in enumerate(plan()):
+            name = f"{index:02}-{variant}-plain"
+            command = [sys.executable, str(Path(diag.__file__).resolve()), "--build-manifest", str(paths[variant]),
+                       "--output-directory", str(out / name)]
+            for key, value in ARGUMENTS.items():
+                command += ["--" + key.replace("_", "-"), str(value)]
+            for profile in PROFILES:
+                command += ["--profile", profile]
+            block = {"name": name, "variant": variant, "command": command, "exit_code": None}
+            report["blocks"].append(block)
+            sc.write_report(out / "ab-report.json", report)
+            with (out / f"{name}.log").open("x") as log:
+                completed = subprocess.run(command, stdout=log, stderr=subprocess.STDOUT)
+            block["exit_code"] = completed.returncode
+            try:
+                diagnostic = json.loads((out / name / "report.json").read_text())
+                block["analysis"] = analyze_block(diagnostic, manifests[variant], completed.returncode)
+            except (OSError, ValueError, KeyError, TypeError, OverflowError) as error:
+                block["analysis"] = {"measurement_contract_pass": False, "errors": [f"unusable report: {error}"]}
+            print(json.dumps({"name": name, "exit_code": block["exit_code"],
+                              "measurement_contract_pass": block["analysis"]["measurement_contract_pass"]}), flush=True)
+            sc.write_report(out / "ab-report.json", report)
+        report["complete"] = True
+        report["measurement_contract_pass"] = all(block["analysis"]["measurement_contract_pass"] for block in report["blocks"])
+        return 0 if report["measurement_contract_pass"] else 1
+    finally:
+        sc.write_report(out / "ab-report.json", report)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    for variant in REVISIONS:
+        parser.add_argument(f"--{variant}-plain", type=Path, required=True, help="build-manifest.json")
+    parser.add_argument("--output-directory", type=Path, required=True)
+    args = parser.parse_args(argv)
+    if platform.system() != "Linux" or platform.machine() not in ("aarch64", "arm64"):
+        parser.error("use the original dedicated Linux ARM64 VM; local smoke is not this qualification")
+    environment = diag.host_metadata()
+    paths = {variant: getattr(args, f"{variant}_plain").resolve() for variant in REVISIONS}
+    manifests = {variant: json.loads(path.read_text()) for variant, path in paths.items()}
+    harness = build.source_identity(Path(__file__).resolve().parents[1])
+    validate_manifests(manifests, harness, environment)
+    signatures = validate_build_files(paths, manifests)
+    if any(int(environment["sysctls"].get(f"net/core/{key}_max") or 0) < ARGUMENTS["udp_buffer"] for key in ("rmem", "wmem")):
+        parser.error("operator must record/configure/restore UDP maxima of at least 8 MiB")
+    report = {"schema_version": 1, "environment": environment, "manifests": manifests,
+              "toolchain_signatures": signatures, "harness_checkout": harness,
+              "harness_files": [sc.program_identity(Path(module.__file__).resolve()) for module in (diag, sc)],
+              "runner": sc.program_identity(Path(__file__).resolve()),
+              "scope": "plain IPv4 loopback; one connection; no WAN, encryption, live-deadline or release approval"}
+    return run_blocks(paths, manifests, args.output_directory.resolve(), report)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/run_retransmission_ab.py
+++ b/benchmarks/run_retransmission_ab.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Serial matched-rate ABBA plus separate matched/unpaced causal traces.
+
+Run on the original dedicated Linux VM after four clean builds. Does not build,
+change sysctls, retry failures, remove results or start hosted CI.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+import scalability_scorecard as sc
+import throughput_diagnostics as diag
+
+REVISIONS = {"baseline": "a5c428b725b5373651041b0e30678406b2d5c38c",
+             "candidate": "40387f2dc70b7701b266be1c91f048f2d4fa3b61"}
+
+
+def plan() -> list[dict]:
+    plain = [{"variant": v, "capture": "none", "target_bps": 100_000_000, "repetitions": 3}
+             for v in ("baseline", "candidate", "candidate", "baseline")]
+    traces = [{"variant": v, "capture": "transport", "target_bps": rate, "repetitions": 1}
+              for rate in (100_000_000, 0) for v in REVISIONS]
+    return plain + traces
+
+
+def validate_manifests(manifests: dict) -> None:
+    if set(manifests) != {(v, m) for v in REVISIONS for m in ("none", "transport")}:
+        raise ValueError("exactly four A/B plain/trace manifests are required")
+    helpers, platforms, overlays = set(), set(), set()
+    for (variant, mode), manifest in manifests.items():
+        if not manifest.get("complete") or manifest["sources"]["robotweax"]["dirty"]:
+            raise ValueError("all builds must be complete and based on clean revisions")
+        if manifest["sources"]["robotweax"]["revision"] != REVISIONS[variant]:
+            raise ValueError("unexpected A/B source revision")
+        if manifest["sources"]["haivision"]["revision"] != "899348d8318eb9a3c5a5b6ec43c4a1114288773a":
+            raise ValueError("unexpected Haivision reference")
+        overlay = manifest.get("transport_trace", {})
+        if bool(overlay.get("enabled")) != (mode == "transport"):
+            raise ValueError("plain/trace builds are not interchangeable")
+        helpers.add(manifest["harness_source"]["sha256"])
+        platforms.add((manifest["platform"], manifest["architecture"], manifest["crypto"], manifest["linkage"]))
+        if mode == "transport":
+            overlays.add((overlay["overlay_script"]["sha256"], overlay["collector_header"]["sha256"]))
+    if len(helpers) != 1 or len(platforms) != 1 or len(overlays) != 1:
+        raise ValueError("A/B builds do not share helper/platform/overlay")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    for variant in REVISIONS:
+        for mode in ("plain", "trace"):
+            parser.add_argument(f"--{variant}-{mode}", type=Path, required=True, help="build-manifest.json")
+    parser.add_argument("--output-directory", type=Path, required=True)
+    args = parser.parse_args()
+    if platform.system() != "Linux":
+        parser.error("this qualification handoff targets the original Linux VM; use individual diagnostics for local smoke")
+    paths = {(v, capture): getattr(args, f"{v}_{mode}").resolve()
+             for v in REVISIONS for mode, capture in (("plain", "none"), ("trace", "transport"))}
+    manifests = {key: json.loads(path.read_text()) for key, path in paths.items()}
+    validate_manifests(manifests)
+    limits = diag.host_metadata()["sysctls"]
+    if any(int(limits[f"net/core/{key}_max"] or 0) < 8 * 1024**2 for key in ("rmem", "wmem")):
+        parser.error("UDP maxima below 8 MiB; operator must record, temporarily configure and restore the VM limits")
+    out = args.output_directory.resolve()
+    out.mkdir(parents=True, exist_ok=False)
+    report = {"complete": False, "plan": plan(), "blocks": [], "environment": diag.host_metadata(),
+              "manifests": {f"{v}-{m}": value for (v, m), value in manifests.items()},
+              "runner": sc.program_identity(Path(__file__).resolve())}
+    try:
+        for index, block in enumerate(report["plan"]):
+            name = f"{index:02}-{block['variant']}-{block['capture']}-{block['target_bps']}"
+            command = [sys.executable, str(Path(diag.__file__).resolve()),
+                       "--build-manifest", str(paths[block["variant"], block["capture"]]),
+                       "--output-directory", str(out / name), "--capture", block["capture"],
+                       "--repetitions", str(block["repetitions"]), "--target-bps", str(block["target_bps"]),
+                       "--pacing-burst-packets", "4" if block["target_bps"] else "0",
+                       "--cooldown-seconds", "30"]
+            report["blocks"].append({"name": name, "command": command, "exit_code": None})
+            sc.write_report(out / "ab-report.json", report)
+            with (out / f"{name}.log").open("x") as log:
+                result = subprocess.run(command, stdout=log, stderr=subprocess.STDOUT)
+            report["blocks"][-1]["exit_code"] = result.returncode
+            print(json.dumps(report["blocks"][-1]), flush=True)
+            sc.write_report(out / "ab-report.json", report)
+        report["complete"] = True
+        report["all_blocks_pass"] = all(b["exit_code"] == 0 for b in report["blocks"])
+        return 0 if report["all_blocks_pass"] else 1
+    finally:
+        sc.write_report(out / "ab-report.json", report)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/scalability_peer.cpp
+++ b/benchmarks/scalability_peer.cpp
@@ -22,6 +22,11 @@
 #include <utility>
 #include <vector>
 
+#if defined(__unix__) || defined(__APPLE__)
+#include <sys/resource.h>
+#include <unistd.h>
+#endif
+
 #if defined(_WIN32)
 #include <ws2tcpip.h>
 #else
@@ -50,6 +55,14 @@ struct Configuration {
     int timeout_milliseconds = 60'000;
     int latency_milliseconds = 20;
     int shutdown_grace_milliseconds = 50;
+    // Opt-in capacity controls. Defaults preserve the scalability scorecard.
+    std::size_t pending_packets = maximum_pending_packets_per_socket;
+    int flow_window = 1'024;
+    int send_buffer = 4 * 1'024 * 1'024;
+    int receive_buffer = 0;
+    int udp_buffer = 0;
+    std::int64_t maximum_bandwidth = -1;
+    std::uint64_t target_bits_per_second = 0;
 };
 
 struct EndpointAddress {
@@ -229,6 +242,48 @@ bool parse_arguments(int argc, char** argv, Configuration& configuration)
                 || configuration.shutdown_grace_milliseconds < 0) {
                 return false;
             }
+        } else if (option == "--pending-packets"
+            && take_value(index, argc, argv, value)) {
+            if (!parse_integer(value, configuration.pending_packets)
+                || configuration.pending_packets == 0U
+                || configuration.pending_packets > 65'536U) {
+                return false;
+            }
+        } else if (option == "--flow-window"
+            && take_value(index, argc, argv, value)) {
+            if (!parse_integer(value, configuration.flow_window)
+                || configuration.flow_window < 32
+                || configuration.flow_window > 65'536) {
+                return false;
+            }
+        } else if ((option == "--send-buffer" || option == "--receive-buffer"
+                       || option == "--udp-buffer")
+            && take_value(index, argc, argv, value)) {
+            int bytes = 0;
+            if (!parse_integer(value, bytes) || bytes < 65'536
+                || bytes > 256 * 1'024 * 1'024) {
+                return false;
+            }
+            if (option == "--send-buffer") {
+                configuration.send_buffer = bytes;
+            } else if (option == "--receive-buffer") {
+                configuration.receive_buffer = bytes;
+            } else {
+                configuration.udp_buffer = bytes;
+            }
+        } else if (option == "--max-bandwidth"
+            && take_value(index, argc, argv, value)) {
+            if (!parse_integer(value, configuration.maximum_bandwidth)
+                || configuration.maximum_bandwidth < -1
+                || configuration.maximum_bandwidth > 12'500'000'000LL) {
+                return false;
+            }
+        } else if (option == "--target-bps"
+            && take_value(index, argc, argv, value)) {
+            if (!parse_integer(value, configuration.target_bits_per_second)
+                || configuration.target_bits_per_second > 100'000'000'000ULL) {
+                return false;
+            }
         } else {
             return false;
         }
@@ -280,23 +335,26 @@ bool configure_socket(
 {
     const SRT_TRANSTYPE transport = SRTT_LIVE;
     const bool message_api = true;
-    const int flow_window = 1'024;
-    const int send_buffer = 4 * 1'024 * 1'024;
     const int maximum_segment_size = 1'500;
-    const std::int64_t maximum_bandwidth = -1;
     const bool too_late_packet_drop = false;
     return set_option(socket, SRTO_TRANSTYPE, transport)
         && set_option(socket, SRTO_MESSAGEAPI, message_api)
         && set_option(socket, SRTO_SENDER, sender)
         && set_option(socket, SRTO_SNDTIMEO, configuration.timeout_milliseconds)
         && set_option(socket, SRTO_RCVTIMEO, configuration.timeout_milliseconds)
-        && set_option(socket, SRTO_FC, flow_window)
-        && set_option(socket, SRTO_SNDBUF, send_buffer)
+        && set_option(socket, SRTO_FC, configuration.flow_window)
+        && set_option(socket, SRTO_SNDBUF, configuration.send_buffer)
+        && (configuration.receive_buffer == 0
+            || set_option(socket, SRTO_RCVBUF, configuration.receive_buffer))
+        && (configuration.udp_buffer == 0
+            || (set_option(socket, SRTO_UDP_SNDBUF, configuration.udp_buffer)
+                && set_option(
+                    socket, SRTO_UDP_RCVBUF, configuration.udp_buffer)))
         && set_option(socket, SRTO_MSS, maximum_segment_size)
         && set_option(socket, SRTO_PAYLOADSIZE, configuration.message_size)
         && set_option(socket, SRTO_LATENCY, configuration.latency_milliseconds)
         && set_option(socket, SRTO_TLPKTDROP, too_late_packet_drop)
-        && set_option(socket, SRTO_MAXBW, maximum_bandwidth);
+        && set_option(socket, SRTO_MAXBW, configuration.maximum_bandwidth);
 }
 
 bool make_nonblocking(SRTSOCKET socket)
@@ -304,6 +362,40 @@ bool make_nonblocking(SRTSOCKET socket)
     const bool synchronous = false;
     return set_option(socket, SRTO_SNDSYN, synchronous)
         && set_option(socket, SRTO_RCVSYN, synchronous);
+}
+
+bool print_capacity_options(
+    SRTSOCKET socket, const Configuration& configuration)
+{
+    if (configuration.udp_buffer == 0) {
+        return true;
+    }
+    const std::array<SRT_SOCKOPT, 5> options {
+        SRTO_FC, SRTO_SNDBUF, SRTO_RCVBUF, SRTO_UDP_SNDBUF, SRTO_UDP_RCVBUF};
+    std::array<int, 5> values {};
+    for (std::size_t index = 0; index < options.size(); ++index) {
+        int size = sizeof(int);
+        if (srt_getsockflag(socket, options[index], &values[index], &size)
+            == SRT_ERROR) {
+            std::cerr << "capacity option query failed: "
+                      << srt_getlasterror_str() << '\n';
+            return false;
+        }
+    }
+    // API readbacks are not measurements of the actual OS socket buffer size.
+    std::cout << "{\"event\":\"capacity-options\",\"api_fc\":" << values[0]
+              << ",\"api_sndbuf\":" << values[1]
+              << ",\"api_rcvbuf\":" << values[2]
+              << ",\"api_udp_sndbuf\":" << values[3]
+              << ",\"api_udp_rcvbuf\":" << values[4]
+              << ",\"requested_maxbw_bytes_per_second\":"
+              << configuration.maximum_bandwidth
+              << ",\"pending_packets\":" << configuration.pending_packets
+              << ",\"target_bits_per_second\":"
+              << configuration.target_bits_per_second
+              << ",\"encryption\":\"none\",\"tlpktdrop\":false}\n"
+              << std::flush;
+    return true;
 }
 
 void store_u32(char* output, std::uint32_t value) noexcept
@@ -445,6 +537,23 @@ void print_complete(const char* role, const Configuration& configuration,
               << ",\"srt_version\":" << srt_getversion()
               << ",\"integrity\":true,\"connection_completion_us\":";
     print_distribution(connection_completion);
+#if defined(__unix__) || defined(__APPLE__)
+    rusage usage {};
+    if (getrusage(RUSAGE_SELF, &usage) == 0) {
+        std::cout << ",\"process_resources\":{\"pid\":" << getpid()
+                  << ",\"user_cpu_us\":"
+                  << static_cast<std::int64_t>(usage.ru_utime.tv_sec)
+                    * 1'000'000
+                + usage.ru_utime.tv_usec
+                  << ",\"system_cpu_us\":"
+                  << static_cast<std::int64_t>(usage.ru_stime.tv_sec)
+                    * 1'000'000
+                + usage.ru_stime.tv_usec
+                  << ",\"voluntary_context_switches\":" << usage.ru_nvcsw
+                  << ",\"involuntary_context_switches\":" << usage.ru_nivcsw
+                  << '}';
+    }
+#endif
     if (statistics.available) {
         std::cout << ",\"stats\":{\"pktSentTotal\":" << statistics.packets_sent
                   << ",\"pktRecvTotal\":" << statistics.packets_received
@@ -580,17 +689,31 @@ bool run_sender(const Configuration& configuration,
                           << ' ' << srt_getlasterror_str() << '\n';
                 return false;
             }
-            if (pending_blocks >= maximum_pending_packets_per_socket) {
+            if (pending_blocks >= configuration.pending_packets) {
                 application_window_blocked = true;
                 continue;
             }
             const int socket_budget =
                 static_cast<int>(std::min<std::size_t>(maximum_burst_messages,
-                    maximum_pending_packets_per_socket - pending_blocks));
+                    configuration.pending_packets - pending_blocks));
             int burst = 0;
             while (progress[index] < configuration.messages_per_connection
                 && burst < socket_budget
                 && round_messages < maximum_round_messages) {
+                if (configuration.target_bits_per_second != 0U) {
+                    const auto offset = std::chrono::duration<double> {
+                        static_cast<double>(sent_messages)
+                        * static_cast<double>(configuration.message_size) * 8.0
+                        / static_cast<double>(
+                            configuration.target_bits_per_second)};
+                    const auto due = started
+                        + std::chrono::duration_cast<Clock::duration>(offset);
+                    if (due >= deadline) {
+                        std::cerr << "offered-rate duration exceeds timeout\n";
+                        return false;
+                    }
+                    std::this_thread::sleep_until(due);
+                }
                 prepare_payload(payloads[index],
                     static_cast<std::uint32_t>(index), progress[index]);
                 const int sent = srt_sendmsg(sockets[index],
@@ -897,6 +1020,9 @@ int run_listener(const Configuration& configuration)
         accepted.add(socket);
     }
     const auto establishment = Clock::now() - establishment_started;
+    if (!print_capacity_options(accepted.values().front(), configuration)) {
+        return 5;
+    }
     std::cout << "{\"event\":\"established\",\"role\":\"listener\","
                  "\"connections\":"
               << configuration.connections << "}\n"
@@ -931,6 +1057,9 @@ int run_caller(const Configuration& configuration)
         connected.add(socket);
     }
     const auto establishment = Clock::now() - establishment_started;
+    if (!print_capacity_options(connected.values().front(), configuration)) {
+        return 5;
+    }
     std::cout << "{\"event\":\"established\",\"role\":\"caller\","
                  "\"connections\":"
               << configuration.connections << "}\n"
@@ -940,10 +1069,14 @@ int run_caller(const Configuration& configuration)
 
 void usage()
 {
-    std::cerr << "usage: robotweax_srt_scalability_peer listener|caller"
-                 " --host IP --port PORT --connections N --messages N"
-                 " --message-size 16..1456 [--timeout-ms N] [--latency-ms N]"
-                 " [--shutdown-grace-ms N]\n";
+    std::cerr
+        << "usage: robotweax_srt_scalability_peer listener|caller"
+           " --host IP --port PORT --connections N --messages N"
+           " --message-size 16..1456 [--timeout-ms N] [--latency-ms N]"
+           " [--shutdown-grace-ms N] [--pending-packets N]"
+           " [--flow-window N] [--send-buffer BYTES] [--receive-buffer BYTES]"
+           " [--udp-buffer BYTES] [--max-bandwidth BYTES_PER_SECOND]"
+           " [--target-bps BITS_PER_SECOND]\n";
 }
 
 } // namespace

--- a/benchmarks/scalability_peer.cpp
+++ b/benchmarks/scalability_peer.cpp
@@ -63,6 +63,7 @@ struct Configuration {
     int udp_buffer = 0;
     std::int64_t maximum_bandwidth = -1;
     std::uint64_t target_bits_per_second = 0;
+    std::uint32_t pacing_burst_packets = 0;
 };
 
 struct EndpointAddress {
@@ -276,6 +277,12 @@ bool parse_arguments(int argc, char** argv, Configuration& configuration)
             if (!parse_integer(value, configuration.maximum_bandwidth)
                 || configuration.maximum_bandwidth < -1
                 || configuration.maximum_bandwidth > 12'500'000'000LL) {
+                return false;
+            }
+        } else if (option == "--pacing-burst-packets"
+            && take_value(index, argc, argv, value)) {
+            if (!parse_integer(value, configuration.pacing_burst_packets)
+                || configuration.pacing_burst_packets > 64U) {
                 return false;
             }
         } else if (option == "--target-bps"
@@ -646,6 +653,11 @@ bool run_sender(const Configuration& configuration,
     std::uint64_t sent_messages = 0;
     std::size_t cursor = 0;
     const auto started = Clock::now();
+    auto pacing_origin = started;
+    Clock::time_point first_enqueue {}, last_enqueue {};
+    std::int64_t pacing_forgiven_nanoseconds = 0;
+    std::uint64_t enqueue_bucket = 0, bucket_packets = 0,
+                  maximum_bucket_packets = 0;
     const auto deadline = started
         + std::chrono::milliseconds {configuration.timeout_milliseconds};
 
@@ -706,8 +718,28 @@ bool run_sender(const Configuration& configuration,
                         * static_cast<double>(configuration.message_size) * 8.0
                         / static_cast<double>(
                             configuration.target_bits_per_second)};
-                    const auto due = started
+                    auto due = pacing_origin
                         + std::chrono::duration_cast<Clock::duration>(offset);
+                    if (configuration.pacing_burst_packets != 0U) {
+                        const auto credit = std::chrono::duration<double> {
+                            static_cast<double>(
+                                configuration.pacing_burst_packets - 1U)
+                            * configuration.message_size * 8.0
+                            / static_cast<double>(
+                                configuration.target_bits_per_second)};
+                        const auto earliest = Clock::now()
+                            - std::chrono::duration_cast<Clock::duration>(
+                                credit);
+                        if (due < earliest) {
+                            const auto forgiven = earliest - due;
+                            pacing_origin += forgiven;
+                            due = earliest;
+                            pacing_forgiven_nanoseconds +=
+                                std::chrono::duration_cast<
+                                    std::chrono::nanoseconds>(forgiven)
+                                    .count();
+                        }
+                    }
                     if (due >= deadline) {
                         std::cerr << "offered-rate duration exceeds timeout\n";
                         return false;
@@ -736,6 +768,22 @@ bool run_sender(const Configuration& configuration,
                 if (sent != configuration.message_size) {
                     std::cerr << "message send was unexpectedly partial\n";
                     return false;
+                }
+                if (configuration.target_bits_per_second != 0U) {
+                    last_enqueue = Clock::now();
+                    if (sent_messages == 0U) {
+                        first_enqueue = last_enqueue;
+                    }
+                    const auto bucket = static_cast<std::uint64_t>(
+                        std::chrono::duration_cast<std::chrono::milliseconds>(
+                            last_enqueue - first_enqueue)
+                            .count());
+                    if (bucket != enqueue_bucket) {
+                        bucket_packets = 0;
+                        enqueue_bucket = bucket;
+                    }
+                    maximum_bucket_packets =
+                        std::max(maximum_bucket_packets, ++bucket_packets);
                 }
                 ++progress[index];
                 ++sent_messages;
@@ -807,6 +855,27 @@ bool run_sender(const Configuration& configuration,
         std::this_thread::sleep_for(std::chrono::milliseconds {1});
     }
 
+    if (configuration.target_bits_per_second != 0U) {
+        const auto span = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            last_enqueue - first_enqueue)
+                              .count();
+        const double offered_bps = span > 0
+            ? static_cast<double>(sent_messages - 1U)
+                * configuration.message_size * 8.0 * 1e9
+                / static_cast<double>(span)
+            : 0.0;
+        std::cout << "{\"event\":\"offered-rate\",\"target_bps\":"
+                  << configuration.target_bits_per_second
+                  << ",\"enqueue_bps\":" << offered_bps
+                  << ",\"enqueue_span_ns\":" << span
+                  << ",\"messages\":" << sent_messages
+                  << ",\"catchup_credit_packets\":"
+                  << configuration.pacing_burst_packets
+                  << ",\"forgiven_ns\":" << pacing_forgiven_nanoseconds
+                  << ",\"maximum_fixed_1ms_bucket_packets\":"
+                  << maximum_bucket_packets << "}\n"
+                  << std::flush;
+    }
     const AggregateStatistics statistics = capture_statistics(sockets);
     print_complete("caller", configuration, Clock::now() - started,
         establishment, completion, statistics);

--- a/benchmarks/scalability_scorecard.py
+++ b/benchmarks/scalability_scorecard.py
@@ -802,6 +802,7 @@ def run_many_socket_profile(
     *,
     iteration: int,
     warmup: bool,
+    peer_arguments: tuple[str, ...] = (),
 ) -> dict[str, object]:
     sender_name, receiver_name = PROFILE_IMPLEMENTATIONS[profile_name]
     try:
@@ -820,7 +821,7 @@ def run_many_socket_profile(
         listener = spawn_command_peer(
             many_socket_peer_command(
                 receiver_program, "listener", port, options
-            ),
+            ) + list(peer_arguments),
             receiver_name,
             "listener",
             directory,
@@ -831,7 +832,7 @@ def run_many_socket_profile(
         caller = spawn_command_peer(
             many_socket_peer_command(
                 sender_program, "caller", port, options
-            ),
+            ) + list(peer_arguments),
             sender_name,
             "caller",
             directory,
@@ -961,6 +962,11 @@ def run_many_socket_profile(
         "versions": {
             "sender": [caller_event.get("srt_version")],
             "receiver": [listener_event.get("srt_version")],
+        },
+        "peer_process_resources": {
+            "scope": "process start through completion event (includes setup)",
+            "sender": caller_event.get("process_resources"),
+            "receiver": listener_event.get("process_resources"),
         },
     }
 

--- a/benchmarks/throughput_diagnostics.py
+++ b/benchmarks/throughput_diagnostics.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Serial, cleartext capacity controls and separate Linux perf captures.
+
+Uses the public-API scalability peer and its existing integrity validation.
+Never adjusts sysctls, installs tools, retries a failed transfer, or treats
+instrumented throughput as an uninstrumented performance result.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import re
+import shutil
+import signal
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import asdict
+from pathlib import Path
+
+import scalability_scorecard as sc
+
+try:
+    import resource
+except ImportError:  # importable for portable harness tests; runner is POSIX only
+    resource = None
+
+ROOT = Path(__file__).resolve().parents[1]
+PROFILES = tuple(sc.PROFILE_IMPLEMENTATIONS)
+
+
+def bounded_int(low: int, high: int):
+    def parse(value: str) -> int:
+        result = int(value)
+        if not low <= result <= high:
+            raise argparse.ArgumentTypeError(f"must be in {low}..{high}")
+        return result
+    return parse
+
+
+def host_metadata() -> dict:
+    values = {}
+    for key in ("net/core/rmem_max", "net/core/wmem_max", "kernel/perf_event_paranoid",
+                "kernel/kptr_restrict"):
+        path = Path("/proc/sys") / key
+        values[key] = path.read_text().strip() if path.is_file() else None
+    return {"platform": platform.platform(), "architecture": platform.machine(),
+            "cpu_count": os.cpu_count(), "cpu_model": sc.cpu_model(), "sysctls": values,
+            "affinity": sorted(os.sched_getaffinity(0)) if hasattr(os, "sched_getaffinity") else None,
+            "load_average": os.getloadavg() if hasattr(os, "getloadavg") else None,
+            "python": sys.version}
+
+
+def udp_snapshot() -> dict:
+    path = Path("/proc/net/snmp")
+    if not path.is_file():
+        return {}
+    lines = path.read_text().splitlines()
+    for index, line in enumerate(lines[:-1]):
+        if line.startswith("Udp:"):
+            return dict(zip(line.split()[1:], map(int, lines[index + 1].split()[1:])))
+    return {}
+
+
+def peer_arguments(args) -> tuple[str, ...]:
+    return ("--pending-packets", str(args.pending_packets), "--flow-window", "16384",
+            "--send-buffer", "33554432", "--receive-buffer", "33554432",
+            "--udp-buffer", str(args.udp_buffer), "--max-bandwidth", "1250000000",
+            "--target-bps", str(args.target_bps))
+
+
+def case_plan(profiles: list[str], repetitions: int, warmups: int,
+              reference: bool, capture: str) -> list[dict]:
+    plan = []
+    if reference and capture == "none":
+        plan.append({"profile": "haivision-self", "kind": "control-before"})
+    for profile in profiles:
+        for _ in range(warmups if capture == "none" else 0):
+            plan.append({"profile": profile, "kind": "warmup"})
+        for _ in range(repetitions):
+            plan.append({"profile": profile, "kind": "measurement" if capture == "none" else capture})
+    if reference and capture == "none":
+        plan.append({"profile": "haivision-self", "kind": "control-after"})
+    return plan
+
+
+def perf_command(capture: str, data: Path, command: list[str], perf: str) -> list[str]:
+    if capture == "none":
+        return command
+    if capture == "cpu":
+        # Software clock works without a virtualized hardware PMU. DWARF avoids
+        # silently losing stacks when the unchanged Release build omits FP.
+        return [perf, "record", "-o", str(data), "-e", "cpu-clock", "-F", "199",
+                "--call-graph", "dwarf,8192", "--", *command]
+    if capture == "scheduler":
+        # perf sched records system-wide scheduler tracepoints. Explicit opt-in.
+        return [perf, "sched", "record", "-o", str(data), "--", *command]
+    raise ValueError("unknown capture mode")
+
+
+def limit_trace_size() -> None:
+    if resource is None:
+        raise RuntimeError("POSIX resource limits are unavailable")
+    limit = 128 * 1024 * 1024
+    _, hard = resource.getrlimit(resource.RLIMIT_FSIZE)
+    resource.setrlimit(resource.RLIMIT_FSIZE, (min(limit, hard) if hard >= 0 else limit, hard))
+
+
+def run_bounded(command: list[str], directory: Path, timeout: int) -> int:
+    with (directory / "command.log").open("w") as output:
+        process = subprocess.Popen(command, stdout=output, stderr=subprocess.STDOUT,
+                                   start_new_session=True, preexec_fn=limit_trace_size)
+        try:
+            return process.wait(timeout=timeout)
+        except (subprocess.TimeoutExpired, KeyboardInterrupt):
+            try:
+                os.killpg(process.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            try:
+                process.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait()
+            raise
+        finally:
+            # A profiler can fail before its workload (e.g. file-size limit).
+            # Do not leave that workload competing with the next serial case.
+            try:
+                os.killpg(process.pid, signal.SIGTERM)
+                time.sleep(.1)
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+
+def run_case(path: Path) -> int:
+    request = json.loads(path.read_text())
+    directory = path.parent
+    entry = {"transfer_pass": False, "started_unix_ns": time.time_ns()}
+    before = udp_snapshot()
+    try:
+        result = sc.run_many_socket_profile(
+            request["profile"], {k: Path(v) for k, v in request["programs"].items()},
+            sc.RunOptions(**request["options"]), directory,
+            iteration=request["index"], warmup=request["kind"] == "warmup",
+            peer_arguments=tuple(request["peer_arguments"]))
+        # The completion contract already validates both complete payloads and
+        # both exit statuses. Retain API buffer readbacks alongside the result.
+        result["capacity_options"] = {
+            role: [event for event in sc.parse_json_events(sc.read_output(directory / f"many-socket-{role}.stdout"))
+                   if event.get("event") == "capacity-options"]
+            for role in ("caller", "listener")
+        }
+        if not all(result["capacity_options"].values()):
+            raise sc.ScorecardFailure("peer lacks capacity-option readbacks; rebuild both peers")
+        entry.update(transfer_pass=True, result=result,
+                     rate_pass=(request["target_bps"] == 0 or result["rates"]["useful_bits_per_second"] >= .95 * request["target_bps"]))
+        return 0
+    except Exception as error:
+        entry["error"] = str(error)
+        return 1
+    finally:
+        after = udp_snapshot()
+        entry["system_udp_delta"] = {k: after[k] - v for k, v in before.items() if k in after}
+        entry["finished_unix_ns"] = time.time_ns()
+        sc.write_report(directory / "case.json", entry)
+
+
+def sample_counts(text: str, pids: list[int]) -> dict[int, int]:
+    counts = dict.fromkeys(pids, 0)
+    for line in text.splitlines():
+        fields = line.split()
+        # perf's field selection is not an output-order guarantee. Versions
+        # commonly render COMM then PID even for '-F pid,comm'.
+        if len(fields) == 2:
+            for field in fields:
+                if field.isdigit() and int(field) in counts:
+                    counts[int(field)] += 1
+                    break
+    return counts
+
+
+def render_capture(capture: str, directory: Path, result: dict, perf: str) -> dict:
+    data = directory / "perf.data"
+    pids = [(result.get("peer_process_resources", {}).get(role) or {}).get("pid")
+            for role in ("sender", "receiver")]
+    if not data.is_file() or not all(isinstance(pid, int) for pid in pids):
+        return {"valid": False, "error": "missing perf data or peer PID evidence"}
+    commands = [([perf, "report", "--stdio", "--no-children", "--sort", "comm,pid,dso,symbol",
+                 "-i", str(data)], "perf-report.txt"),
+                ([perf, "script", "-i", str(data)], "perf-stacks.txt")]
+    if capture == "scheduler":
+        commands = [([perf, "sched", "timehist", "-i", str(data), "--summary", "--pid",
+                      ",".join(map(str, pids))], "perf-scheduler.txt")]
+    for command, name in commands:
+        with (directory / name).open("w") as output:
+            completed = subprocess.run(command, stdout=output, stderr=subprocess.STDOUT,
+                                       timeout=30, preexec_fn=limit_trace_size)
+        if completed.returncode:
+            return {"valid": False, "error": f"render failed: {name}", "command": command}
+    if capture == "cpu":
+        completed = subprocess.run([perf, "script", "-i", str(data), "-F", "pid,comm"],
+                                   stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=30)
+        counts = sample_counts(completed.stdout, pids)
+        sc.write_report(directory / "sample-coverage.json", counts)
+        return {"valid": completed.returncode == 0 and all(counts.values()),
+                "samples_by_peer_pid": counts,
+                "call_stack_quality_requires_review": True}
+    # A successful renderer is not proof of a usable per-peer schedule trace.
+    content = (directory / "perf-scheduler.txt").read_text()
+    found = all(re.search(rf"(?<!\d){pid}(?!\d)", content) for pid in pids)
+    return {"valid": found, "peer_pids": pids, "trace_coverage_requires_review": True}
+
+
+def summarize(entries: list[dict]) -> list[dict]:
+    summaries = []
+    for profile in sorted({entry["profile"] for entry in entries if entry["kind"] == "measurement"}):
+        selected = [e for e in entries if e["profile"] == profile and e["kind"] == "measurement"]
+        values = [e["result"]["rates"]["useful_bits_per_second"] / 1e6 for e in selected if e.get("transfer_pass")]
+        summaries.append({"profile": profile, "attempts": len(selected), "complete": len(values),
+                          "failed": len(selected) - len(values), "conditional_on_complete_transfers": True,
+                          "median_mbps": statistics.median(values) if values else None,
+                          "p95_mbps": sc.percentile(values, .95) if values else None,
+                          "mean_mbps": statistics.mean(values) if values else None})
+    return summaries
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build-manifest", type=Path, required=True)
+    parser.add_argument("--output-directory", type=Path, required=True)
+    parser.add_argument("--profile", action="append", choices=PROFILES)
+    parser.add_argument("--capture", choices=("none", "cpu", "scheduler"), default="none")
+    parser.add_argument("--repetitions", type=bounded_int(1, 10))
+    parser.add_argument("--warmups", type=bounded_int(0, 2), default=1)
+    parser.add_argument("--bytes-per-connection", type=bounded_int(1316, 1024**3), default=128 * 1024**2)
+    parser.add_argument("--target-bps", type=bounded_int(0, 100_000_000_000), default=0)
+    parser.add_argument("--pending-packets", type=bounded_int(1, 65536), default=8192)
+    parser.add_argument("--udp-buffer", type=bounded_int(65536, 32 * 1024**2), default=8 * 1024**2)
+    parser.add_argument("--timeout-seconds", type=bounded_int(10, 90), default=45)
+    parser.add_argument("--cooldown-seconds", type=bounded_int(0, 60), default=10)
+    parser.add_argument("--allow-small-udp-buffers", action="store_true")
+    parser.add_argument("--allow-system-wide", action="store_true")
+    args = parser.parse_args(argv)
+    if platform.system() not in ("Linux", "Darwin"):
+        parser.error("this process-group diagnostic runner requires Linux or macOS")
+    if args.capture != "none" and platform.system() != "Linux":
+        parser.error("perf capture requires Linux; use Instruments separately on macOS")
+    if args.capture == "scheduler" and not args.allow_system_wide:
+        parser.error("scheduler capture requires --allow-system-wide on a dedicated test VM")
+    perf = shutil.which("perf") or "perf"
+    if args.capture != "none" and not shutil.which("perf"):
+        parser.error("perf is not installed; no fallback to an unprofiled success")
+    manifest = json.loads(args.build_manifest.read_text())
+    if manifest.get("complete") is not True:
+        parser.error("build manifest is incomplete")
+    for identity in [*manifest["programs"].values(), *manifest["libraries"].values()]:
+        if sc.file_sha256(Path(identity["path"])) != identity["sha256"]:
+            parser.error("a peer or library changed since the recorded build")
+    programs = {name: value["path"] for name, value in manifest["programs"].items()}
+    profiles = args.profile or ["robotweax-self", "robotweax-to-haivision"]
+    if any("haivision" in sc.PROFILE_IMPLEMENTATIONS[p] for p in profiles) and "haivision" not in programs:
+        parser.error("selected profile needs the reference peer")
+    environment = host_metadata()
+    limits = [environment["sysctls"][f"net/core/{key}_max"] for key in ("rmem", "wmem")]
+    adequate = all(value is not None and int(value) >= args.udp_buffer for value in limits)
+    if platform.system() == "Linux" and not adequate and not args.allow_small_udp_buffers:
+        parser.error("UDP kernel limits are below requested buffers; see docs/throughput-profiling.md (no sysctl was changed)")
+    repetitions = args.repetitions or (5 if args.capture == "none" else 1)
+    out = args.output_directory.resolve()
+    out.mkdir(parents=True, exist_ok=False)
+    report = {"schema_version": 1, "finished": False, "capture": args.capture,
+              "environment": environment, "udp_capacity_controlled": adequate,
+              "build_manifest": manifest, "arguments": {k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()},
+              "runs": [], "scope": "cleartext IPv4 loopback; TSBPD 120ms; TLPKTDROP=false; no deadline qualification",
+              "profiling_scope": "driver and descendant peers, including connection setup and drain; filter by peer PID",
+              "started_unix_ns": time.time_ns()}
+    report["harness_files"] = [sc.program_identity(path) for path in
+                               (Path(__file__).resolve(), ROOT / "benchmarks/scalability_scorecard.py")]
+    sc.write_report(out / "report.json", report)
+    options = sc.RunOptions("127.0.0.1", 1, args.bytes_per_connection, 1316,
+                            args.timeout_seconds, 120, 500, .02)
+    try:
+        time.sleep(args.cooldown_seconds)
+        for index, item in enumerate(case_plan(profiles, repetitions, args.warmups, "haivision" in programs, args.capture)):
+            directory = out / f"{index:02}-{item['profile']}-{item['kind']}"
+            directory.mkdir()
+            request = {**item, "index": index, "programs": programs, "options": asdict(options),
+                       "target_bps": args.target_bps, "peer_arguments": peer_arguments(args)}
+            sc.write_report(directory / "request.json", request)
+            command = perf_command(args.capture, directory / "perf.data",
+                                   [sys.executable, str(Path(__file__).resolve()), "--case-file", str(directory / "request.json")], perf)
+            entry = {**item, "index": index, "command": command, "transfer_pass": False}
+            try:
+                entry["exit_code"] = run_bounded(command, directory, 2 * args.timeout_seconds + 15)
+                if (directory / "case.json").is_file():
+                    entry.update(json.loads((directory / "case.json").read_text()))
+                else:
+                    entry["error"] = "capture/driver exited without a case report; see command.log"
+                if args.capture != "none":
+                    entry["profiling"] = render_capture(args.capture, directory, entry.get("result", {}), perf)
+            except Exception as error:
+                entry["error"] = str(error)
+            report["runs"].append(entry)
+            report["summary"] = summarize(report["runs"])
+            sc.write_report(out / "report.json", report)
+            print(json.dumps({"index": index, **item, "transfer_pass": entry["transfer_pass"],
+                              "profiling": entry.get("profiling")}), flush=True)
+        report["finished"] = True
+        report["all_transfers_pass"] = all(e["transfer_pass"] and e.get("exit_code") == 0 for e in report["runs"])
+        report["all_captures_usable"] = args.capture == "none" or all(e.get("profiling", {}).get("valid") for e in report["runs"])
+        return 0 if report["all_transfers_pass"] and report["all_captures_usable"] else 1
+    finally:
+        report["finished_unix_ns"] = time.time_ns()
+        sc.write_report(out / "report.json", report)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 3 and sys.argv[1] == "--case-file":
+        raise SystemExit(run_case(Path(sys.argv[2])))
+    raise SystemExit(main())

--- a/benchmarks/throughput_diagnostics.py
+++ b/benchmarks/throughput_diagnostics.py
@@ -22,6 +22,7 @@ from dataclasses import asdict
 from pathlib import Path
 
 import scalability_scorecard as sc
+import retransmission_trace as rt
 
 try:
     import resource
@@ -66,10 +67,11 @@ def udp_snapshot() -> dict:
 
 
 def peer_arguments(args) -> tuple[str, ...]:
+    pacing = getattr(args, "pacing_burst_packets", 0)
     return ("--pending-packets", str(args.pending_packets), "--flow-window", "16384",
             "--send-buffer", "33554432", "--receive-buffer", "33554432",
             "--udp-buffer", str(args.udp_buffer), "--max-bandwidth", "1250000000",
-            "--target-bps", str(args.target_bps))
+            "--target-bps", str(args.target_bps)) + (("--pacing-burst-packets", str(pacing)) if pacing else ())
 
 
 def case_plan(profiles: list[str], repetitions: int, warmups: int,
@@ -88,7 +90,7 @@ def case_plan(profiles: list[str], repetitions: int, warmups: int,
 
 
 def perf_command(capture: str, data: Path, command: list[str], perf: str) -> list[str]:
-    if capture == "none":
+    if capture in ("none", "transport"):
         return command
     if capture == "cpu":
         # Software clock works without a virtualized hardware PMU. DWARF avoids
@@ -143,6 +145,14 @@ def run_case(path: Path) -> int:
     entry = {"transfer_pass": False, "started_unix_ns": time.time_ns()}
     before = udp_snapshot()
     try:
+        # This child process runs exactly one case. The environment is inherited
+        # by both peers, not by concurrent/unrelated callers of the scorecard.
+        if request.get("capture") == "transport":
+            trace_directory = directory / "transport-trace"
+            trace_directory.mkdir(exist_ok=False)
+            os.environ["ROBOTWEAX_TRANSPORT_TRACE_DIR"] = str(trace_directory)
+        else:
+            os.environ.pop("ROBOTWEAX_TRANSPORT_TRACE_DIR", None)
         result = sc.run_many_socket_profile(
             request["profile"], {k: Path(v) for k, v in request["programs"].items()},
             sc.RunOptions(**request["options"]), directory,
@@ -159,6 +169,18 @@ def run_case(path: Path) -> int:
             raise sc.ScorecardFailure("peer lacks capacity-option readbacks; rebuild both peers")
         entry.update(transfer_pass=True, result=result,
                      rate_pass=(request["target_bps"] == 0 or result["rates"]["useful_bits_per_second"] >= .95 * request["target_bps"]))
+        offered = [e for e in sc.parse_json_events(sc.read_output(directory / "many-socket-caller.stdout"))
+                   if e.get("event") == "offered-rate"]
+        if request.get("pacing_burst_packets", 0):
+            if len(offered) != 1:
+                raise sc.ScorecardFailure("missing bounded-pacer evidence")
+            entry["offered_rate"] = offered[0]
+            entry["matched_rate_pass"] = (
+                .98 * request["target_bps"] <= offered[0]["enqueue_bps"] <= 1.02 * request["target_bps"]
+                and offered[0]["catchup_credit_packets"] == request["pacing_burst_packets"]
+                and entry["rate_pass"])
+        if request.get("capture") == "transport":
+            entry["profiling"] = rt.analyze_case(directory, result)
         return 0
     except Exception as error:
         entry["error"] = str(error)
@@ -240,11 +262,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--build-manifest", type=Path, required=True)
     parser.add_argument("--output-directory", type=Path, required=True)
     parser.add_argument("--profile", action="append", choices=PROFILES)
-    parser.add_argument("--capture", choices=("none", "cpu", "scheduler"), default="none")
+    parser.add_argument("--capture", choices=("none", "cpu", "scheduler", "transport"), default="none")
     parser.add_argument("--repetitions", type=bounded_int(1, 10))
     parser.add_argument("--warmups", type=bounded_int(0, 2), default=1)
     parser.add_argument("--bytes-per-connection", type=bounded_int(1316, 1024**3), default=128 * 1024**2)
     parser.add_argument("--target-bps", type=bounded_int(0, 100_000_000_000), default=0)
+    parser.add_argument("--pacing-burst-packets", type=bounded_int(0, 64), default=0)
     parser.add_argument("--pending-packets", type=bounded_int(1, 65536), default=8192)
     parser.add_argument("--udp-buffer", type=bounded_int(65536, 32 * 1024**2), default=8 * 1024**2)
     parser.add_argument("--timeout-seconds", type=bounded_int(10, 90), default=45)
@@ -254,21 +277,28 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     if platform.system() not in ("Linux", "Darwin"):
         parser.error("this process-group diagnostic runner requires Linux or macOS")
-    if args.capture != "none" and platform.system() != "Linux":
+    if args.capture in ("cpu", "scheduler") and platform.system() != "Linux":
         parser.error("perf capture requires Linux; use Instruments separately on macOS")
     if args.capture == "scheduler" and not args.allow_system_wide:
         parser.error("scheduler capture requires --allow-system-wide on a dedicated test VM")
     perf = shutil.which("perf") or "perf"
-    if args.capture != "none" and not shutil.which("perf"):
+    if args.capture in ("cpu", "scheduler") and not shutil.which("perf"):
         parser.error("perf is not installed; no fallback to an unprofiled success")
     manifest = json.loads(args.build_manifest.read_text())
     if manifest.get("complete") is not True:
         parser.error("build manifest is incomplete")
+    traced_build = manifest.get("transport_trace", {}).get("enabled", False)
+    if traced_build != (args.capture == "transport"):
+        parser.error("transport capture requires an overlay build; overlay builds cannot produce plain/perf capacity results")
+    if args.pacing_burst_packets and not args.target_bps:
+        parser.error("bounded pacing requires a positive target rate")
     for identity in [*manifest["programs"].values(), *manifest["libraries"].values()]:
         if sc.file_sha256(Path(identity["path"])) != identity["sha256"]:
             parser.error("a peer or library changed since the recorded build")
     programs = {name: value["path"] for name, value in manifest["programs"].items()}
     profiles = args.profile or ["robotweax-self", "robotweax-to-haivision"]
+    if args.capture == "transport" and any(sc.PROFILE_IMPLEMENTATIONS[p][0] != "robotweax" for p in profiles):
+        parser.error("transport attribution currently requires a Robotweax sender")
     if any("haivision" in sc.PROFILE_IMPLEMENTATIONS[p] for p in profiles) and "haivision" not in programs:
         parser.error("selected profile needs the reference peer")
     environment = host_metadata()
@@ -286,7 +316,8 @@ def main(argv: list[str] | None = None) -> int:
               "profiling_scope": "driver and descendant peers, including connection setup and drain; filter by peer PID",
               "started_unix_ns": time.time_ns()}
     report["harness_files"] = [sc.program_identity(path) for path in
-                               (Path(__file__).resolve(), ROOT / "benchmarks/scalability_scorecard.py")]
+                               (Path(__file__).resolve(), ROOT / "benchmarks/scalability_scorecard.py",
+                                ROOT / "benchmarks/retransmission_trace.py")]
     sc.write_report(out / "report.json", report)
     options = sc.RunOptions("127.0.0.1", 1, args.bytes_per_connection, 1316,
                             args.timeout_seconds, 120, 500, .02)
@@ -296,7 +327,8 @@ def main(argv: list[str] | None = None) -> int:
             directory = out / f"{index:02}-{item['profile']}-{item['kind']}"
             directory.mkdir()
             request = {**item, "index": index, "programs": programs, "options": asdict(options),
-                       "target_bps": args.target_bps, "peer_arguments": peer_arguments(args)}
+                       "target_bps": args.target_bps, "peer_arguments": peer_arguments(args), "capture": args.capture,
+                       "pacing_burst_packets": args.pacing_burst_packets}
             sc.write_report(directory / "request.json", request)
             command = perf_command(args.capture, directory / "perf.data",
                                    [sys.executable, str(Path(__file__).resolve()), "--case-file", str(directory / "request.json")], perf)
@@ -307,7 +339,7 @@ def main(argv: list[str] | None = None) -> int:
                     entry.update(json.loads((directory / "case.json").read_text()))
                 else:
                     entry["error"] = "capture/driver exited without a case report; see command.log"
-                if args.capture != "none":
+                if args.capture in ("cpu", "scheduler"):
                     entry["profiling"] = render_capture(args.capture, directory, entry.get("result", {}), perf)
             except Exception as error:
                 entry["error"] = str(error)
@@ -319,7 +351,8 @@ def main(argv: list[str] | None = None) -> int:
         report["finished"] = True
         report["all_transfers_pass"] = all(e["transfer_pass"] and e.get("exit_code") == 0 for e in report["runs"])
         report["all_captures_usable"] = args.capture == "none" or all(e.get("profiling", {}).get("valid") for e in report["runs"])
-        return 0 if report["all_transfers_pass"] and report["all_captures_usable"] else 1
+        report["all_matched_rates_pass"] = not args.pacing_burst_packets or all(e.get("matched_rate_pass") for e in report["runs"])
+        return 0 if report["all_transfers_pass"] and report["all_captures_usable"] and report["all_matched_rates_pass"] else 1
     finally:
         report["finished_unix_ns"] = time.time_ns()
         sc.write_report(out / "report.json", report)

--- a/benchmarks/throughput_diagnostics.py
+++ b/benchmarks/throughput_diagnostics.py
@@ -210,10 +210,16 @@ def render_capture(capture: str, directory: Path, result: dict, perf: str) -> di
         return {"valid": completed.returncode == 0 and all(counts.values()),
                 "samples_by_peer_pid": counts,
                 "call_stack_quality_requires_review": True}
-    # A successful renderer is not proof of a usable per-peer schedule trace.
+    # Linux 6.8/perf 6.8.12 ARM64 can print both endpoint PIDs while omitting
+    # seconds of worker runtime. PID presence is only diagnostic evidence.
+    # Fail closed until thread-family coverage and runtime plausibility have
+    # an independently validated check; do not bless a partial native summary.
     content = (directory / "perf-scheduler.txt").read_text()
     found = all(re.search(rf"(?<!\d){pid}(?!\d)", content) for pid in pids)
-    return {"valid": found, "peer_pids": pids, "trace_coverage_requires_review": True}
+    return {"valid": False, "peer_pids": pids, "peer_pid_mentions": found,
+            "render_succeeded": True, "worker_coverage_validated": False,
+            "runtime_coverage_validated": False, "trace_coverage_requires_review": True,
+            "error": "native scheduler summary is unqualified: independent worker and runtime coverage review required"}
 
 
 def summarize(entries: list[dict]) -> list[dict]:

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,7 @@ combining features.
 - [ACK and ACKACK semantics](acknowledgements.md)
 - [Protocol edge-case policy](protocol-edge-cases.md)
 - [Performance and scalability measurement](performance.md)
+- [Throughput profiling and empty-receive-buffer experiment](throughput-profiling.md)
 
 These pages document stable protocol behavior, resource contracts, and
 reproducible measurement methods. Internal implementation details that are not

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -5,6 +5,11 @@ size, lock counts, or one unusually fast local transfer are not substitutes for
 a controlled comparison. Protocol correctness and timing semantics remain
 mandatory while measuring speed.
 
+For serial single-connection capacity investigations with explicit buffer and
+bandwidth settings, optimized symbolized builds and separate Linux CPU/scheduler
+captures, see [Throughput profiling](throughput-profiling.md). These diagnostics
+are opt-in and do not change the library's runtime defaults.
+
 ## Comparative scorecard
 
 `benchmarks/scalability_scorecard.py` runs public-API peer source linked
@@ -36,7 +41,7 @@ Every connection receives an exact deterministic payload. Process-isolated
 runs validate output SHA-256; the many-socket receiver validates every message,
 logical connection ID, sequence number, and payload byte in memory. Both
 implementations receive the same Live/Message configuration,
-MSS, payload size, flow window, send buffer, unlimited `SRTO_MAXBW`, latency,
+MSS, payload size, flow window, send buffer, default `SRTO_MAXBW=-1`, latency,
 and shutdown grace. The integrity-oriented scorecard explicitly disables
 `SRTO_TLPKTDROP`: packets that miss a deliberately dense benchmark burst must
 remain observable as late delivery rather than being silently removed from a

--- a/docs/throughput-profiling.md
+++ b/docs/throughput-profiling.md
@@ -355,4 +355,138 @@ Acceptance requires correct payloads, no regression of the existing contracts,
 repeatable throughput gain beyond host drift, and reduced work in the measured
 receive scan. This experiment does not establish WAN/media-deadline behavior,
 multi-connection scaling, encrypted throughput or superiority to Haivision.
-No Linux before/after improvement is claimed until those results are reviewed.
+The completed [Linux ARM64 A/B report](https://github.com/Robotweax/srt_network_lab/blob/main/results/2026-09-11-empty-receive-ab/report-de.md)
+(private lab evidence) confirms the receive-scan and throughput improvement.
+It also records additional candidate retransmissions: 0.51–1.84% relative to
+original packets in the unpaced plain measurements. These are **not measured
+network-loss percentages**. Zero observed UDP error counters do not rule out
+delayed ACKs, gaps, bursts or timer-triggered retransmission. The candidate is
+not transport-qualified for merge/release on that evidence alone.
+
+## Matched-rate retransmission investigation
+
+Keep all previous unpaced results, manifests and raw profiles unchanged. This
+follow-up uses the **same original VM**, baseline `a5c428b725b5373651041b0e30678406b2d5c38c`,
+candidate `40387f2dc70b7701b266be1c91f048f2d4fa3b61`, and the same pinned Haivision
+1.5.7 revision above. Record the exact new harness commit; the peer now has an
+optional bounded pacer. Do not label these new measurements as harness `98425af`.
+
+Start at **100,000,000 payload bit/s**, comfortably below the slowest historical
+baseline (~177 Mbit/s). It is a proposed common offered load, **not an assumed
+achieved rate**. `--pacing-burst-packets 4` bounds catch-up credit to four packets;
+long scheduling/backpressure stalls cannot create unbounded application catch-up
+bursts. No sleep/spin changes to the library. With the default value zero, the
+previous peer pacing and all unpaced behavior are preserved.
+
+Each paced caller records first-to-last successful enqueue rate, duration,
+forgiven pacing time and maximum **fixed** 1-ms bucket occupancy (not a sliding
+window or a wire-burst measurement). A matched run requires enqueue rate within
+±2% of target and end-to-end useful throughput at least 95% of target. If either
+variant misses that contract, retain the result and do not claim equal-load
+qualification. Do not silently reduce only one side's rate or retry failures.
+
+### Four fresh builds, identical diagnostic overlay
+
+Use this branch's scripts at one recorded harness commit. Create detached clean
+worktrees for the two library revisions; never reset a working checkout. The
+following assumes `SRT` names that harness checkout, `REFERENCE` the clean pinned
+Haivision checkout, and `WORK` a **new** investigation directory on the VM.
+
+```sh
+git -C "$SRT" worktree add --detach "$WORK/baseline-source" a5c428b725b5373651041b0e30678406b2d5c38c
+git -C "$SRT" worktree add --detach "$WORK/candidate-source" 40387f2dc70b7701b266be1c91f048f2d4fa3b61
+
+for variant in baseline candidate; do
+  python3 "$SRT/benchmarks/prepare_throughput.py" \
+    --robotweax-source "$WORK/$variant-source" --reference-source "$REFERENCE" \
+    --output-directory "$WORK/$variant-plain"
+  python3 "$SRT/benchmarks/prepare_throughput.py" \
+    --robotweax-source "$WORK/$variant-source" --reference-source "$REFERENCE" \
+    --output-directory "$WORK/$variant-trace" --transport-trace
+done
+```
+
+`--transport-trace` exports only committed source to a fresh build-local copy.
+Exact unique anchors insert diagnostic hooks into three implementation files;
+the original checkout and public headers/ABI remain untouched. Original and
+instrumented file hashes, overlay/header hashes, library and peer hashes are
+recorded in the build manifest. Reject dirty source for the overlay. Normal
+builds contain **none** of these hooks. The same overlay must be used on both
+revisions. Source exports/reference programs are runner-local, not artifacts.
+
+This is an intrusive diagnostic build: timestamping/memory stores, initial
+thread-local allocation and the larger working set can alter behavior. Each
+participating thread has at most 32 MiB of event storage (524288 events), no
+per-event heap allocation, synchronization with another trace writer or file
+write. Files are flushed at thread exit, outside transfer completion. It must
+not be sold as a zero-overhead tracer or mixed into plain throughput figures.
+
+### Serial execution and preserved failures
+
+Record the VM's original UDP limits, temporarily raise them as for the previous
+A/B experiment, and restore them in the operator's `finally`/shell trap even
+after interruption. The runner does not use `sudo` or change sysctls. Keep builds
+and unrelated load tests outside the measurement period. Use plain VM-user
+execution; neither `perf` nor system-wide packet capture is needed for these hooks.
+
+```sh
+python3 "$SRT/benchmarks/run_retransmission_ab.py" \
+  --baseline-plain "$WORK/baseline-plain/build-manifest.json" \
+  --candidate-plain "$WORK/candidate-plain/build-manifest.json" \
+  --baseline-trace "$WORK/baseline-trace/build-manifest.json" \
+  --candidate-trace "$WORK/candidate-trace/build-manifest.json" \
+  --output-directory "$WORK/results"
+```
+
+The bounded plan contains **48 transfers**, serially, with 30 s cooldown before
+each block and unchanged 128-MiB payload/FC/buffer/latency/MAXBW parameters:
+
+- Four plain **A–B–B–A** blocks at 100 Mbit/s. Each contains Haivision controls
+  before/after, one excluded warmup per direction and three measurements per
+  direction: 40 transfers, 24 retained measured values in total.
+- Separate traced A/B at 100 Mbit/s: one transfer per direction/variant (4).
+- Separate traced A/B unpaced: one transfer per direction/variant (4), to connect
+  the equal-load findings with the original high-rate symptom. These are new,
+  instrumented experiments; they do not replace the old unpaced A/B results.
+
+All block statuses, including failures, remain in `ab-report.json`; no automatic
+retries. Each block retains `report.json`, case reports, commands, stdout/stderr,
+options, public statistics and VM UDP counter deltas. Captures are labelled
+`transport`, not `measurement`; their rates never enter plain summaries.
+
+### Causal records and acceptance
+
+Every Robotweax sender trace records:
+
+- Validated NAK ranges, including ranges partially older than the active buffer.
+- Actual **new** retransmission queue entries, selection and successful UDP
+  send completion, keyed by send buffer/session and 31-bit packet sequence.
+- Timer expiration with the **pre-poll deadline**, poll time, smoothed RTT and
+  variance; flight size, timeout multiplier after poll and periodic-NAK mode.
+- Accepted ACK sequence/kind, cumulative progress, remaining flight and local/
+  peer RTT estimates. Lite ACK's absent peer fields are not valid RTT samples.
+- Original packet sends and, for the Robotweax receiver, accepted DATA sequence
+  and retransmit flag. This is userspace observation, not kernel/wire time.
+
+`retransmissions.json` contains **one row per actual retransmission**, with its
+original send, first enqueue cause (`nak`, `tail`, `all`), trigger record,
+latest ACK/progress/RTT and receiver observations where available. Repeated NAKs
+do not overwrite a timer cause if the packet was already queued; a timer firing
+does not imply it actually selected a packet. ACK/NAK/timer records remain in
+the raw JSONL files for independent sequence/time correlation.
+
+Missing headers/trailers, overflow, missing cause/original/selection, incomplete
+Robotweax receive-sequence coverage or mismatch against public original and
+retransmission counters invalidate the trace. A crash can leave incomplete
+files; those are evidence, not a zero-retransmission result. Haivision receiver
+internals are not instrumented; its ACK/NAK messages are observed at the
+Robotweax sender. No payload contents, keys or reference binaries are recorded.
+
+Analyze each direction separately: offered-rate/bucket comparability; count and
+ratio of each retransmission reason; timer deadline vs last progressing ACK;
+RTT/variance; NAK ranges vs original send/receiver sequence; queue-to-send delay;
+and changes between plain and traced behavior. No repeats at 100 Mbit/s alone
+exonerate the unpaced behavior. A missing high-rate symptom under instrumentation
+is inconclusive, not fixed. Keep this merge/release question open until the
+unpaced retransmissions are explained. WAN, encryption, multiple connections,
+live deadlines and new optimization work remain separate qualification tasks.

--- a/docs/throughput-profiling.md
+++ b/docs/throughput-profiling.md
@@ -278,7 +278,7 @@ of causality. Validate an optimization with identical before/after blocks on
 the same host, and retain all incomplete transfers.
 
 The first profiles selected the empty receive-side message search in an active
-sender, not `SendBuffer::next_packet()`. This branch therefore adds only an
+sender, not `SendBuffer::next_packet()`. The first candidate therefore adds only an
 `occupied_ == 0` return to `ReceiveBuffer::first_complete_message()`. Occupied
 buffers follow the original search; no send-only shortcut disables receiving.
 The send-buffer cursor and pacing/notification changes are separate work with explicit
@@ -407,7 +407,7 @@ done
 ```
 
 `--transport-trace` exports only committed source to a fresh build-local copy.
-Exact unique anchors insert diagnostic hooks into three implementation files;
+Exact unique anchors insert diagnostic hooks into four implementation files;
 the original checkout and public headers/ABI remain untouched. Original and
 instrumented file hashes, overlay/header hashes, library and peer hashes are
 recorded in the build manifest. Reject dirty source for the overlay. Normal
@@ -465,18 +465,23 @@ Every Robotweax sender trace records:
   variance; flight size, timeout multiplier after poll and periodic-NAK mode.
 - Accepted ACK sequence/kind, cumulative progress, remaining flight and local/
   peer RTT estimates. Lite ACK's absent peer fields are not valid RTT samples.
-- Original packet sends and, for the Robotweax receiver, accepted DATA sequence
-  and retransmit flag. This is userspace observation, not kernel/wire time.
+- Original packet sends and the applied sender flow window after ACK processing.
+- For the Robotweax receiver, pre-insert sequence base/occupancy/capacity,
+  actual `ReceiveStatus`/error/retransmit flag, and successful application pops
+  with remaining occupancy and next ACK sequence. These are userspace
+  observations, not kernel/wire times. The older `data_receive` event with
+  `Error::none` means processing succeeded, **not** that insertion succeeded.
 
 `retransmissions.json` contains **one row per actual retransmission**, with its
 original send, first enqueue cause (`nak`, `tail`, `all`), trigger record,
-latest ACK/progress/RTT and receiver observations where available. Repeated NAKs
+latest ACK/progress/RTT, applied window and receiver insertion outcomes where
+available. Repeated NAKs
 do not overwrite a timer cause if the packet was already queued; a timer firing
 does not imply it actually selected a packet. ACK/NAK/timer records remain in
 the raw JSONL files for independent sequence/time correlation.
 
 Missing headers/trailers, overflow, missing cause/original/selection, incomplete
-Robotweax receive-sequence coverage or mismatch against public original and
+Robotweax accepted-insertion/application-pop coverage or mismatch against public original and
 retransmission counters invalidate the trace. A crash can leave incomplete
 files; those are evidence, not a zero-retransmission result. Haivision receiver
 internals are not instrumented; its ACK/NAK messages are observed at the
@@ -490,3 +495,94 @@ exonerate the unpaced behavior. A missing high-rate symptom under instrumentatio
 is inconclusive, not fixed. Keep this merge/release question open until the
 unpaced retransmissions are explained. WAN, encryption, multiple connections,
 live deadlines and new optimization work remain separate qualification tasks.
+
+## Lite-ACK window-credit correction: focused follow-up
+
+The [matched-rate lab report](https://github.com/Robotweax/srt_network_lab/blob/b7afe84b4a90835343fba06bf997b837ceb0fb03/results/2026-09-11-matched-rate-retransmissions/report-de.md)
+retains all 48 transfers and the failed mixed-direction offered-rate contract.
+Unpaced candidate retransmissions were 650 NAK + 2 tail (self) and 392 NAK +
+3 tail (to Haivision). Timers did not precede their deadlines. Missing sequences
+begin at the 16384/16383 receive-window boundary, but the old trace did not
+record insertion status. Do not reinterpret those files as acceptance evidence.
+
+A deterministic runtime regression now models an undrained four-packet
+receiver: send four, Full ACK two with two free slots, then Lite ACK the remaining
+two. Previously, acknowledging the flight left the window budget unchanged and
+allowed two additional originals. Both `a5c428b` and `40387f2` contain that path;
+this was not introduced by the empty-buffer fast path. Haivision 1.5.7
+[debits Lite-ACK progress](https://github.com/Haivision/srt/blob/899348d8318eb9a3c5a5b6ec43c4a1114288773a/srtcore/core.cpp#L8755).
+
+The correction consumes validated cumulative ACK advancement from the remaining
+window budget, saturating at zero. It runs under the existing connection lock,
+adds no allocation or public API/ABI, and leaves Full/Small-ACK advertisements,
+retransmission permission, counters, and timers unchanged. Four deterministic
+tests cover Live/FileCC, sequence rollover, duplicate/stale/invalid ACKs,
+saturation, and reopening by an actual buffer advertisement. This is not a
+redesign of sender-drop or group sequence-synchronization semantics.
+
+### First run only four unpaced diagnostic transfers
+
+Use the original Linux ARM64 VM, not local macOS or hosted x86-64 results as a
+substitute. Compare the old fast-path candidate `40387f2` (A) against the clean
+tip containing the Lite-ACK correction (B), with the **same new harness/overlay**.
+Record all full SHAs. Do not run the older 48-transfer runner for this stage;
+its fixed pins and matched-rate plan describe a different experiment.
+
+Assume `SRT` is this clean branch checkout, `REFERENCE` the exact clean Haivision
+1.5.7 checkout, and `WORK` a new directory. Build both before measuring:
+
+```sh
+FIX=$(git -C "$SRT" rev-parse HEAD)
+git -C "$SRT" worktree add --detach "$WORK/before-source" 40387f2dc70b7701b266be1c91f048f2d4fa3b61
+git -C "$SRT" worktree add --detach "$WORK/after-source" "$FIX"
+for variant in before after; do
+  python3 "$SRT/benchmarks/prepare_throughput.py" \
+    --robotweax-source "$WORK/$variant-source" --reference-source "$REFERENCE" \
+    --output-directory "$WORK/$variant-trace" --transport-trace --jobs 2
+done
+```
+
+Stop if either build fails. As before, record/temporarily configure/restore
+Linux UDP maxima in the operator's trap; do not silently lower the 8-MiB socket
+requests. Then run these serially, retaining both statuses even if A fails:
+
+```sh
+for variant in before after; do
+  python3 "$SRT/benchmarks/throughput_diagnostics.py" \
+    --build-manifest "$WORK/$variant-trace/build-manifest.json" \
+    --output-directory "$WORK/$variant-results" --capture transport \
+    --profile robotweax-self --profile robotweax-to-haivision \
+    --repetitions 1 --warmups 0 --target-bps 0 --cooldown-seconds 30
+  status=$?
+  printf '%s\n' "variant=$variant exit=$status"
+done
+```
+
+The unchanged defaults retain 128 MiB, 1316-byte messages, FC 16384, pending
+8192, 120-ms TSBPD, TLPKTDROP off, MAXBW and timeout. No retries or relaxed
+integrity/trace checks. Review the first window fill and each repeated sequence:
+
+- `rx_window`: sequence, base, occupied slots, capacity **before** insertion.
+- `rx_insert`: sequence, status (0 in-order, 1 out-of-order, 2 duplicate,
+  3 old, 4 beyond-window), error, retransmit flag. Only error zero and status
+  0/1 prove insertion. A `bind` event's `d` maps its receive buffer.
+- `rx_pop`: receive-buffer object, new base, remaining occupancy, next ACK,
+  bytes delivered; correlate with the first actual drain.
+- `tx_window`: session, validated send-buffer boundary, effective window,
+  remaining flight, runtime time; correlate with Full/Lite ACKs and original sends.
+
+The current analyzer requires outcome/pop evidence for Robotweax self-tests
+and applied-window evidence for either direction. Old traces remain valid
+historical evidence under their original analyzer, not under these new checks.
+New raw events, rejected originals and successful retransmission insertions
+must remain available even when all payloads eventually match.
+
+Acceptance of this diagnostic stage requires a visible pre-fix symptom and
+evidence connecting each rejection to window/base/drain state. An absent
+symptom under instrumentation is inconclusive. Any remaining repetitions must
+still be explained; zero UDP error deltas are not proof of zero network loss.
+After that review, perform separate plain ABBA measurements for performance
+and a new lower common offered rate if needed. Preserve the failed 100-Mbit/s
+results; do not change their tolerance. No broad transport/release approval,
+WAN, encryption or multi-connection throughput claim follows from these four
+diagnostic transfers alone.

--- a/docs/throughput-profiling.md
+++ b/docs/throughput-profiling.md
@@ -1,9 +1,11 @@
 # Throughput profiling (diagnostic branch)
 
-This diagnostic branch now includes an **experimental empty-receive-buffer
-fast path**, not a performance qualification or a released throughput claim.
-Only an empty message search returns earlier; public API, locking and transport
-configuration remain unchanged. Use a dedicated Linux test VM to reproduce a Linux
+This diagnostic branch includes an **experimental empty-receive-buffer
+fast path and Lite-ACK receive-window credit correction**, not a complete transport
+qualification or a released throughput claim. Public API, locking and transport
+configuration remain unchanged. The latest follow-up is the
+[fixed-pin plain ABBA stage](#plain-abba-after-the-lite-ack-diagnosis); earlier
+experiments below retain their original pins and contracts. Use a dedicated Linux test VM to reproduce a Linux
 capacity observation; native macOS and hosted x86-64 CI are separate platform
 controls, not substitutes for that environment.
 
@@ -586,3 +588,123 @@ and a new lower common offered rate if needed. Preserve the failed 100-Mbit/s
 results; do not change their tolerance. No broad transport/release approval,
 WAN, encryption or multi-connection throughput claim follows from these four
 diagnostic transfers alone.
+
+## Plain ABBA after the Lite-ACK diagnosis
+
+The [four-transfer diagnostic report from Lab PR #23](https://github.com/Robotweax/srt_network_lab/blob/292dd3c0352f479456b23c21e962276fa9cb6efb/results/2026-09-12-lite-ack-window/report-de.md)
+connects the old self-test repeats to 508 originals rejected beyond a full
+16384-packet receive window before the first application drain. The corrected
+sender stopped at exactly 16384 originals before that drain, with no insertion
+rejections. Instrumented retransmissions fell from 510 to zero (self) and from
+1362 to zero (to Haivision). Haivision receiver internals were not instrumented.
+These are causal diagnostics, not uninstrumented throughput measurements.
+
+The next stage asks whether the original throughput improvement remains with
+the corrected window accounting and without tracing. It does **not** rerun
+the old 48-transfer matched-rate experiment or change its failed 100-Mbit/s
+offered-rate contract. Use only these library revisions:
+
+| Role | Exact library revision |
+|---|---|
+| A: original slow baseline | `a5c428b725b5373651041b0e30678406b2d5c38c` |
+| B: fast path plus Lite-ACK correction | `09c852b40374d21e60e68b8aadaaabb5aa7294b8` |
+| Haivision 1.5.7 | `899348d8318eb9a3c5a5b6ec43c4a1114288773a` |
+
+All builds and the runner use one clean, committed checkout of this updated
+diagnostic harness. Record that harness's full SHA separately; **do not** use
+its tip as the candidate library revision. The shared peer source remains
+byte-identical to the previous experiment (SHA-256
+`faf487b34f5661e4dc602130628ed216b8054a2ab364abcc275bdda1d826d2ae`).
+
+### Lab-agent handoff: fresh builds, then one serial run
+
+Run on the same dedicated `srt-network-lab-runtime` Ubuntu ARM64 VM, retaining
+the original 4-vCPU/6-GiB configuration. Linux ARM64 alone does not identify
+that VM: the operator must verify its identity and the absence of competing
+workloads. Do not substitute hosted CI or local macOS. Do not run builds,
+profilers, packet capture or other capacity tests during the measurement.
+
+Use a clean checkout of `codex/throughput-send-path` containing this section as
+`SRT`, an existing clean exact-pinned Haivision checkout as `REFERENCE`, and a
+new `WORK` directory. Build **both** pairs before the first measurement; stop
+on any build error. These commands do not modify source checkouts:
+
+```sh
+HARNESS=$(git -C "$SRT" rev-parse HEAD)
+printf '%s\n' "harness=$HARNESS"
+git -C "$SRT" worktree add --detach "$WORK/baseline-source" a5c428b725b5373651041b0e30678406b2d5c38c || exit 1
+git -C "$SRT" worktree add --detach "$WORK/candidate-source" 09c852b40374d21e60e68b8aadaaabb5aa7294b8 || exit 1
+for variant in baseline candidate; do
+  python3 "$SRT/benchmarks/prepare_throughput.py" \
+    --robotweax-source "$WORK/$variant-source" --reference-source "$REFERENCE" \
+    --output-directory "$WORK/$variant-plain" --linkage static --jobs 2 || exit 1
+done
+```
+
+Record, temporarily configure and restore UDP maxima using the operator trap
+in section 2, in the same shell. Run as the normal VM user, with no profiler:
+
+```sh
+python3 "$SRT/benchmarks/run_plain_capacity_ab.py" \
+  --baseline-plain "$WORK/baseline-plain/build-manifest.json" \
+  --candidate-plain "$WORK/candidate-plain/build-manifest.json" \
+  --output-directory "$WORK/plain-abba-results"
+status=$?
+printf '%s\n' "plain-abba-exit=$status"
+```
+
+No automatic retries, selective deletion, alternate parameters or extra
+qualification runs. Preserve the nonzero status if the runner fails. The
+runner finishes subsequent planned blocks after a failed block, but an
+interruption leaves an incomplete report. It never changes sysctls or creates
+hosted CI runs. It rejects wrong/dirty pins, mixed harnesses, overlay builds,
+different toolchain evidence, changed binary hashes and unexpected Release
+flags. Both libraries are static OpenSSL Release `-O3 -DNDEBUG` with `-g`;
+peers retain the builder's common `-O2 -g` flags.
+
+### Fixed measurement plan and interpretation
+
+Four blocks in **A → B → B → A** order, with 30 seconds' cooldown per block.
+Each block has one Haivision self-control before and after, one excluded warmup
+per direction, and **three measured transfers per direction**. Total:
+**40 transfers = 24 measurements + 8 warmups + 8 controls**. This bounded
+confirmation uses six measured samples per variant/direction across its two
+blocks; it is not a long-term stability or tail-distribution qualification.
+
+Every transfer remains unpaced (`target-bps=0`, no bounded pacer), at least
+128 MiB rounded to 101990 messages / 134218840 bytes, 1316-byte payload,
+one connection, Live/Message, 120-ms TSBPD, TLPKTDROP off, pending 8192,
+FC 16384, 32-MiB SRT buffers, 8-MiB requested UDP buffers, MAXBW
+1,250,000,000 bytes/s, 45-second timeout and 500-ms shutdown grace.
+
+`ab-report.json` retains every block status and every case's rate, sender CPU,
+original/retransmitted packet counts, retransmission ratio and host UDP error
+deltas. Per-block/direction summaries provide median, mean and interpolated
+p95 for throughput and sender CPU seconds. With three observations, p95 is
+descriptive only. CPU is sender process user+system time through completion,
+including setup, not a CPU-sample percentage. Warmups and Haivision controls
+remain individually visible and are excluded from those summaries.
+
+The automated `measurement_contract_pass` requires all 40 payloads, complete
+consistent counters, **zero retransmissions in all variants, warmups and
+controls**, and recorded zero host UDP `InErrors`, `RcvbufErrors`,
+`SndbufErrors` and `InCsumErrors` deltas. Missing data is not zero. Nonzero
+retransmissions still remain in throughput summaries if the transfer completed;
+they are never filtered away as outliers. Host counter deltas are not a
+measured network-loss rate.
+
+Even exit zero is **not automatic performance or transport approval**. Review
+all four blocks separately, compare A/B throughput and sender CPU per equal
+transfer, and compare the eight Haivision controls for host drift. Report
+median/mean/p95 and individual retransmissions, not only the best runs. There
+is no new hard-coded 1.4-Gbit/s threshold: decide whether the gain is repeatable
+and substantially larger than control variation. If not, mark the result
+inconclusive; do not silently rerun until green.
+
+Deliver a new Lab result directory/PR with raw JSON/stdout/stderr/logs, build
+commands/caches/compiler/OpenSSL/loader evidence, exact SHAs, SHA-256 manifest,
+runner status and verified cleanup/restored sysctls. Keep all earlier archives
+unchanged. **Do not upload Haivision binaries, static libraries or whole build
+directories.** No WAN, encryption, multi-connection, Live-deadline or release
+claim follows from this loopback stage. Keep the SRT branch unmerged pending
+review of the results and a separate decision on further qualification.

--- a/docs/throughput-profiling.md
+++ b/docs/throughput-profiling.md
@@ -1,8 +1,9 @@
 # Throughput profiling (diagnostic branch)
 
-This is preparation for an investigation, **not a throughput improvement or a
-performance qualification**. The library, public API and default transport
-behavior are unchanged. Use a dedicated Linux test VM to reproduce a Linux
+This diagnostic branch now includes an **experimental empty-receive-buffer
+fast path**, not a performance qualification or a released throughput claim.
+Only an empty message search returns earlier; public API, locking and transport
+configuration remain unchanged. Use a dedicated Linux test VM to reproduce a Linux
 capacity observation; native macOS and hosted x86-64 CI are separate platform
 controls, not substitutes for that environment.
 
@@ -195,6 +196,19 @@ privately. Check event availability and PID/TID coverage. Some kernels/VMs or
 CI runners do not permit these events; that is an explicitly reported capture
 failure, not evidence that there are no waits.
 
+**Known qualification limitation:** on Linux 6.8/perf 6.8.12 ARM64, native
+timehist summaries mentioned both PIDs but omitted seconds of worker runtime.
+The earlier PID-presence acceptance rule was a false positive. Scheduler
+captures now always remain `valid=false` pending independent worker-thread
+coverage and runtime-plausibility review, even if recording and rendering
+succeed. Logs, raw data and the transfer verdict are retained separately;
+the diagnostic command exits nonzero. This is a conservative guard, **not a
+repair of the native renderer**. A validated thread-family/runtime coverage
+checker is still needed before restoring automatic scheduler acceptance.
+Do not infer absence of contention from an incomplete summary. The first
+empty-receive-buffer A/B experiment uses plain blocks and separate CPU
+captures; it does not require a qualified scheduler summary.
+
 Scheduler traces show running, waiting and scheduling delay. They do not by
 themselves prove which C++ mutex caused a wait. If the critical path remains
 ambiguous, the next stage is narrowly scoped off-CPU/lock tracing or optional
@@ -263,12 +277,82 @@ cost or wait tied to the sending critical path. CPU percentages are not proof
 of causality. Validate an optimization with identical before/after blocks on
 the same host, and retain all incomplete transfers.
 
-Potential first change: replace repeated scanning of already-sent buffer slots
-with an independently implemented forward cursor, **if the profile justifies
-its priority**. Pacing/notification changes are separate work with explicit
+The first profiles selected the empty receive-side message search in an active
+sender, not `SendBuffer::next_packet()`. This branch therefore adds only an
+`occupied_ == 0` return to `ReceiveBuffer::first_complete_message()`. Occupied
+buffers follow the original search; no send-only shortcut disables receiving.
+The send-buffer cursor and pacing/notification changes are separate work with explicit
 burst, fairness, lifetime, loss-recovery and timing regression tests. Neither
 more permissive timeouts nor disabled integrity checks count as optimizations.
 
 No hard throughput gate is introduced on noisy hosted runners. The immediate
 milestone is to explain the sender plateau; parity and leadership claims need
 matched cross-provider, multi-connection and physical-network evidence.
+
+## Empty-receive-buffer A/B handoff
+
+Use the same dedicated Ubuntu ARM64 VM as the original profiles. Native macOS
+tests and hosted x86-64 CI cannot establish the before/after result for that VM.
+The two library revisions are:
+
+- Baseline: `a5c428b725b5373651041b0e30678406b2d5c38c`.
+- Candidate: `40387f2dc70b7701b266be1c91f048f2d4fa3b61` (five implementation lines plus regression tests).
+- Haivision: `899348d8318eb9a3c5a5b6ec43c4a1114288773a` in both builds.
+
+From a clean checkout of the current diagnostic branch, prepare both source
+worktrees and builds before any measurement. Use this same checkout's harness
+for both; it records its own identity separately from the library source.
+`scalability_peer.cpp` has not changed between baseline and candidate.
+
+```sh
+SRT="$PWD"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/srt-empty-receive-ab.XXXXXX")"
+git worktree add --detach "$WORK/baseline-source" a5c428b725b5373651041b0e30678406b2d5c38c
+git worktree add --detach "$WORK/candidate-source" 40387f2dc70b7701b266be1c91f048f2d4fa3b61
+git clone --depth 1 --branch v1.5.7 https://github.com/Haivision/srt.git "$WORK/reference"
+for version in baseline candidate; do
+  python3 "$SRT/benchmarks/prepare_throughput.py" \
+    --robotweax-source "$WORK/$version-source" \
+    --reference-source "$WORK/reference" \
+    --output-directory "$WORK/$version-build" --jobs 2
+done
+```
+
+Apply only the approved temporary UDP maxima from section 2, keeping the
+restore trap in the same shell. Stop other builds/load tests. Run four serial
+plain blocks in **baseline → candidate → candidate → baseline** order to expose
+host drift. Each block retains the unchanged 14-case contract: two reference
+controls, two warmups and ten measurements. Do not increase parallelism or
+change pending limits, payload, buffers, MAXBW, timeouts or loss policy.
+
+```sh
+index=0
+for version in baseline candidate candidate baseline; do
+  python3 "$SRT/benchmarks/throughput_diagnostics.py" \
+    --build-manifest "$WORK/$version-build/build-manifest.json" \
+    --output-directory "$WORK/plain-$index-$version" --cooldown-seconds 30
+  status=$?
+  printf '%s\n' "block=$index version=$version exit=$status"
+  index=$((index + 1))
+done
+```
+
+Every output directory is new. Keep nonzero statuses and failed attempts;
+never rerun them away. A shell using `set -e` may stop at the first failure:
+retain it and investigate before continuing rather than disabling a gate.
+Compare median, mean and p95 rates per direction and per block, as well as
+complete counts, CPU time, retransmissions, UDP error deltas and reference
+controls. Do not pool captures/warmups/controls or hide incomplete transfers.
+
+Then run `--capture cpu` separately for each build, with fresh output
+directories and the same parameters. Review symbols, endpoint sample coverage
+and the absolute CPU cost as well as the relative share of the receive search.
+If the optimized transfer is too short for useful samples, retain that result;
+a separately labelled longer-duration experiment must use the same larger
+transfer on **both** revisions. Never lengthen only the candidate capture.
+
+Acceptance requires correct payloads, no regression of the existing contracts,
+repeatable throughput gain beyond host drift, and reduced work in the measured
+receive scan. This experiment does not establish WAN/media-deadline behavior,
+multi-connection scaling, encrypted throughput or superiority to Haivision.
+No Linux before/after improvement is claimed until those results are reviewed.

--- a/docs/throughput-profiling.md
+++ b/docs/throughput-profiling.md
@@ -1,0 +1,274 @@
+# Throughput profiling (diagnostic branch)
+
+This is preparation for an investigation, **not a throughput improvement or a
+performance qualification**. The library, public API and default transport
+behavior are unchanged. Use a dedicated Linux test VM to reproduce a Linux
+capacity observation; native macOS and hosted x86-64 CI are separate platform
+controls, not substitutes for that environment.
+
+## Measurement contract
+
+The first stage deliberately isolates **cleartext, one connection, IPv4
+loopback**, Robotweax → Robotweax and Robotweax → Haivision. The same public-API
+`benchmarks/scalability_peer.cpp` is compiled against both libraries. Defaults
+of the older scalability scorecard remain unchanged; capacity settings are
+explicit additional CLI arguments, never ambient `BENCH_*` variables.
+
+| Setting | Capacity default |
+|---|---|
+| Payload / transfer | 1,316 bytes / at least 128 MiB, rounded up to whole messages |
+| Mode | Live / Message API; TSBPD 120 ms; TLPKTDROP off |
+| Cipher | None: isolate transport before CTR/GCM follow-up |
+| MAXBW | Explicit 1,250,000,000 bytes/s (10 Gbit/s ceiling) |
+| SRT send / receive buffer | 32 MiB each |
+| Flow window / application pending limit | 16,384 / 8,192 packets |
+| Requested UDP buffers | 8 MiB each |
+| Sender workset | Up to 64 messages/socket, 128/round, then yield |
+| Application pacing | Unpaced by default; optional `--target-bps` |
+| Timeout / shutdown grace | 45 s / 500 ms |
+
+These are **capacity diagnostics**, not a recommended production Live
+configuration. TLPKTDROP is off to retain late payload; this cannot establish
+Live deadline compliance. MAXBW=-1 in other scorecards must not be assumed to
+mean unlimited capacity on every implementation.
+
+Uninstrumented blocks contain one Haivision self-control before and after,
+one excluded warmup per selected direction, and five serial measurements per
+direction. Every failed attempt is kept; there are no automatic retries.
+Profile blocks contain one separately instrumented attempt per selected
+direction by default. Their rates are never pooled with baseline summaries.
+
+## 1. Prepare clean identified builds
+
+Requirements: Linux or macOS, Git, CMake >=3.20, a C++20-capable compiler,
+Python >=3.10, pkg-config, and OpenSSL >=3 with development headers. On Ubuntu
+the core packages are `build-essential cmake git pkg-config libssl-dev`.
+For capture also install the kernel/distribution's `perf` tools, commonly
+`linux-tools-common` and `linux-tools-$(uname -r)` or `linux-tools-generic`.
+Check `perf --version`; a hosted/custom kernel may need the actual executable
+under `/usr/lib/linux-tools*/` rather than a mismatched `/usr/bin/perf` wrapper.
+
+From a **clean checkout** of this diagnostic branch:
+
+```sh
+SRT="$PWD"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/srt-throughput.XXXXXX")"
+git clone --depth 1 --branch v1.5.7 https://github.com/Haivision/srt.git "$WORK/reference"
+python3 benchmarks/prepare_throughput.py \
+  --robotweax-source "$SRT" --reference-source "$WORK/reference" \
+  --output-directory "$WORK/build-static" --jobs 2
+```
+
+The builder verifies the exact reference commit
+`899348d8318eb9a3c5a5b6ec43c4a1114288773a`, rejects dirty library sources, uses a
+new output directory, and records both Git revisions, helper identity, all
+build commands, compiler/OpenSSL information, CMake caches, executable/library
+SHA-256 hashes and loader dependencies. No existing build cache is reused.
+
+Libraries use **Release with `-g`**, preserving CMake Release optimization.
+Peers use identical `-std=c++17 -O2 -g` flags, matching the original lab's
+peer optimization level. No sanitizers, Tracy instrumentation, extra frame
+pointers or changed optimization flags are added. CPU recording uses DWARF
+unwinding. Keep unstripped binaries and exact symbols locally for analysis.
+`--allow-dirty-robotweax` is only for development smoke tests and is prominently
+recorded; it is not suitable for release comparisons.
+
+Static linking is the default because the September 11 capacity report used
+static archives. Use `--linkage shared` with a **different fresh output
+directory** for a separate linkage control. Both libraries still use OpenSSL.
+Keep the same linkage for every before/after comparison.
+
+To reproduce the original Robotweax library revision rather than current main:
+
+```sh
+git worktree add --detach "$WORK/robotweax-original" 7b6467ac8bc262ab5f35ac2143b39597cf2cc70e
+python3 benchmarks/prepare_throughput.py \
+  --robotweax-source "$WORK/robotweax-original" \
+  --reference-source "$WORK/reference" \
+  --output-directory "$WORK/build-original" --jobs 2
+```
+
+The helper is always taken from the diagnostic branch, not the old library
+checkout. Record this distinction: it reproduces the settings and integrity
+algorithm, not the byte-identical historical helper. Extra end-of-run resource
+and option observations are outside the per-packet hot loop.
+
+## 2. Check UDP limits, do not silently tune the host
+
+```sh
+sysctl net.core.rmem_max net.core.wmem_max kernel.perf_event_paranoid kernel.kptr_restrict
+```
+
+The runner refuses a Linux capacity run if the configured UDP request exceeds
+either kernel maximum. It never calls sudo or changes sysctls. API readbacks
+are retained, but **are not proof of actual OS buffer allocation**. UDP error
+deltas from `/proc/net/snmp` are VM-global and can include unrelated traffic.
+
+Only if this is a dedicated test VM and you approve the temporary change:
+
+```sh
+old_rmem="$(sysctl -n net.core.rmem_max)"
+old_wmem="$(sysctl -n net.core.wmem_max)"
+trap 'sudo sysctl -w net.core.rmem_max="$old_rmem" net.core.wmem_max="$old_wmem"' EXIT
+sudo sysctl -w net.core.rmem_max=33554432 net.core.wmem_max=33554432
+```
+
+Run the measurements and then restore/verify both values in the same shell.
+Never change production-host network settings for a benchmark. The explicit
+`--allow-small-udp-buffers` override permits a labelled small-buffer experiment,
+not a successful large-buffer capacity qualification.
+
+## 3. Uninstrumented serial baseline
+
+After builds have finished, no concurrent load tests or builds:
+
+```sh
+python3 benchmarks/throughput_diagnostics.py \
+  --build-manifest "$WORK/build-static/build-manifest.json" \
+  --output-directory "$WORK/baseline-01" --cooldown-seconds 30
+```
+
+The default block is 14 short transfers (two controls, two warmups, ten
+measurements), not a broad cipher/fault/platform matrix. Optional independent
+experiments use a new output directory each time:
+
+- `--profile robotweax-to-haivision` isolates the Robotweax sender.
+- `--profile haivision-to-robotweax` controls the Robotweax receiver.
+- `--target-bps 250000000` changes only offered application rate.
+- `--pending-packets 512` changes only the application window.
+- `--bytes-per-connection 536870912` extends a too-short capture/transfer.
+
+The runner checks recorded executable/library hashes before starting. It does
+not overwrite result directories. A throughput summary contains median, p95,
+mean and explicit successful/failed counts. These percentiles describe repeated
+transfer rates, **not packet latency**, and are conditional on complete
+transfers. Throughput uses the existing scorecard interval from before caller
+launch until both completion events are observed, including setup and drain
+but excluding the subsequent shutdown tail. Endpoint completion durations are
+also retained. Do not compare these with differently defined payload-only rates.
+
+## 4. Separate CPU profile
+
+```sh
+python3 benchmarks/throughput_diagnostics.py \
+  --build-manifest "$WORK/build-static/build-manifest.json" \
+  --output-directory "$WORK/cpu-01" --capture cpu --cooldown-seconds 30
+```
+
+This uses `perf record -e cpu-clock -F 199 --call-graph dwarf,8192` around one
+driver plus its descendant peers per case. It does not require a virtualized
+hardware cycle counter. Event access and stack unwinding still depend on the
+guest kernel and permissions. A permission failure, absent perf data, rendering
+failure, or zero recorded samples for either endpoint is **not** an unprofiled
+success. If permissions block capture, review the kernel policy with the test
+host administrator; on a dedicated VM you may explicitly run the command with
+sudo. Do not disable host security policy globally merely to make the test green.
+
+Artifacts include `perf-report.txt`, `perf-stacks.txt`, `sample-coverage.json`,
+and local `perf.data`. The report contains peer PIDs and role/provider mapping.
+Filter by these PIDs: the Python observer is included in the capture, and setup,
+steady transfer and drain are all present. Inspect endpoint samples and stack
+quality before attributing costs; nonzero samples alone do not guarantee useful
+unwinding. DWARF stack dumps are bounded at 8 KiB and may truncate deep stacks.
+Increase trace length before raising sample frequency indiscriminately.
+
+Read CPU-heavy paths first: packet selection, queueing, readiness notifications,
+runtime scheduling, serialization, `sendto`, receiver dispatch, ACK processing,
+and the application's generator/validation loop. User/system CPU and voluntary/
+involuntary context switches are also reported **separately by endpoint process**
+through its completion event; they include setup, not just payload handling.
+
+## 5. Separate scheduler trace
+
+```sh
+python3 benchmarks/throughput_diagnostics.py \
+  --build-manifest "$WORK/build-static/build-manifest.json" \
+  --output-directory "$WORK/scheduler-01" \
+  --capture scheduler --allow-system-wide --cooldown-seconds 30
+```
+
+`perf sched record` uses **system-wide scheduler tracepoints**. It normally
+needs elevated permissions and must only run on a dedicated machine without
+sensitive workloads. The script requires explicit consent. The rendered
+`perf-scheduler.txt` filters the endpoint process IDs; retain the local raw trace
+privately. Check event availability and PID/TID coverage. Some kernels/VMs or
+CI runners do not permit these events; that is an explicitly reported capture
+failure, not evidence that there are no waits.
+
+Scheduler traces show running, waiting and scheduling delay. They do not by
+themselves prove which C++ mutex caused a wait. If the critical path remains
+ambiguous, the next stage is narrowly scoped off-CPU/lock tracing or optional
+Tracy zones. **Tracy is not yet integrated, and no per-packet transport counters
+or new telemetry API have been added.** Packet-per-poll and pacing-reason
+instrumentation should be selected after these initial profiles.
+
+Captures have a 128-MiB per-file limit and bounded process-group timeouts.
+Reaching a limit is a failed/partial capture. Build logs and transfer failures
+are retained. Perform the next plain control block without the profiler.
+
+## 6. macOS smoke and Instruments
+
+The same builder/runner can validate both peers locally. Example short smoke,
+using a new directory and an explicit conservative macOS UDP request:
+
+```sh
+python3 benchmarks/throughput_diagnostics.py \
+  --build-manifest "$WORK/build-static/build-manifest.json" \
+  --output-directory "$WORK/mac-smoke" --repetitions 1 --warmups 0 \
+  --bytes-per-connection 2097152 --udp-buffer 262144 --cooldown-seconds 0
+```
+
+This is a functional check, not Linux capacity evidence. Use Xcode Instruments
+Time Profiler/System Trace for separate native macOS investigation. The Linux
+`--capture` modes intentionally refuse to run on macOS instead of pretending an
+unprofiled run is equivalent. Keep those results in a different evidence set.
+
+## 7. Manual GitHub Actions only
+
+The existing **Timing diagnostics** workflow accepts three additional choices
+on this branch. These jobs run only for explicit `workflow_dispatch`, not on
+push, pull request or schedule. The existing workflow is already registered on
+main, so target the diagnostic branch explicitly:
+
+```sh
+gh workflow run timing-diagnostics.yml --repo Robotweax/srt \
+  --ref codex/throughput-send-path -f investigation=throughput-baseline
+# After reviewing the baseline, separately:
+gh workflow run timing-diagnostics.yml --repo Robotweax/srt \
+  --ref codex/throughput-send-path -f investigation=throughput-cpu
+# Only if scheduler evidence is needed:
+gh workflow run timing-diagnostics.yml --repo Robotweax/srt \
+  --ref codex/throughput-send-path -f investigation=throughput-scheduler
+```
+
+Each job has a 15-minute budget, clean static Release builds, fixed reference,
+two build workers, and a 30-second cooldown. CI is Ubuntu x86-64, **not** the
+original Ubuntu ARM64 VM; record that platform distinction. The ephemeral
+runner temporarily increases UDP maxima and restores them in an EXIT trap.
+Capture commands run with explicit sudo, without altering perf security
+sysctls. Baselines run as the normal runner user; profile rates are not baseline
+results. Jobs can fail if hosted-kernel tracing restrictions prevent capture.
+
+Only JSON/text/log evidence is uploaded (14-day retention), including failed
+attempts. **No Haivision libraries, executables, perf build-ID archives or raw
+system-wide scheduler traces are uploaded.** Raw profiles stay on the runner;
+CPU stacks/reports are symbolized there before teardown. Payloads are synthetic.
+The workflow never downloads code from the private Network Lab repository.
+
+## Review and next change
+
+Required before optimizing: repeatable plain baseline, intact payloads, both
+endpoint profiles with useful symbols, explained UDP errors, and a dominant
+cost or wait tied to the sending critical path. CPU percentages are not proof
+of causality. Validate an optimization with identical before/after blocks on
+the same host, and retain all incomplete transfers.
+
+Potential first change: replace repeated scanning of already-sent buffer slots
+with an independently implemented forward cursor, **if the profile justifies
+its priority**. Pacing/notification changes are separate work with explicit
+burst, fairness, lifetime, loss-recovery and timing regression tests. Neither
+more permissive timeouts nor disabled integrity checks count as optimizations.
+
+No hard throughput gate is introduced on noisy hosted runners. The immediate
+milestone is to explain the sender plateau; parity and leadership claims need
+matched cross-provider, multi-connection and physical-network evidence.

--- a/interop/ci_changes.py
+++ b/interop/ci_changes.py
@@ -400,7 +400,7 @@ def enable_file_interop_profiles(
 def enable_interop_profiles(change_set: ChangeSet, path: str) -> None:
     normalized = path.lower()
     if any(token in normalized for token in
-           ("scalability_scorecard", "throughput_diagnostics")):
+           ("scalability_scorecard", "throughput_diagnostics", "retransmission_trace")):
         # The scorecard uses existing public-API peers. Its own deterministic
         # unit tests validate orchestration and aggregation; comparative runs
         # belong on an explicitly controlled benchmark host, not shared CI.

--- a/interop/ci_changes.py
+++ b/interop/ci_changes.py
@@ -399,7 +399,8 @@ def enable_file_interop_profiles(
 
 def enable_interop_profiles(change_set: ChangeSet, path: str) -> None:
     normalized = path.lower()
-    if "scalability_scorecard" in normalized:
+    if any(token in normalized for token in
+           ("scalability_scorecard", "throughput_diagnostics")):
         # The scorecard uses existing public-API peers. Its own deterministic
         # unit tests validate orchestration and aggregation; comparative runs
         # belong on an explicitly controlled benchmark host, not shared CI.

--- a/interop/tests/test_ci_changes.py
+++ b/interop/tests/test_ci_changes.py
@@ -675,6 +675,9 @@ class CiChangeClassifierTests(unittest.TestCase):
             [
                 "benchmarks/scalability_scorecard.py",
                 "interop/tests/test_scalability_scorecard.py",
+                "benchmarks/throughput_diagnostics.py",
+                "benchmarks/prepare_throughput.py",
+                "interop/tests/test_throughput_diagnostics.py",
                 "docs/performance.md",
             ]
         )

--- a/interop/tests/test_ci_changes.py
+++ b/interop/tests/test_ci_changes.py
@@ -678,6 +678,9 @@ class CiChangeClassifierTests(unittest.TestCase):
                 "benchmarks/throughput_diagnostics.py",
                 "benchmarks/prepare_throughput.py",
                 "interop/tests/test_throughput_diagnostics.py",
+                "benchmarks/retransmission_trace.py",
+                "benchmarks/run_retransmission_ab.py",
+                "interop/tests/test_retransmission_trace.py",
                 "docs/performance.md",
             ]
         )

--- a/interop/tests/test_retransmission_trace.py
+++ b/interop/tests/test_retransmission_trace.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "benchmarks"))
+import retransmission_trace as rt
+import run_retransmission_ab as ab
+import throughput_diagnostics as diag
+
+
+class RetransmissionTraceTests(unittest.TestCase):
+    def test_plan_retains_abba_plain_and_separate_matched_unpaced_traces(self):
+        plan = ab.plan()
+        self.assertEqual([b["variant"] for b in plan[:4]], ["baseline", "candidate", "candidate", "baseline"])
+        self.assertTrue(all(b["capture"] == "none" and b["target_bps"] == 100000000 for b in plan[:4]))
+        self.assertEqual([b["target_bps"] for b in plan[4:]], [100000000, 100000000, 0, 0])
+        transfers = sum(len(diag.case_plan(["robotweax-self", "robotweax-to-haivision"],
+                                           b["repetitions"], 1, True, b["capture"])) for b in plan)
+        self.assertEqual(transfers, 48)
+        self.assertEqual(diag.perf_command("transport", Path("unused"), ["driver"], "unused"), ["driver"])
+
+    def manifests(self):
+        return {(v, m): {"complete": True, "sources": {
+                    "robotweax": {"dirty": False, "revision": revision},
+                    "haivision": {"revision": "899348d8318eb9a3c5a5b6ec43c4a1114288773a"}},
+                    "harness_source": {"sha256": "helper"}, "platform": "linux", "architecture": "arm64",
+                    "crypto": "openssl", "linkage": "static",
+                    "transport_trace": {"enabled": m == "transport", "overlay_script": {"sha256": "overlay"},
+                                        "collector_header": {"sha256": "header"}}}
+                for v, revision in ab.REVISIONS.items() for m in ("none", "transport")}
+
+    def test_manifest_contract(self):
+        ab.validate_manifests(self.manifests())
+        for field, value in (("harness_source", {"sha256": "other"}), ("platform", "darwin"),
+                             ("complete", False), ("transport_trace", {"enabled": True})):
+            manifests = self.manifests()
+            manifests["baseline", "none"][field] = value
+            with self.assertRaises(ValueError):
+                ab.validate_manifests(manifests)
+        with self.assertRaises(ValueError):
+            ab.validate_manifests({})
+
+    def test_exact_hooks_match_both_experimental_revisions(self):
+        # Source anchors also run in shallow CI checkouts via the current source;
+        # the separate local overlay smoke tests pin both historical revisions.
+        for relative, hooks in rt.HOOKS.items():
+            original = (rt.ROOT / relative).read_text()
+            changed = rt.instrument(original, hooks)
+            self.assertIn("RWX_TRACE", changed)
+            with self.assertRaises(ValueError):
+                rt.instrument(changed, hooks)
+
+    def test_ambiguous_anchor_fails_closed(self):
+        with self.assertRaises(ValueError):
+            rt.instrument("x x", [("x", "y")])
+
+    def event(self, kind, a=0, b=0, c=0, d=0, obj=100, ns=None, pid=1):
+        self.clock = getattr(self, "clock", 0) + 1000
+        return dict(kind=kind, a=a, b=b, c=c, d=d, object=obj,
+                    ns=self.clock if ns is None else ns, pid=pid, file="1-0.jsonl", index=self.clock)
+
+    def base(self, seq=42):
+        return [self.event("bind", a=200), self.event("wire_send", a=seq),
+                self.event("ack", a=seq, c=1000, d=200)]
+
+    def test_duplicate_nak_does_not_override_timer_queue_cause(self):
+        e = self.base()
+        e += [self.event("timer"), self.event("request_tail", obj=200),
+              self.event("queued", a=42, obj=200), self.event("nak", a=42, b=42),
+              self.event("request_nak", a=42, b=42, obj=200),
+              self.event("selected", a=42, obj=200), self.event("wire_send", a=42, b=1)]
+        result = rt.analyze_events(e, 1, 1, 1)
+        self.assertTrue(result["valid"], result)
+        self.assertEqual(result["retransmission_reasons"], {"tail": 1})
+        self.assertEqual(result["retransmissions"][0]["lineage"]["trigger"]["kind"], "timer")
+
+    def test_nak_and_timer_all_and_rollover_sequences(self):
+        for reason, trigger in (("nak", "nak"), ("all", "timer")):
+            e = self.base(seq=0x7fffffff)
+            e += [self.event(trigger, a=0x7fffffff), self.event("request_" + reason, obj=200),
+                  self.event("queued", a=0x7fffffff, obj=200),
+                  self.event("selected", a=0x7fffffff, obj=200), self.event("wire_send", a=0x7fffffff, b=1)]
+            result = rt.analyze_events(e, 1, 1, 1)
+            self.assertTrue(result["valid"], result)
+            self.assertEqual(result["retransmission_reasons"], {reason: 1})
+
+    def test_missing_selection_or_original_is_not_guessed_from_latest_nak(self):
+        e = self.base() + [self.event("nak", a=42), self.event("wire_send", a=42, b=1)]
+        result = rt.analyze_events(e, 1, 1, 1)
+        self.assertFalse(result["valid"])
+        self.assertEqual(result["retransmission_reasons"], {"unknown": 1})
+
+    def test_statistic_mismatch_invalidates_otherwise_complete_trace(self):
+        result = rt.analyze_events(self.base(), 1, 1, 2)
+        self.assertFalse(result["valid"])
+        self.assertIn("retransmission coverage 0 != 2", result["errors"])
+
+    def test_receiver_original_observed_before_retransmission_is_preserved(self):
+        e = self.base()
+        e += [self.event("data_receive", a=42, pid=2), self.event("nak", a=42),
+              self.event("request_nak", obj=200), self.event("queued", a=42, obj=200),
+              self.event("selected", a=42, obj=200), self.event("wire_send", a=42, b=1)]
+        result = rt.analyze_events(e, 1, 1, 1)
+        self.assertTrue(result["valid"])
+        self.assertEqual(len(result["retransmissions"][0]["receiver_observations"]), 1)
+
+    def test_missing_or_truncated_or_overflow_trace_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            with self.assertRaises(ValueError):
+                rt.read_events(directory)
+            path = directory / "1-0.jsonl"
+            for tail in (None, {"end": True, "events": 0, "dropped": 1},
+                         {"end": True, "events": 2, "dropped": 0}):
+                lines = [{"schema": 1, "pid": 1}]
+                if tail:
+                    lines.append(tail)
+                path.write_text("\n".join(json.dumps(e) for e in lines) + "\n")
+                with self.assertRaises(ValueError):
+                    rt.read_events(directory)
+
+    def test_trace_reader_uses_pid_and_monotonic_timestamps(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            for pid, ns in ((1, 20), (2, 10)):
+                events = [{"schema": 1, "pid": pid}, self.event("ack", ns=ns),
+                          {"end": True, "events": 1, "dropped": 0}]
+                (directory / f"{pid}-0.jsonl").write_text("\n".join(json.dumps(e) for e in events) + "\n")
+            self.assertEqual([e["pid"] for e in rt.read_events(directory)], [2, 1])

--- a/interop/tests/test_retransmission_trace.py
+++ b/interop/tests/test_retransmission_trace.py
@@ -4,6 +4,7 @@ import json
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "benchmarks"))
@@ -107,6 +108,64 @@ class RetransmissionTraceTests(unittest.TestCase):
         result = rt.analyze_events(e, 1, 1, 1)
         self.assertTrue(result["valid"])
         self.assertEqual(len(result["retransmissions"][0]["receiver_observations"]), 1)
+
+    def test_receive_error_none_is_not_proof_of_insertion(self):
+        events = [self.event("bind", d=300, pid=2),
+                  self.event("rx_window", a=42, b=10, c=32, d=32, pid=2),
+                  self.event("rx_insert", a=42, b=4, c=0, pid=2),
+                  self.event("data_receive", a=42, c=0, pid=2)]
+        summary, insertions = rt.receive_evidence(events, 2)
+        self.assertEqual(summary["accepted_unique_sequences"], 0)
+        self.assertEqual(summary["insert_status_counts"], {"beyond_window": 1})
+        self.assertEqual(insertions[42][0]["window_before"]["b"], 10)
+
+    def test_receive_outcome_and_pop_mapping_are_required(self):
+        events = [self.event("rx_insert", a=42, pid=2), self.event("rx_pop", obj=300, pid=2)]
+        summary, _ = rt.receive_evidence(events, 2)
+        self.assertIn("receive insertion without pre-insert window", summary["errors"])
+        self.assertIn("unmapped receive-buffer pop", summary["errors"])
+
+    def test_receive_acceptance_is_unique_and_retains_rejected_original(self):
+        events = [self.event("bind", d=300, pid=2)]
+        for status, retransmitted in ((4, 0), (0, 1), (2, 1)):
+            events += [self.event("rx_window", a=42, b=42, d=32, pid=2),
+                       self.event("rx_insert", a=42, b=status, d=retransmitted, pid=2)]
+        events.append(self.event("rx_pop", a=43, c=43, d=1316, obj=300, pid=2))
+        summary, insertions = rt.receive_evidence(events, 2)
+        self.assertEqual(summary["errors"], [])
+        self.assertEqual(summary["accepted_unique_sequences"], 1)
+        self.assertEqual(summary["popped_bytes"], 1316)
+        self.assertEqual([i["status"] for i in insertions[42]],
+                         ["beyond_window", "accepted_in_order", "duplicate"])
+
+    def test_case_requires_accepted_insertions_and_complete_application_drain(self):
+        events = self.base() + [self.event("tx_window", a=43), self.event("bind", d=300, pid=2),
+                               self.event("rx_window", a=42, d=32, pid=2),
+                               self.event("rx_insert", a=42, pid=2),
+                               self.event("rx_pop", a=43, c=43, d=1316, obj=300, pid=2)]
+        result = {"peer_process_resources": {"sender": {"pid": 1}, "receiver": {"pid": 2}},
+                  "receiver_implementation": "robotweax", "messages_per_connection": 1,
+                  "message_size_bytes": 1316}
+        complete = [{"event": "complete", "stats": {"pktSentUniqueTotal": 1, "pktRetransTotal": 0}}]
+        with patch.object(rt, "read_events", return_value=events), \
+             patch.object(rt.sc, "read_output", return_value=""), \
+             patch.object(rt.sc, "parse_json_events", return_value=complete), \
+             patch.object(rt.sc, "write_report"):
+            self.assertTrue(rt.analyze_case(Path("unused"), result)["valid"])
+            events[-1]["d"] = 1315
+            self.assertFalse(rt.analyze_case(Path("unused"), result)["valid"])
+            events[-1]["d"] = 1316
+            events[-2]["b"] = 4
+            self.assertFalse(rt.analyze_case(Path("unused"), result)["valid"])
+
+    def test_retransmission_includes_applied_send_window(self):
+        events = self.base() + [self.event("tx_window", a=42, b=0, c=1),
+            self.event("nak", a=42), self.event("request_nak", obj=200),
+            self.event("queued", a=42, obj=200), self.event("selected", a=42, obj=200),
+            self.event("wire_send", a=42, b=1)]
+        result = rt.analyze_events(events, 1, 1, 1)
+        self.assertTrue(result["valid"])
+        self.assertEqual(result["retransmissions"][0]["applied_send_window"]["b"], 0)
 
     def test_missing_or_truncated_or_overflow_trace_is_rejected(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/interop/tests/test_throughput_diagnostics.py
+++ b/interop/tests/test_throughput_diagnostics.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "benchmarks"))
+import prepare_throughput as build
+import throughput_diagnostics as diag
+
+
+class ThroughputDiagnosticsTests(unittest.TestCase):
+    def test_bounded_arguments(self):
+        parse = diag.bounded_int(1, 10)
+        self.assertEqual(parse("5"), 5)
+        for value in ("0", "11"):
+            with self.assertRaises(argparse.ArgumentTypeError):
+                parse(value)
+
+    def test_serial_plan_retains_controls_and_warmups(self):
+        plan = diag.case_plan(["robotweax-self", "robotweax-to-haivision"], 5, 1, True, "none")
+        self.assertEqual(len(plan), 14)
+        self.assertEqual(plan[0]["kind"], "control-before")
+        self.assertEqual(plan[-1]["kind"], "control-after")
+        self.assertEqual(sum(p["kind"] == "measurement" for p in plan), 10)
+
+    def test_profile_plan_never_labels_instrumented_runs_as_baseline(self):
+        for capture in ("cpu", "scheduler"):
+            plan = diag.case_plan(["robotweax-self"], 1, 2, True, capture)
+            self.assertEqual(plan, [{"profile": "robotweax-self", "kind": capture}])
+
+    def test_cpu_capture_uses_software_clock_dwarf_and_child_inheritance(self):
+        command = diag.perf_command("cpu", Path("/tmp/cpu.data"), ["python", "driver"], "/usr/bin/perf")
+        self.assertIn("cpu-clock", command)
+        self.assertIn("dwarf,8192", command)
+        self.assertNotIn("-a", command)
+        self.assertEqual(command[-3:], ["--", "python", "driver"])
+        self.assertEqual(diag.perf_command("none", Path("x"), ["driver"], "perf"), ["driver"])
+
+    def test_peer_controls_are_explicit_not_environment_driven(self):
+        args = argparse.Namespace(pending_packets=8192, udp_buffer=8388608, target_bps=0)
+        command = diag.peer_arguments(args)
+        options = dict(zip(command[::2], command[1::2]))
+        self.assertEqual(options["--max-bandwidth"], "1250000000")
+        self.assertEqual(options["--flow-window"], "16384")
+        self.assertEqual(options["--send-buffer"], "33554432")
+        self.assertEqual(options["--receive-buffer"], "33554432")
+
+    def test_pid_sample_counts_ignore_stacks_and_other_processes(self):
+        text = " 100 rwx-capacity\n 200 hvs-capacity\n 100 rwx-capacity\n 900 python\n ffffffff runtime::poll\n"
+        self.assertEqual(diag.sample_counts(text, [100, 200, 300]), {100: 2, 200: 1, 300: 0})
+        self.assertEqual(diag.sample_counts("rwx-capacity 100\nhvs-capacity 200\n", [100, 200]), {100: 1, 200: 1})
+
+    def test_summary_does_not_hide_failures_or_mix_profiled_rates(self):
+        def entry(kind, passed, rate=0):
+            return {"profile": "robotweax-self", "kind": kind, "transfer_pass": passed,
+                    "result": {"rates": {"useful_bits_per_second": rate * 1e6}}}
+        summary = diag.summarize([entry("measurement", True, 100), entry("measurement", False),
+                                  entry("measurement", True, 300), entry("cpu", True, 999),
+                                  entry("warmup", True, 999), entry("control-before", True, 999)])[0]
+        self.assertEqual(summary["attempts"], 3)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["median_mbps"], 200)
+        self.assertEqual(summary["mean_mbps"], 200)
+        self.assertEqual(summary["p95_mbps"], 290)
+        self.assertTrue(summary["conditional_on_complete_transfers"])
+
+    def test_all_failed_summary_has_null_not_zero_measurements(self):
+        summary = diag.summarize([{"profile": "robotweax-self", "kind": "measurement", "transfer_pass": False}])[0]
+        self.assertIsNone(summary["median_mbps"])
+        self.assertEqual(summary["failed"], 1)
+
+    def request(self, directory):
+        request = {"profile": "robotweax-self", "programs": {"robotweax": "/tmp/peer"},
+                   "options": {"host": "127.0.0.1", "connections": 1, "bytes_per_connection": 13160,
+                               "message_size": 1316, "timeout_seconds": 10, "latency_milliseconds": 120,
+                               "shutdown_grace_milliseconds": 500, "sampling_interval_seconds": .02},
+                   "index": 0, "kind": "measurement", "target_bps": 0, "peer_arguments": []}
+        path = directory / "request.json"
+        path.write_text(json.dumps(request))
+        return path
+
+    def test_case_failure_is_preserved_with_udp_delta(self):
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(diag.sc, "run_many_socket_profile", side_effect=RuntimeError("payload mismatch")), mock.patch.object(diag, "udp_snapshot", side_effect=[{"InErrors": 7}, {"InErrors": 9}]):
+            directory = Path(tmp)
+            self.assertEqual(diag.run_case(self.request(directory)), 1)
+            result = json.loads((directory / "case.json").read_text())
+            self.assertFalse(result["transfer_pass"])
+            self.assertEqual(result["error"], "payload mismatch")
+            self.assertEqual(result["system_udp_delta"], {"InErrors": 2})
+
+    def test_case_rejects_old_peer_without_option_readbacks(self):
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(diag.sc, "run_many_socket_profile", return_value={"rates": {"useful_bits_per_second": 1}}), mock.patch.object(diag.sc, "read_output", return_value=""), mock.patch.object(diag, "udp_snapshot", return_value={}):
+            directory = Path(tmp)
+            self.assertEqual(diag.run_case(self.request(directory)), 1)
+            result = json.loads((directory / "case.json").read_text())
+            self.assertIn("readbacks", result["error"])
+
+    def test_case_success_requires_both_role_readbacks(self):
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(diag.sc, "run_many_socket_profile", return_value={"rates": {"useful_bits_per_second": 1}}), mock.patch.object(diag.sc, "read_output", return_value='{"event":"capacity-options"}\n'), mock.patch.object(diag, "udp_snapshot", return_value={}):
+            directory = Path(tmp)
+            self.assertEqual(diag.run_case(self.request(directory)), 0)
+            result = json.loads((directory / "case.json").read_text())
+            self.assertTrue(result["transfer_pass"])
+            self.assertTrue(result["rate_pass"])
+
+    def test_missing_profile_is_not_success(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertFalse(diag.render_capture("cpu", Path(tmp), {}, "perf")["valid"])
+            self.assertFalse(diag.render_capture("cpu", Path(tmp), {"peer_process_resources": {"sender": None}}, "perf")["valid"])
+
+    def test_cpu_render_requires_samples_from_both_endpoint_processes(self):
+        result = {"peer_process_resources": {"sender": {"pid": 100}, "receiver": {"pid": 200}}}
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / "perf.data").touch()
+            for samples, valid in (("rwx-capacity 100\nhvs-capacity 200\n", True),
+                                   ("rwx-capacity 100\n", False)):
+                completed = subprocess.CompletedProcess([], 0, stdout=samples, stderr="")
+                with mock.patch.object(diag.subprocess, "run", return_value=completed) as run:
+                    capture = diag.render_capture("cpu", directory, result, "perf")
+                self.assertEqual(capture["valid"], valid)
+                self.assertIn("comm,pid,dso,symbol", run.call_args_list[0].args[0])
+                self.assertTrue(capture["call_stack_quality_requires_review"])
+
+    def test_scheduler_render_rejects_partial_pid_matches(self):
+        result = {"peer_process_resources": {"sender": {"pid": 100}, "receiver": {"pid": 200}}}
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / "perf.data").touch()
+            for content, valid in (("rwx-capacity[100] hvs-capacity[200]", True),
+                                   ("rwx-capacity[1000] hvs-capacity[200]", False)):
+                def render(command, **kwargs):
+                    self.assertIn("100,200", command)
+                    kwargs["stdout"].write(content)
+                    return subprocess.CompletedProcess(command, 0)
+                with mock.patch.object(diag.subprocess, "run", side_effect=render):
+                    self.assertEqual(diag.render_capture("scheduler", directory, result, "perf")["valid"], valid)
+
+    @unittest.skipUnless(os.name == "posix", "POSIX process groups")
+    def test_bounded_command_preserves_nonzero_status(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            status = diag.run_bounded([sys.executable, "-c", "print('evidence'); raise SystemExit(7)"], Path(tmp), 5)
+            self.assertEqual(status, 7)
+            self.assertIn("evidence", (Path(tmp) / "command.log").read_text())
+
+    @unittest.skipUnless(os.name == "posix", "POSIX process groups")
+    def test_bounded_command_times_out(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(subprocess.TimeoutExpired):
+                diag.run_bounded([sys.executable, "-c", "import time; time.sleep(60)"], Path(tmp), .1)
+
+    @unittest.skipUnless(os.name == "posix", "POSIX process groups")
+    def test_failed_profiler_cannot_leave_workload_running(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            marker = Path(tmp) / "unexpected-workload"
+            child = f"import time,pathlib; time.sleep(.4); pathlib.Path({str(marker)!r}).touch()"
+            wrapper = f"import subprocess,sys; subprocess.Popen([sys.executable, '-c', {child!r}]); raise SystemExit(9)"
+            self.assertEqual(diag.run_bounded([sys.executable, "-c", wrapper], Path(tmp), 5), 9)
+            time.sleep(.5)
+            self.assertFalse(marker.exists())
+
+    def test_scheduler_requires_explicit_system_wide_consent(self):
+        with mock.patch.object(diag.platform, "system", return_value="Linux"):
+            with self.assertRaises(SystemExit) as context:
+                diag.main(["--build-manifest", "/missing", "--output-directory", "/missing", "--capture", "scheduler"])
+            self.assertEqual(context.exception.code, 2)
+
+    def test_missing_perf_does_not_silently_run_unprofiled(self):
+        with mock.patch.object(diag.platform, "system", return_value="Linux"), mock.patch.object(diag.shutil, "which", return_value=None):
+            with self.assertRaises(SystemExit) as context:
+                diag.main(["--build-manifest", "/missing", "--output-directory", "/missing", "--capture", "cpu"])
+            self.assertEqual(context.exception.code, 2)
+
+    def test_changed_library_is_rejected_before_run(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            library = directory / "lib.a"
+            library.write_bytes(b"changed")
+            manifest = directory / "build.json"
+            manifest.write_text(json.dumps({"complete": True, "programs": {}, "libraries": {"robotweax": {"path": str(library), "sha256": "wrong"}}}))
+            with self.assertRaises(SystemExit):
+                diag.main(["--build-manifest", str(manifest), "--output-directory", str(directory / "results")])
+            self.assertFalse((directory / "results").exists())
+
+    def test_dirty_source_rejected_unless_explicit(self):
+        with mock.patch.object(build.subprocess, "check_output", side_effect=["abc\n", " M file.cpp\n"]):
+            with self.assertRaises(ValueError):
+                build.source_identity(Path("/src"))
+        with mock.patch.object(build.subprocess, "check_output", side_effect=["abc\n", " M file.cpp\n"]):
+            self.assertTrue(build.source_identity(Path("/src"), allow_dirty=True)["dirty"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/interop/tests/test_throughput_diagnostics.py
+++ b/interop/tests/test_throughput_diagnostics.py
@@ -130,19 +130,48 @@ class ThroughputDiagnosticsTests(unittest.TestCase):
                 self.assertIn("comm,pid,dso,symbol", run.call_args_list[0].args[0])
                 self.assertTrue(capture["call_stack_quality_requires_review"])
 
-    def test_scheduler_render_rejects_partial_pid_matches(self):
+    def test_scheduler_pid_presence_never_qualifies_worker_runtime(self):
         result = {"peer_process_resources": {"sender": {"pid": 100}, "receiver": {"pid": 200}}}
         with tempfile.TemporaryDirectory() as tmp:
             directory = Path(tmp)
             (directory / "perf.data").touch()
-            for content, valid in (("rwx-capacity[100] hvs-capacity[200]", True),
-                                   ("rwx-capacity[1000] hvs-capacity[200]", False)):
+            for content, mentioned in (("rwx-capacity[100] hvs-capacity[200]", True),
+                                       ("rwx-capacity[1000] hvs-capacity[200]", False)):
                 def render(command, **kwargs):
                     self.assertIn("100,200", command)
                     kwargs["stdout"].write(content)
                     return subprocess.CompletedProcess(command, 0)
                 with mock.patch.object(diag.subprocess, "run", side_effect=render):
-                    self.assertEqual(diag.render_capture("scheduler", directory, result, "perf")["valid"], valid)
+                    capture = diag.render_capture("scheduler", directory, result, "perf")
+                self.assertFalse(capture["valid"])
+                self.assertEqual(capture["peer_pid_mentions"], mentioned)
+                self.assertTrue(capture["render_succeeded"])
+                self.assertFalse(capture["worker_coverage_validated"])
+                self.assertFalse(capture["runtime_coverage_validated"])
+
+    def test_scheduler_millisecond_only_native_summary_is_not_a_pass(self):
+        # Shape of the observed ARM64 renderer failure, with synthetic PIDs.
+        summary = """Samples of sched_switch event do not have callchains.
+Runtime summary
+comm parent sched-in run-time min-run avg-run max-run stddev migrations
+                 :100[100] -1 1 3.442 3.442 3.442 3.442 0.00 0
+                 :200[200] -1 1 0.766 0.766 0.766 0.766 0.00 0
+"""
+        result = {"peer_process_resources": {
+            "sender": {"pid": 100, "user_cpu_us": 4_800_000, "system_cpu_us": 1_200_000},
+            "receiver": {"pid": 200, "user_cpu_us": 200_000, "system_cpu_us": 170_000}}}
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            (directory / "perf.data").touch()
+            def render(command, **kwargs):
+                kwargs["stdout"].write(summary)
+                return subprocess.CompletedProcess(command, 0)
+            with mock.patch.object(diag.subprocess, "run", side_effect=render):
+                capture = diag.render_capture("scheduler", directory, result, "perf")
+            self.assertTrue(capture["peer_pid_mentions"])
+            self.assertFalse(capture["valid"])
+            self.assertIn("worker", capture["error"])
+            self.assertEqual((directory / "perf-scheduler.txt").read_text(), summary)
 
     @unittest.skipUnless(os.name == "posix", "POSIX process groups")
     def test_bounded_command_preserves_nonzero_status(self):

--- a/interop/tests/test_throughput_diagnostics_plain_ab.py
+++ b/interop/tests/test_throughput_diagnostics_plain_ab.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import copy
+import json
+import math
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "benchmarks"))
+import run_plain_capacity_ab as ab
+
+
+class PlainCapacityABTests(unittest.TestCase):
+    def manifests(self):
+        return {variant: {
+            "complete": True, "sources": {
+                "robotweax": {"dirty": False, "revision": revision},
+                "haivision": {"dirty": False, "revision": ab.build.REFERENCE_REVISION}},
+            "harness_checkout": {"dirty": False, "revision": "common-harness"},
+            "harness_source": {"sha256": ab.PEER_SHA256},
+            "platform": "Linux-test", "architecture": "aarch64", "crypto": "openssl", "linkage": "static",
+            "programs": {"robotweax": {}, "haivision": {}},
+            "libraries": {"robotweax": {}, "haivision": {}},
+        } for variant, revision in ab.REVISIONS.items()}
+
+    def validate(self, manifests):
+        ab.validate_manifests(manifests, {"dirty": False, "revision": "common-harness"},
+                              {"platform": "Linux-test", "architecture": "aarch64"})
+
+    def diagnostic(self, manifest=None):
+        packets = math.ceil(ab.ARGUMENTS["bytes_per_connection"] / 1316)
+        runs = []
+        for index, case in enumerate(ab.cases()):
+            options = {"encryption": "none", "tlpktdrop": False, "pending_packets": 8192,
+                       "requested_maxbw_bytes_per_second": 1250000000, "target_bits_per_second": 0,
+                       "api_fc": 16384, "api_udp_rcvbuf": ab.ARGUMENTS["udp_buffer"],
+                       "api_udp_sndbuf": ab.ARGUMENTS["udp_buffer"]}
+            runs.append({**case, "index": index, "exit_code": 0, "transfer_pass": True,
+                         "system_udp_delta": dict.fromkeys(ab.UDP_ERRORS, 0),
+                         "result": {"connections": 1, "message_size_bytes": 1316,
+                                    "requested_bytes_per_connection": ab.ARGUMENTS["bytes_per_connection"],
+                                    "messages_per_connection": packets, "bytes_per_connection": packets * 1316,
+                                    "integrity": {"deterministic_payload_verified": True, "verified_connections": 1},
+                                    "wire_statistics": {"sender_packets_unique": packets, "sender_packets_total": packets,
+                                                        "receiver_packets_unique": packets, "retransmitted_packets": 0},
+                                    "rates": {"useful_bits_per_second": 100e6},
+                                    "peer_process_resources": {"sender": {"user_cpu_us": 1000000, "system_cpu_us": 500000}},
+                                    "capacity_options": {"caller": [copy.deepcopy(options)], "listener": [copy.deepcopy(options)]}}})
+        return {"finished": True, "all_transfers_pass": True, "capture": "none", "udp_capacity_controlled": True,
+                "arguments": {**ab.ARGUMENTS, "profile": ab.PROFILES, "allow_small_udp_buffers": False},
+                "build_manifest": manifest or {}, "runs": runs}
+
+    def test_fixed_plan_contains_40_cases_with_24_measurements(self):
+        self.assertEqual(ab.plan(), ["baseline", "candidate", "candidate", "baseline"])
+        cases = ab.cases() * len(ab.plan())
+        self.assertEqual(len(cases), 40)
+        self.assertEqual(sum(c["kind"] == "measurement" for c in cases), 24)
+        self.assertEqual(sum(c["kind"] == "warmup" for c in cases), 8)
+        self.assertEqual(sum(c["profile"] == "haivision-self" for c in cases), 8)
+        self.assertEqual(ab.ARGUMENTS["target_bps"], 0)
+        self.assertEqual(ab.REVISIONS["candidate"], "09c852b40374d21e60e68b8aadaaabb5aa7294b8")
+
+    def test_accepts_exact_clean_plain_pair(self):
+        self.validate(self.manifests())
+
+    def test_rejects_wrong_dirty_old_or_traced_sources(self):
+        for keys, value in (
+            (("complete",), False),
+            (("sources", "robotweax", "revision"), "40387f2"),
+            (("sources", "robotweax", "dirty"), True),
+            (("sources", "haivision", "dirty"), True),
+            (("sources", "haivision", "revision"), "wrong"),
+            (("transport_trace",), {"enabled": True}),
+            (("harness_checkout", "dirty"), True),
+            (("harness_checkout", "revision"), "old-harness"),
+            (("harness_source", "sha256"), "changed-peer"),
+            (("platform",), "Darwin"), (("architecture",), "x86_64"),
+            (("crypto",), "none"), (("linkage",), "shared"),
+            (("programs",), {"robotweax": {}}),
+        ):
+            with self.subTest(keys=keys):
+                manifests = self.manifests()
+                target = manifests["candidate"]
+                for key in keys[:-1]:
+                    target = target[key]
+                target[keys[-1]] = value
+                with self.assertRaises(ValueError):
+                    self.validate(manifests)
+
+    def test_requires_both_manifests_and_clean_runner(self):
+        manifests = self.manifests()
+        with self.assertRaises(ValueError):
+            self.validate({"candidate": manifests["candidate"]})
+        with self.assertRaisesRegex(ValueError, "clean committed"):
+            ab.validate_manifests(manifests, {"dirty": True}, {})
+
+    def build_files(self, directory):
+        manifests, paths = self.manifests(), {}
+        for variant in ab.REVISIONS:
+            root = directory / variant
+            root.mkdir()
+            paths[variant] = root / "build-manifest.json"
+            for name in ("compiler.log", "cmake.log", "openssl.log", "crypto-flags.log"):
+                (root / name).write_text(name)
+            for library in ("robotweax", "haivision"):
+                (root / f"{library}-cache.txt").write_text(
+                    "CMAKE_BUILD_TYPE:STRING=Release\nCMAKE_C_FLAGS:STRING=-g\nCMAKE_CXX_FLAGS:STRING=-g\n"
+                    "CMAKE_C_FLAGS_RELEASE:STRING=-O3 -DNDEBUG\nCMAKE_CXX_FLAGS_RELEASE:STRING=-O3 -DNDEBUG\n"
+                    "CMAKE_C_COMPILER:FILEPATH=/usr/bin/cc\nCMAKE_CXX_COMPILER:STRING=/usr/bin/c++\n")
+                for key in ("programs", "libraries"):
+                    artifact = root / f"{key}-{library}"
+                    artifact.write_bytes(b"test build only")
+                    manifests[variant][key][library] = ab.sc.program_identity(artifact)
+        return paths, manifests
+
+    def test_build_preflight_validates_hashes_flags_and_toolchain(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            paths, manifests = self.build_files(Path(tmp))
+            signatures = ab.validate_build_files(paths, manifests)
+            self.assertEqual(signatures["baseline"], signatures["candidate"])
+            (paths["candidate"].parent / "programs-robotweax").write_bytes(b"changed binary")
+            with self.assertRaisesRegex(ValueError, "changed since build"):
+                ab.validate_build_files(paths, manifests)
+
+    def test_build_preflight_rejects_toolchain_or_optimization_changes(self):
+        for filename, text in (("compiler.log", "other compiler"), ("openssl.log", "other OpenSSL"),
+                               ("robotweax-cache.txt", "CMAKE_BUILD_TYPE:STRING=Debug\n")):
+            with self.subTest(filename=filename), tempfile.TemporaryDirectory() as tmp:
+                paths, manifests = self.build_files(Path(tmp))
+                (paths["candidate"].parent / filename).write_text(text)
+                with self.assertRaises(ValueError):
+                    ab.validate_build_files(paths, manifests)
+
+    def test_complete_zero_repeat_block_passes(self):
+        analysis = ab.analyze_block(self.diagnostic(), {}, 0)
+        self.assertTrue(analysis["measurement_contract_pass"], analysis["errors"])
+        self.assertEqual(len(analysis["cases"]), 10)
+
+    def test_nonzero_retransmissions_fail_including_controls_and_warmups(self):
+        for index in range(10):
+            with self.subTest(index=index):
+                report = self.diagnostic()
+                wire = report["runs"][index]["result"]["wire_statistics"]
+                wire["retransmitted_packets"] = 2
+                wire["sender_packets_total"] += 2
+                analysis = ab.analyze_block(report, {}, 0)
+                self.assertFalse(analysis["measurement_contract_pass"])
+                self.assertIn("nonzero retransmissions", " ".join(analysis["errors"]))
+                self.assertGreater(analysis["cases"][index]["retransmission_ratio"], 0)
+
+    def test_missing_counters_are_not_zero_and_inconsistent_totals_fail(self):
+        for key, value in (("retransmitted_packets", None), ("retransmitted_packets", False),
+                           ("retransmitted_packets", -1), ("sender_packets_unique", 0),
+                           ("sender_packets_total", 1), ("receiver_packets_unique", None)):
+            with self.subTest(key=key, value=value):
+                report = self.diagnostic()
+                report["runs"][2]["result"]["wire_statistics"][key] = value
+                self.assertFalse(ab.analyze_block(report, {}, 0)["measurement_contract_pass"])
+
+    def test_udp_missing_reset_or_errors_fail(self):
+        for udp in ({}, {**dict.fromkeys(ab.UDP_ERRORS, 0), "InErrors": 1},
+                    {**dict.fromkeys(ab.UDP_ERRORS, 0), "SndbufErrors": -1}):
+            report = self.diagnostic()
+            report["runs"][2]["system_udp_delta"] = udp
+            self.assertFalse(ab.analyze_block(report, {}, 0)["measurement_contract_pass"])
+
+    def test_reduced_api_udp_buffer_fails_even_with_large_kernel_maximum(self):
+        report = self.diagnostic()
+        report["runs"][2]["result"]["capacity_options"]["listener"][0]["api_udp_rcvbuf"] = 262144
+        self.assertFalse(ab.analyze_block(report, {}, 0)["measurement_contract_pass"])
+
+    def test_rejects_missing_payload_cpu_or_changed_options(self):
+        for key, value in (("integrity", {}), ("connections", 2), ("bytes_per_connection", 0),
+                           ("peer_process_resources", {}), ("capacity_options", {}),
+                           ("rates", {"useful_bits_per_second": float("nan")})):
+            report = self.diagnostic()
+            report["runs"][2]["result"][key] = value
+            self.assertFalse(ab.analyze_block(report, {}, 0)["measurement_contract_pass"])
+
+    def test_missing_extra_reordered_or_failed_runs_fail(self):
+        for mode in ("missing", "extra", "reordered", "failed", "exit"):
+            report = self.diagnostic()
+            if mode == "missing":
+                report["runs"].pop()
+            elif mode == "extra":
+                report["runs"].append(copy.deepcopy(report["runs"][-1]))
+            elif mode == "reordered":
+                report["runs"].reverse()
+            elif mode == "failed":
+                report["runs"][2]["transfer_pass"] = False
+            self.assertFalse(ab.analyze_block(report, {}, 1 if mode == "exit" else 0)["measurement_contract_pass"])
+
+    def test_changed_block_arguments_or_build_fail(self):
+        for key, value in (("capture", "transport"), ("finished", False), ("udp_capacity_controlled", False),
+                           ("build_manifest", {"different": True}), ("arguments", {})):
+            report = self.diagnostic()
+            report[key] = value
+            self.assertFalse(ab.analyze_block(report, {}, 0)["measurement_contract_pass"])
+
+    def test_summary_excludes_controls_and_warmups_but_retains_repeat_failures(self):
+        report = self.diagnostic()
+        for run in report["runs"]:
+            run["result"]["rates"]["useful_bits_per_second"] = 9999e6
+        for index, rate in zip((2, 3, 4), (100, 200, 300)):
+            report["runs"][index]["result"]["rates"]["useful_bits_per_second"] = rate * 1e6
+        wire = report["runs"][2]["result"]["wire_statistics"]
+        wire["retransmitted_packets"] = 1
+        wire["sender_packets_total"] += 1
+        summary = ab.analyze_block(report, {}, 0)["summary"][0]
+        self.assertEqual(summary["mbps"], {"samples": 3, "median": 200, "mean": 200, "p95": 290})
+        self.assertEqual(summary["sender_cpu_seconds"]["median"], 1.5)
+        self.assertEqual(summary["evidence_passes"], 2)
+
+    def test_all_failed_summary_is_null_not_zero(self):
+        report = self.diagnostic()
+        for run in report["runs"]:
+            run["transfer_pass"] = False
+        summary = ab.analyze_block(report, {}, 0)["summary"][0]
+        self.assertIsNone(summary["mbps"]["median"])
+        self.assertEqual(summary["mbps"]["samples"], 0)
+
+    def run_fake(self, tmp, mode):
+        manifests = self.manifests()
+        paths = {variant: Path(tmp) / f"{variant}.json" for variant in ab.REVISIONS}
+        report = {}
+
+        def execute(command, **kwargs):
+            out = Path(command[command.index("--output-directory") + 1])
+            variant = "candidate" if "candidate" in out.name else "baseline"
+            self.assertNotIn("--allow-small-udp-buffers", command)
+            self.assertEqual(command[command.index("--capture") + 1], "none")
+            self.assertEqual(command[command.index("--repetitions") + 1], "3")
+            self.assertEqual(command[command.index("--target-bps") + 1], "0")
+            self.assertEqual(command[command.index("--cooldown-seconds") + 1], "30")
+            if out.name.startswith("00") and mode == "interrupt":
+                raise KeyboardInterrupt
+            if not (out.name.startswith("00") and mode == "missing"):
+                out.mkdir()
+                (out / "report.json").write_text(json.dumps(self.diagnostic(manifests[variant])))
+            return subprocess.CompletedProcess(command, 1 if out.name.startswith("00") and mode == "failed" else 0)
+
+        with patch.object(ab.subprocess, "run", side_effect=execute) as run:
+            if mode == "interrupt":
+                with self.assertRaises(KeyboardInterrupt):
+                    ab.run_blocks(paths, manifests, Path(tmp) / "results", report)
+            else:
+                status = ab.run_blocks(paths, manifests, Path(tmp) / "results", report)
+                self.assertEqual(status, 0 if mode == "pass" else 1)
+                self.assertEqual(run.call_count, 4)  # no retry, even after a failed/missing block
+        return json.loads((Path(tmp) / "results/ab-report.json").read_text())
+
+    def test_runner_pass_never_grants_performance_release_approval(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = self.run_fake(tmp, "pass")
+            self.assertTrue(report["complete"])
+            self.assertTrue(report["measurement_contract_pass"])
+            self.assertTrue(report["performance_decision_requires_review"])
+
+    def test_runner_preserves_failures_missing_reports_and_continues_abba(self):
+        for mode in ("missing", "failed"):
+            with self.subTest(mode=mode), tempfile.TemporaryDirectory() as tmp:
+                report = self.run_fake(tmp, mode)
+                self.assertTrue(report["complete"])
+                self.assertFalse(report["measurement_contract_pass"])
+                self.assertEqual(len(report["blocks"]), 4)
+                self.assertFalse(report["blocks"][0]["analysis"]["measurement_contract_pass"])
+
+    def test_interrupt_keeps_incomplete_report(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            report = self.run_fake(tmp, "interrupt")
+            self.assertFalse(report["complete"])
+            self.assertIsNone(report["blocks"][0]["exit_code"])
+
+    def test_rejects_macos_and_x86_qualification(self):
+        for system, machine in (("Darwin", "arm64"), ("Linux", "x86_64")):
+            with patch.object(ab.platform, "system", return_value=system), patch.object(ab.platform, "machine", return_value=machine):
+                with self.assertRaises(SystemExit):
+                    ab.main(["--baseline-plain", "unused", "--candidate-plain", "unused", "--output-directory", "unused"])
+
+    def test_ci_selection_is_python_only(self):
+        sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+        import ci_changes
+        for path in ("benchmarks/run_plain_capacity_ab.py", "interop/tests/test_throughput_diagnostics_plain_ab.py"):
+            selected = ci_changes.classify([path])
+            self.assertTrue(selected.python)
+            self.assertFalse(selected.full)
+            self.assertFalse(selected.cpp)
+            self.assertFalse(selected.portable)
+            self.assertFalse(selected.interop)
+            self.assertEqual(selected.reference_profiles(), ())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/compat/transport_runtime.cpp
+++ b/src/compat/transport_runtime.cpp
@@ -2330,6 +2330,8 @@ bool ConnectionRuntime::process_reliability_packet_locked(
         }
     }
 
+    const SequenceNumber first_unacknowledged =
+        session_.send_buffer().first_sequence();
     const auto processed = session_.receive(
         clear_packet, now, context);
     if (!processed) {
@@ -2341,6 +2343,21 @@ bool ConnectionRuntime::process_reliability_packet_locked(
         pacer_.set_flow_window(flow_window_packets_);
         if (flow_window_packets_ > previous_flow_window) {
             send_ready_.notify_all();
+        }
+    } else if (clear_packet.kind == PacketKind::control
+        && clear_packet.control.type == ControlType::acknowledgement) {
+        // Lite ACKs advance the cumulative ACK but do not advertise newly
+        // freed receive space. Consume that progress from the last window
+        // budget, or removing the acknowledged flight would permit new data
+        // beyond an undrained receiver's window. Rejected/stale/duplicate ACKs
+        // cannot advance this validated send-buffer boundary.
+        const auto progress =
+            session_.send_buffer().first_sequence().distance_from(
+                first_unacknowledged);
+        if (progress > 0) {
+            flow_window_packets_ -= std::min(
+                flow_window_packets_, static_cast<std::size_t>(progress));
+            pacer_.set_flow_window(flow_window_packets_);
         }
     }
     if (packet.kind == PacketKind::data) {

--- a/src/receive_buffer.cpp
+++ b/src/receive_buffer.cpp
@@ -326,6 +326,11 @@ bool ReceiveBuffer::has_complete_message() const noexcept
 std::optional<BufferedMessageInfo>
 ReceiveBuffer::first_complete_message() const noexcept
 {
+    // Runtime readiness also queries idle receive sides of active senders.
+    // No occupied packet means no complete message, regardless of capacity.
+    if (occupied_ == 0U) {
+        return std::nullopt;
+    }
     SequenceNumber candidate = first_stored_sequence_;
     for (std::size_t offset = 0; offset < capacity(); ++offset) {
         const auto* first = find(candidate);

--- a/tests/test_compat_runtime.cpp
+++ b/tests/test_compat_runtime.cpp
@@ -1145,6 +1145,159 @@ TEST(compat_runtime_honors_peer_receive_window_from_full_ack)
     REQUIRE_EQ(decoded.packet.data.sequence, SequenceNumber {701});
 }
 
+namespace {
+
+void exercise_lite_ack_receive_window(
+    SequenceNumber initial, CongestionController controller)
+{
+    const auto channel = std::make_shared<DatagramChannel>();
+    CapturedDatagrams output;
+    channel->set_send_hook_for_testing(capture_datagram, &output);
+    const Ipv4Endpoint peer {
+        .address = {192, 0, 2, 31},
+        .port = 12'031,
+    };
+    SocketOptions options;
+    REQUIRE_EQ(options.set(SocketOption::send_buffer_packets, 8), Error::none);
+    REQUIRE_EQ(options.set_congestion_controller(
+                   controller == CongestionController::file ? "file" : "live"),
+        Error::none);
+    std::uint64_t now = 1'000;
+    ConnectionRuntime runtime {{
+        .channel = channel,
+        .peer = peer,
+        .peer_socket_id = 301,
+        .initial_sequence = initial,
+        .flow_window_packets = 4,
+        .options = options,
+        .origin = ConnectionRuntime::Clock::now(),
+        .now_function = injected_now,
+        .now_context = &now,
+    }};
+    const std::array<std::byte, 1> payload {std::byte {'x'}};
+    for (int index = 0; index < 8; ++index) {
+        REQUIRE_EQ(runtime.queue_message(payload, 0, true, false, -1).status,
+            MessageIoStatus::success);
+    }
+    const auto poll_data = [&] {
+        for (int index = 0; index < 4; ++index) {
+            now += 1'000;
+            (void)runtime.poll();
+        }
+        std::vector<SequenceNumber> sequences;
+        for (const auto& datagram : take_datagrams(output)) {
+            const auto decoded = decode_packet(datagram);
+            REQUIRE(decoded);
+            if (decoded.packet.kind == PacketKind::data) {
+                REQUIRE(!decoded.packet.data.retransmitted);
+                sequences.push_back(decoded.packet.data.sequence);
+            }
+        }
+        return sequences;
+    };
+    std::uint32_t ack_number = 0;
+    const auto acknowledge = [&](AcknowledgementKind kind,
+                                 std::uint32_t advance, std::uint32_t free) {
+        std::array<std::byte, 32> bytes {};
+        const Acknowledgement acknowledgement {
+            .kind = kind,
+            .acknowledgement_number =
+                kind == AcknowledgementKind::full ? ++ack_number : 0U,
+            .next_sequence = initial.advanced(advance),
+            .available_receive_buffer_packets = free,
+        };
+        const auto encoded =
+            encode_acknowledgement_payload(acknowledgement, bytes);
+        REQUIRE(encoded);
+        runtime.process_packet(
+            {
+                .kind = PacketKind::control,
+                .control =
+                    {
+                        .type = ControlType::acknowledgement,
+                        .type_specific = acknowledgement.acknowledgement_number,
+                        .destination_socket_id = 301,
+                    },
+                .payload = std::span {bytes}.first(encoded.bytes_written),
+            },
+            peer);
+    };
+    const auto window = [&] {
+        return runtime.statistics(false, true)
+            .instantaneous.flow_window_packets;
+    };
+
+    const auto first = poll_data();
+    REQUIRE_EQ(first.size(), 4U);
+    REQUIRE_EQ(first.front(), initial);
+    REQUIRE_EQ(first.back(), initial.advanced(3));
+    // Two packets received, two still in flight; the four-slot receiver
+    // has not delivered anything to its application.
+    acknowledge(AcknowledgementKind::full, 2, 2);
+    REQUIRE_EQ(window(), 2U);
+    REQUIRE(poll_data().empty());
+    acknowledge(AcknowledgementKind::lite, 3, 0);
+    REQUIRE_EQ(window(), 1U);
+    REQUIRE(poll_data().empty());
+
+    // Duplicated/stale ACKs and an invalid future ACK cannot consume credit
+    // twice or reopen the window. No wall-clock sleeps or network are used.
+    acknowledge(AcknowledgementKind::lite, 3, 0);
+    acknowledge(AcknowledgementKind::lite, 2, 0);
+    acknowledge(AcknowledgementKind::full, 2, 100);
+    acknowledge(AcknowledgementKind::lite, 9, 0);
+    REQUIRE_EQ(window(), 1U);
+    acknowledge(AcknowledgementKind::lite, 4, 0);
+    REQUIRE_EQ(window(), 0U);
+    REQUIRE(poll_data().empty());
+
+    // Only a fresh buffer advertisement permits new data again.
+    acknowledge(AcknowledgementKind::full, 4, 2);
+    REQUIRE_EQ(window(), 2U);
+    const auto second = poll_data();
+    REQUIRE_EQ(second.size(), 2U);
+    REQUIRE_EQ(second.front(), initial.advanced(4));
+    REQUIRE_EQ(second.back(), initial.advanced(5));
+    // A shrinking advertisement can be smaller than the outstanding flight.
+    // Its following Lite ACK must saturate at zero, not wrap to a huge window.
+    acknowledge(AcknowledgementKind::full, 4, 1);
+    acknowledge(AcknowledgementKind::lite, 6, 0);
+    REQUIRE_EQ(window(), 0U);
+    REQUIRE(poll_data().empty());
+    acknowledge(AcknowledgementKind::small, 6, 2);
+    REQUIRE_EQ(window(), 2U);
+    const auto last = poll_data();
+    REQUIRE_EQ(last.size(), 2U);
+    REQUIRE_EQ(last.front(), initial.advanced(6));
+    REQUIRE_EQ(last.back(), initial.advanced(7));
+}
+
+} // namespace
+
+TEST(compat_runtime_lite_ack_consumes_live_receive_window_credit)
+{
+    exercise_lite_ack_receive_window(
+        SequenceNumber {700}, CongestionController::live);
+}
+
+TEST(compat_runtime_lite_ack_consumes_file_receive_window_credit)
+{
+    exercise_lite_ack_receive_window(
+        SequenceNumber {700}, CongestionController::file);
+}
+
+TEST(compat_runtime_lite_ack_receive_window_handles_live_sequence_rollover)
+{
+    exercise_lite_ack_receive_window(
+        SequenceNumber {SequenceNumber::mask - 1}, CongestionController::live);
+}
+
+TEST(compat_runtime_lite_ack_receive_window_handles_file_sequence_rollover)
+{
+    exercise_lite_ack_receive_window(
+        SequenceNumber {SequenceNumber::mask - 1}, CongestionController::file);
+}
+
 TEST(compat_runtime_initializes_sender_window_from_peer_handshake)
 {
     SocketOptions options;

--- a/tests/test_receive_buffer.cpp
+++ b/tests/test_receive_buffer.cpp
@@ -24,6 +24,126 @@ PacketView data_packet(SequenceNumber sequence, std::uint32_t message_number,
 
 } // namespace
 
+TEST(receive_buffer_empty_readiness_is_non_mutating_at_all_capacities)
+{
+    for (const std::size_t capacity : {1U, 8U, 16'384U}) {
+        const SequenceNumber initial {SequenceNumber::mask};
+        ReceiveBuffer buffer {initial, capacity};
+        for (int query = 0; query < 4; ++query) {
+            REQUIRE(!buffer.first_complete_message());
+            REQUIRE(!buffer.has_complete_message());
+            REQUIRE(!buffer.has_stream_data());
+            REQUIRE_EQ(buffer.occupied(), 0U);
+            REQUIRE_EQ(buffer.available(), capacity);
+            REQUIRE_EQ(buffer.first_stored_sequence(), initial);
+            REQUIRE_EQ(buffer.next_ack_sequence(), initial);
+        }
+    }
+}
+
+TEST(
+    receive_buffer_empty_fragmented_empty_queries_survive_sequence_and_ring_wrap)
+{
+    ReceiveBuffer buffer {SequenceNumber {SequenceNumber::mask - 1U}, 8};
+    const std::array<std::byte, 1> payload {std::byte {'x'}};
+    for (std::uint32_t message = 1; message <= 4; ++message) {
+        const auto first = buffer.first_stored_sequence();
+        REQUIRE(!buffer.first_complete_message());
+        // Out-of-order fragments are occupied, but not yet a complete message.
+        REQUIRE(buffer.insert(data_packet(
+            first.advanced(2), message, MessageBoundary::last, payload)));
+        REQUIRE(!buffer.first_complete_message());
+        REQUIRE(buffer.insert(
+            data_packet(first, message, MessageBoundary::first, payload)));
+        REQUIRE(!buffer.first_complete_message());
+        REQUIRE(buffer.insert(data_packet(
+            first.next(), message, MessageBoundary::subsequent, payload)));
+        const auto complete = buffer.first_complete_message();
+        REQUIRE(complete);
+        REQUIRE_EQ(complete->first_sequence, first);
+        REQUIRE_EQ(complete->last_sequence, first.advanced(2));
+        REQUIRE(buffer.has_complete_message());
+        REQUIRE_EQ(buffer.occupied(), 3U);
+        std::array<std::byte, 3> output {};
+        REQUIRE_EQ(buffer.pop_message(output).bytes_written, 3U);
+        REQUIRE_EQ(output,
+            (std::array<std::byte, 3> {payload[0], payload[0], payload[0]}));
+        REQUIRE_EQ(buffer.occupied(), 0U);
+        REQUIRE(!buffer.first_complete_message());
+        REQUIRE_EQ(buffer.next_ack_sequence(), first.advanced(3));
+    }
+}
+
+TEST(receive_buffer_empty_readiness_preserves_drop_markers_and_reuse)
+{
+    ReceiveBuffer buffer {SequenceNumber {100}, 8};
+    const std::array<std::byte, 1> payload {std::byte {'d'}};
+    REQUIRE(buffer.insert(
+        data_packet(SequenceNumber {102}, 1, MessageBoundary::solo, payload)));
+    REQUIRE_EQ(buffer.drop_range({SequenceNumber {101}, SequenceNumber {102}}),
+        Error::none);
+    // Interior tombstones are not occupied payload, but must remain in place.
+    REQUIRE_EQ(buffer.occupied(), 0U);
+    REQUIRE(!buffer.first_complete_message());
+    REQUIRE_EQ(buffer.first_stored_sequence(), SequenceNumber {100});
+    REQUIRE_EQ(buffer.next_ack_sequence(), SequenceNumber {100});
+    REQUIRE_EQ(buffer
+                   .insert(data_packet(
+                       SequenceNumber {102}, 1, MessageBoundary::solo, payload))
+                   .status,
+        ReceiveStatus::duplicate);
+    REQUIRE(buffer.insert(
+        data_packet(SequenceNumber {100}, 2, MessageBoundary::solo, payload)));
+    REQUIRE(buffer.has_complete_message());
+    REQUIRE_EQ(buffer.next_ack_sequence(), SequenceNumber {103});
+    std::array<std::byte, 1> output {};
+    REQUIRE(buffer.pop_message(output));
+    REQUIRE(!buffer.first_complete_message());
+    REQUIRE_EQ(buffer.first_stored_sequence(), SequenceNumber {103});
+    REQUIRE(buffer.insert(
+        data_packet(SequenceNumber {103}, 3, MessageBoundary::solo, payload)));
+    REQUIRE(buffer.has_complete_message());
+    REQUIRE(buffer.pop_message(output));
+    REQUIRE(!buffer.first_complete_message());
+}
+
+TEST(receive_buffer_empty_readiness_after_discard_and_partial_stream_drain)
+{
+    ReceiveBuffer buffer {SequenceNumber {SequenceNumber::mask}, 4};
+    const std::array<std::byte, 2> payload {std::byte {'a'}, std::byte {'b'}};
+    REQUIRE(buffer.insert(
+        data_packet(SequenceNumber {0}, 1, MessageBoundary::solo, payload)));
+    REQUIRE_EQ(buffer.discard_before(SequenceNumber {1}), Error::none);
+    REQUIRE_EQ(buffer.occupied(), 0U);
+    REQUIRE(!buffer.first_complete_message());
+    REQUIRE(buffer.insert(
+        data_packet(SequenceNumber {1}, 2, MessageBoundary::solo, payload)));
+    std::array<std::byte, 1> output {};
+    REQUIRE_EQ(buffer.pop_stream(output).bytes_written, 1U);
+    REQUIRE_EQ(output[0], payload[0]);
+    REQUIRE_EQ(buffer.occupied(), 1U);
+    REQUIRE(buffer.first_complete_message());
+    REQUIRE_EQ(buffer.pop_stream(output).bytes_written, 1U);
+    REQUIRE_EQ(output[0], payload[1]);
+    REQUIRE_EQ(buffer.occupied(), 0U);
+    REQUIRE(!buffer.first_complete_message());
+    REQUIRE(!buffer.has_stream_data());
+}
+
+TEST(receive_buffer_empty_payload_is_not_an_empty_buffer)
+{
+    ReceiveBuffer buffer {SequenceNumber {10}, 1};
+    REQUIRE(buffer.insert(
+        data_packet(SequenceNumber {10}, 1, MessageBoundary::solo, {})));
+    REQUIRE_EQ(buffer.buffered_payload_bytes(), 0U);
+    REQUIRE_EQ(buffer.occupied(), 1U);
+    REQUIRE(buffer.first_complete_message());
+    REQUIRE(buffer.has_complete_message());
+    REQUIRE(buffer.pop_message({}));
+    REQUIRE_EQ(buffer.occupied(), 0U);
+    REQUIRE(!buffer.first_complete_message());
+}
+
 TEST(receive_buffer_reports_gap_then_advances_ack_when_filled)
 {
     ReceiveBuffer buffer{SequenceNumber{100}, 8};

--- a/tests/test_session.cpp
+++ b/tests/test_session.cpp
@@ -413,6 +413,46 @@ TEST(session_tsbpd_gate_holds_complete_message_until_delivery_time)
     REQUIRE_EQ(output[0], std::byte{'x'});
 }
 
+TEST(session_active_sender_empty_receive_side_can_become_tsbpd_readable)
+{
+    ReliabilitySession session {{
+        .local_initial_sequence = SequenceNumber {100},
+        .peer_initial_sequence = SequenceNumber {SequenceNumber::mask},
+        .send_capacity_packets = 4,
+        .receive_capacity_packets = 4,
+    }};
+    session.enable_tsbpd(1'000, PacketTimestamp {0}, 100);
+    const std::array<std::byte, 1> payload {std::byte {'x'}};
+    REQUIRE_EQ(
+        session.queue_message(payload, PacketTimestamp {0}), Error::none);
+    REQUIRE_EQ(session.send_buffer().size(), 1U);
+    REQUIRE(!session.message_ready_at(1'000));
+    REQUIRE(!session.next_receive_delivery_time());
+    REQUIRE_EQ(session.drop_too_late_receiver(1'000).receiver_drop_packets, 0U);
+
+    PacketView packet;
+    packet.kind = PacketKind::data;
+    packet.data.sequence = SequenceNumber {SequenceNumber::mask};
+    packet.data.boundary = MessageBoundary::solo;
+    packet.data.timestamp = PacketTimestamp {50};
+    packet.payload = payload;
+    std::array<std::byte, 1> output {};
+    for (int cycle = 0; cycle < 2; ++cycle) {
+        REQUIRE(session.receive(packet, 1'010));
+        REQUIRE(!session.message_ready_at(1'149));
+        REQUIRE_EQ(session.next_receive_delivery_time(),
+            std::optional<std::uint64_t> {1'150});
+        REQUIRE(session.message_ready_at(1'150));
+        REQUIRE(session.pop_message_at(output, 1'150));
+        REQUIRE_EQ(output, payload);
+        REQUIRE(!session.message_ready_at(1'151));
+        REQUIRE(!session.next_receive_delivery_time());
+        REQUIRE_EQ(session.send_buffer().size(), 1U);
+        packet.data.sequence = packet.data.sequence.next();
+    }
+    REQUIRE(session.next_data_packet());
+}
+
 TEST(session_receiver_tlpktdrop_releases_a_due_message_and_fakes_ack)
 {
     ReliabilitySession receiver{{


### PR DESCRIPTION
## Summary

Idle receive-side readiness checks scanned every receive-buffer slot on active senders. Return immediately when the existing occupied-packet count is zero. Also preserve receive-window credit across Lite ACKs: advancing the cumulative ACK without a fresh receive-space advertisement now consumes the remaining budget, preventing new originals from overrunning an undrained receiver.

The branch includes regression tests and reproducible profiling/diagnostic runners. Production changes are confined to `src/receive_buffer.cpp` and `src/compat/transport_runtime.cpp`; public headers, layouts and exports are unchanged. This draft opens the full branch for CI and review. Keep it unmerged pending qualification.

## Evidence

- [Lab PR #23](https://github.com/Robotweax/srt_network_lab/pull/23): instrumented receive-window diagnosis; 508 originals rejected beyond the full receive window before drain, eliminated by corrected accounting.
- [Lab PR #24, reviewed at d44cce30f34097c908ec237681e7b231bb481882](https://github.com/Robotweax/srt_network_lab/tree/d44cce30f34097c908ec237681e7b231bb481882/results/2026-09-12-plain-abba-lite-ack): one uninstrumented serial ABBA run on the original dedicated Ubuntu ARM64 VM, 40/40 payload-correct transfers, zero retransmissions and zero recorded UDP error deltas, original runner and all blocks exit 0.
- Baseline A: `a5c428b725b5373651041b0e30678406b2d5c38c`; candidate B: `09c852b40374d21e60e68b8aadaaabb5aa7294b8`; harness: `1492de88460dc32b99336bfb6bd7956d3232d531`; Haivision 1.5.7: `899348d8318eb9a3c5a5b6ec43c4a1114288773a`.
- Self median: 171.699 to 1440.259 Mbit/s (8.388x); toward Haivision: 170.212 to 1416.494 Mbit/s (8.322x). Sender CPU per equal transfer falls 90.19% / 89.95%. Both B blocks retain the gain against both A blocks; Haivision controls span 4.81% relative to their minimum.
- Evidence validator rerun successfully during review: 342 archived files, hashes, pins, build profiles, raw case/report consistency and recomputed statistics. Archived runner and peer are byte-identical to the pinned source checkout.

## Validation

- [x] DCO check: all six branch commits pass.
- [x] Debug, ASan/UBSan, TSan and fuzz CI results for this branch.
- [x] Local macOS ARM64 Release build, AppleClang 21, OpenSSL 3.6.3, Python 3.13.15.
- [x] All 47 registered CTest entries passed across the initial run and a targeted rerun: 30 passed initially; 17 sandbox-blocked entries passed with local socket access. The original failed log is retained. This is regression validation, not a macOS throughput qualification.
- [x] Native suite 602/602; Python harness suite 621/621; local ABI-baseline and package-consumer tests pass.
- [x] 42 Markdown files validated; branch diff whitespace check passes.
- [x] Linux/macOS/Windows Debug/Release and shared/AEAD platform matrix.
- [x] All 21 existing reference interoperability profiles, including encrypted/AEAD, timing, fault/recovery, FEC, rendezvous and scalability profiles. Broader deployment qualification remains out of scope.

Final CI: [run 34679403004](https://github.com/Robotweax/srt/actions/runs/34679403004) passed at `1492de88460dc32b99336bfb6bd7956d3232d531`: 45 successful jobs, including **Required CI gate** and its **Full validation selected (v1)** marker. The separate Live timing job is intentionally skipped because the core suite already includes it. [Timing diagnostics 34679402993](https://github.com/Robotweax/srt/actions/runs/34679402993) also passed; its manual throughput/group jobs were not selected. No CI retries were needed.

Commands:

```sh
cmake -S . -B build-review -DCMAKE_BUILD_TYPE=Release -DPython3_EXECUTABLE=/opt/homebrew/bin/python3.13
cmake --build build-review --parallel 4
ctest --test-dir build-review --output-on-failure
# Only after proving UDP bind is denied by the sandbox:
ctest --test-dir build-review --rerun-failed --output-on-failure
python3 tools/check_dco.py origin/main HEAD
python3 tests/package_consumer/check_documentation.py .
git diff --check origin/main...HEAD
```

## Performance and risk

No new packet-path allocations, ownership changes, locks or public API/ABI changes. The readiness fast path uses the existing occupied count; zero-byte messages remain occupied, and drop markers are preserved. Lite-ACK progress is computed across validated send-buffer boundaries under the existing connection mutex, with saturating subtraction. Full/Small ACK advertisements still replace the budget; retransmissions still bypass the new-data window gate. Existing tests cover stale/duplicate/future ACKs, saturation, reopening, Live/File controllers, rollover, fragmented messages, drop markers and TSBPD transitions.

The public flow-window statistic now reflects remaining credit after Lite ACKs; packet counter definitions are unchanged. Code review found no new blocking defect in the two production changes, but this is not proof of general transport safety.

The repository classifier selects the full validation matrix for this branch. ABBA establishes bounded single-connection plain loopback performance only. It does not qualify WAN, encryption, multiple connections, bonding, Live deadlines or long-term stability, and does not repair the earlier failed 100-Mbit/s matched-rate contract. No repeat ABBA run is required. Preserve earlier failures and archives; do not publish Haivision binaries or complete reference build directories.
