### PR TITLE
Add aggregate poll and wake diagnostics for the next lab stage

### DIFF
--- a/benchmarks/diagnostics/poll_wake_counters.hpp
+++ b/benchmarks/diagnostics/poll_wake_counters.hpp
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Robotweax GmbH
+#pragma once
+
+// Included only in a fresh diagnostic source export. Fixed thread-local
+// storage; no clock query, allocation, synchronization or I/O per increment.
+// PID/TID registration writes one header once. Counters flush at thread exit
+// and include setup and shutdown activity.
+#include <array>
+#include <atomic>
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <unistd.h>
+#ifdef __linux__
+#include <sys/syscall.h>
+#else
+#include <pthread.h>
+#endif
+
+// clang-format off: keep the counter schema one name per line.
+#define RWX_COUNTER_NAMES(X) \
+    X(channel_polls) \
+    X(rx_attempts) \
+    X(rx_datagrams) \
+    X(rx_eagain) \
+    X(rx_oversize) \
+    X(rx_errors) \
+    X(rx_decode_ok) \
+    X(rx_ack) \
+    X(rx_data) \
+    X(channel_immediate_io) \
+    X(channel_immediate_pacer) \
+    X(channel_delayed) \
+    X(connection_polls) \
+    X(poll_packets) \
+    X(batch_0) \
+    X(batch_1) \
+    X(batch_2_4) \
+    X(batch_5_16) \
+    X(batch_17_64) \
+    X(batch_over_64) \
+    X(tx_originals) \
+    X(tx_retransmissions) \
+    X(poll_flow_block) \
+    X(poll_crypto_block) \
+    X(paced_selection_calls) \
+    X(selection_pacer_block) \
+    X(selection_empty) \
+    X(pacer_queries) \
+    X(pacer_flow_block) \
+    X(pacer_time_block) \
+    X(runtime_now_calls) \
+    X(runtime_clock_reads) \
+    X(scheduler_clock_reads) \
+    X(channel_notify_calls) \
+    X(channel_notify_coalesced) \
+    X(channel_notify_pending) \
+    X(scheduler_submit_calls) \
+    X(scheduler_submit_accepted) \
+    X(scheduler_notify_submit) \
+    X(scheduler_notify_timer) \
+    X(scheduler_notify_cancel) \
+    X(scheduler_tasks) \
+    X(scheduler_waits) \
+    X(scheduler_wait_returns) \
+    X(readiness_notify_calls) \
+    X(readiness_no_waiters) \
+    X(readiness_notify_all) \
+    X(readiness_waits) \
+    X(readiness_wait_returns)
+// clang-format on
+
+namespace robotweax::srt::diagnostics {
+#define RWX_ENUM(name) name,
+enum class Counter { RWX_COUNTER_NAMES(RWX_ENUM) count };
+#undef RWX_ENUM
+#define RWX_NAME(name) #name,
+inline constexpr const char* counter_names[] = {RWX_COUNTER_NAMES(RWX_NAME)};
+#undef RWX_NAME
+inline std::atomic<unsigned> counter_thread_serial {0};
+
+class PollWakeCounters {
+public:
+    PollWakeCounters() noexcept
+    {
+        const char* directory = std::getenv("ROBOTWEAX_POLL_COUNTER_DIR");
+        if (directory == nullptr || *directory == '\0') {
+            return;
+        }
+        pid_ = static_cast<std::uint64_t>(getpid());
+#ifdef __linux__
+        tid_ = static_cast<std::uint64_t>(syscall(SYS_gettid));
+#else
+        if (pthread_threadid_np(nullptr, &tid_) != 0) {
+            std::fputs("poll counters: cannot identify thread\n", stderr);
+            return;
+        }
+#endif
+        serial_ =
+            counter_thread_serial.fetch_add(1U, std::memory_order_relaxed);
+        const int size = std::snprintf(path_.data(), path_.size(),
+            "%s/%" PRIu64 "-%" PRIu64 "-%u.jsonl", directory, pid_, tid_,
+            serial_);
+        enabled_ = size > 0 && static_cast<std::size_t>(size) < path_.size();
+        if (!enabled_) {
+            std::fputs("poll counters: output path too long\n", stderr);
+        }
+        if (enabled_) {
+            file_ = std::fopen(path_.data(), "wx");
+            enabled_ = file_ != nullptr;
+            if (enabled_) {
+                std::fprintf(file_,
+                    "{\"schema\":1,\"pid\":%" PRIu64 ",\"tid\":%" PRIu64
+                    ",\"serial\":%u}\n",
+                    pid_, tid_, serial_);
+                std::fflush(file_);
+            } else {
+                std::fputs(
+                    "poll counters: cannot register thread output\n", stderr);
+            }
+        }
+    }
+
+    void add(Counter counter, std::uint64_t amount = 1) noexcept
+    {
+        if (!enabled_) {
+            return;
+        }
+        auto& value = values_[static_cast<std::size_t>(counter)];
+        if (amount > std::numeric_limits<std::uint64_t>::max() - value) {
+            overflow_ = true;
+            value = std::numeric_limits<std::uint64_t>::max();
+        } else {
+            value += amount;
+        }
+    }
+
+    ~PollWakeCounters()
+    {
+        if (!enabled_) {
+            return;
+        }
+        auto* file = file_;
+        std::fprintf(file,
+            "{\"schema\":1,\"pid\":%" PRIu64 ",\"tid\":%" PRIu64
+            ",\"serial\":%u,\"overflow\":%s,\"counters\":{",
+            pid_, tid_, serial_, overflow_ ? "true" : "false");
+        for (std::size_t i = 0; i < values_.size(); ++i) {
+            std::fprintf(file, "%s\"%s\":%" PRIu64, i == 0 ? "" : ",",
+                counter_names[i], values_[i]);
+        }
+        std::fputs("},\"complete\":true}\n", file);
+        const bool failed = std::ferror(file) != 0;
+        if (std::fclose(file) != 0 || failed) {
+            std::fputs("poll counters: incomplete thread output\n", stderr);
+        }
+    }
+
+private:
+    std::array<std::uint64_t, static_cast<std::size_t>(Counter::count)>
+        values_ {};
+    std::array<char, 4096> path_ {};
+    std::uint64_t pid_ = 0, tid_ = 0;
+    unsigned serial_ = 0;
+    std::FILE* file_ = nullptr;
+    bool enabled_ = false, overflow_ = false;
+};
+
+inline PollWakeCounters& poll_counters() noexcept
+{
+    static thread_local PollWakeCounters counters;
+    return counters;
+}
+
+// Stack-local scope; counts successful DATA sends in this connection poll,
+// including retransmissions, excluding FEC/control. No class layout changes.
+struct PollScope {
+    std::uint64_t packets = 0;
+    PollScope() noexcept
+    {
+        poll_counters().add(Counter::connection_polls);
+    }
+    ~PollScope()
+    {
+        auto& counts = poll_counters();
+        counts.add(Counter::poll_packets, packets);
+        counts.add(packets == 0 ? Counter::batch_0
+                : packets == 1  ? Counter::batch_1
+                : packets <= 4  ? Counter::batch_2_4
+                : packets <= 16 ? Counter::batch_5_16
+                : packets <= 64 ? Counter::batch_17_64
+                                : Counter::batch_over_64);
+    }
+};
+} // namespace robotweax::srt::diagnostics
+
+#define RWX_COUNT(name)                                                        \
+    ::robotweax::srt::diagnostics::poll_counters().add(                        \
+        ::robotweax::srt::diagnostics::Counter::name)
+#define RWX_CLOCK(name, expression) (RWX_COUNT(name), (expression))

--- a/benchmarks/poll_wake_counters.py
+++ b/benchmarks/poll_wake_counters.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Exact-source aggregate-counter overlay; never a plain performance result."""
+from __future__ import annotations
+
+import io
+import json
+import re
+import subprocess
+import zipfile
+from pathlib import Path
+
+import scalability_scorecard as sc
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_REVISION = "8e1bdebed836cb7b732db852f51ef6a7b212e925"
+HEADER = ROOT / "benchmarks/diagnostics/poll_wake_counters.hpp"
+NAMES = tuple(re.findall(r"X\((\w+)\)", HEADER.read_text()))
+
+# Each anchor must occur exactly once, in the unmodified pinned source.
+HOOKS = {
+    "src/compat/transport_runtime.cpp": [
+        ("RuntimePollResult DatagramChannel::run_once() noexcept\n{\n",
+         "RuntimePollResult DatagramChannel::run_once() noexcept\n{\n    RWX_COUNT(channel_polls);\n"),
+        ("        const UdpIoResult received = socket.receive_from(datagram);\n",
+         "        RWX_COUNT(rx_attempts);\n        const UdpIoResult received = socket.receive_from(datagram);\n"),
+        ("        if (received.error == Error::would_block) {\n            break;\n",
+         "        if (received.error == Error::would_block) {\n            RWX_COUNT(rx_eagain);\n            break;\n"),
+        ("        if (received.error == Error::buffer_too_small) {\n            received_any = true;\n",
+         "        if (received.error == Error::buffer_too_small) {\n            RWX_COUNT(rx_oversize);\n            received_any = true;\n"),
+        ("        if (!received) {\n            mark_connections_broken(received.system_error);\n",
+         "        if (!received) {\n            RWX_COUNT(rx_errors);\n            mark_connections_broken(received.system_error);\n"),
+        ("        received_any = true;\n        const auto decoded = decode_packet(\n",
+         "        RWX_COUNT(rx_datagrams);\n        received_any = true;\n        const auto decoded = decode_packet(\n"),
+        ("        if (decoded) {\n            dispatch(decoded.packet,\n",
+         "        if (decoded) {\n            RWX_COUNT(rx_decode_ok);\n"
+         "            if (decoded.packet.kind == PacketKind::data) { RWX_COUNT(rx_data); }\n"
+         "            else if (decoded.packet.control.type == ControlType::acknowledgement) { RWX_COUNT(rx_ack); }\n"
+         "            dispatch(decoded.packet,\n"),
+        ("    if (send_work || received_any) {\n",
+         "    if (send_work || received_any) {\n        RWX_COUNT(channel_immediate_io);\n"),
+        ("        // Queue the final sub-millisecond pacing slice behind other work on\n",
+         "        RWX_COUNT(channel_immediate_pacer);\n        // Queue the final sub-millisecond pacing slice behind other work on\n"),
+        ("    const auto delay = next_work_delay.has_value()\n",
+         "    RWX_COUNT(channel_delayed);\n    const auto delay = next_work_delay.has_value()\n"),
+        ("RuntimePollResult ConnectionRuntime::poll() noexcept\n{\n",
+         "RuntimePollResult ConnectionRuntime::poll() noexcept\n{\n    diagnostics::PollScope rwx_poll_scope;\n"),
+        ("                >= flow_window_packets_) {\n            break;\n",
+         "                >= flow_window_packets_) {\n            RWX_COUNT(poll_flow_block);\n            break;\n"),
+        ("            && !session_.has_pending_retransmission()) {\n            break;\n",
+         "            && !session_.has_pending_retransmission()) {\n            RWX_COUNT(poll_crypto_block);\n            break;\n"),
+        ("        if (!send_data(*packet, packet_time)) {\n            return {};\n        }\n",
+         "        if (!send_data(*packet, packet_time)) {\n            return {};\n        }\n        ++rwx_poll_scope.packets;\n"),
+        ("    const std::size_t application_payload_size = authenticated_data\n",
+         "    if (packet.header.retransmitted) { RWX_COUNT(tx_retransmissions); }\n"
+         "    else { RWX_COUNT(tx_originals); }\n"
+         "    const std::size_t application_payload_size = authenticated_data\n"),
+        ("std::uint64_t ConnectionRuntime::now_microseconds() const noexcept\n{\n",
+         "std::uint64_t ConnectionRuntime::now_microseconds() const noexcept\n{\n    RWX_COUNT(runtime_now_calls);\n"),
+        ("        ConnectionRuntime::Clock::now() - origin).count();\n",
+         "        RWX_CLOCK(runtime_clock_reads, ConnectionRuntime::Clock::now()) - origin).count();\n"),
+        ("void DatagramChannel::notify_send_work() noexcept\n{\n",
+         "void DatagramChannel::notify_send_work() noexcept\n{\n    RWX_COUNT(channel_notify_calls);\n"),
+        ("        if (!scheduled_timer_.valid()) {\n            if (task_active_) {\n",
+         "        if (!scheduled_timer_.valid()) {\n            RWX_COUNT(channel_notify_coalesced);\n            if (task_active_) {\n"),
+        ("            // The worker already owns the continuation. Record a follow-up in\n",
+         "            RWX_COUNT(channel_notify_pending);\n            // The worker already owns the continuation. Record a follow-up in\n"),
+    ],
+    "src/session.cpp": [
+        ("    std::size_t new_packet_wire_overhead) noexcept\n{\n",
+         "    std::size_t new_packet_wire_overhead) noexcept\n{\n    RWX_COUNT(paced_selection_calls);\n"),
+        ("    if (!pacer.query(now_microseconds, flow_count).ready) {\n",
+         "    if (!pacer.query(now_microseconds, flow_count).ready) {\n        RWX_COUNT(selection_pacer_block);\n"),
+        ("    auto packet = send_buffer_.next_packet();\n    if (packet.has_value()) {\n",
+         "    auto packet = send_buffer_.next_packet();\n    if (!packet.has_value()) { RWX_COUNT(selection_empty); }\n    if (packet.has_value()) {\n"),
+    ],
+    "src/timing.cpp": [
+        ("    return {\n        .ready = packets_in_flight < flow_window_packets_\n",
+         "    RWX_COUNT(pacer_queries);\n"
+         "    if (packets_in_flight >= flow_window_packets_) { RWX_COUNT(pacer_flow_block); }\n"
+         "    else if (now_microseconds < next_send_microseconds_) { RWX_COUNT(pacer_time_block); }\n"
+         "    return {\n        .ready = packets_in_flight < flow_window_packets_\n"),
+    ],
+    "src/compat/readiness.cpp": [
+        ("void ReadinessSignal::notify() noexcept\n{\n",
+         "void ReadinessSignal::notify() noexcept\n{\n    RWX_COUNT(readiness_notify_calls);\n"),
+        ("    if (state.waiters.load() == 0U) {\n",
+         "    if (state.waiters.load() == 0U) {\n        RWX_COUNT(readiness_no_waiters);\n"),
+        ("    state.changed.notify_all();\n",
+         "    RWX_COUNT(readiness_notify_all);\n    state.changed.notify_all();\n"),
+        ("    state.waiters.fetch_add(1U);\n",
+         "    state.waiters.fetch_add(1U);\n    RWX_COUNT(readiness_waits);\n"),
+        ("    state.waiters.fetch_sub(1U);\n",
+         "    RWX_COUNT(readiness_wait_returns);\n    state.waiters.fetch_sub(1U);\n"),
+    ],
+    "src/compat/runtime_scheduler.cpp": [
+        ("    std::uint64_t affinity, Task task) noexcept\n{\n",
+         "    std::uint64_t affinity, Task task) noexcept\n{\n    RWX_COUNT(scheduler_submit_calls);\n"),
+        ("    shard.ready.notify_one();\n    return SubmitStatus::accepted;\n",
+         "    RWX_COUNT(scheduler_submit_accepted);\n    RWX_COUNT(scheduler_notify_submit);\n"
+         "    shard.ready.notify_one();\n    return SubmitStatus::accepted;\n"),
+        ("    shard.ready.notify_one();\n    return {\n        .status = SubmitStatus::accepted,\n",
+         "    RWX_COUNT(scheduler_notify_timer);\n    shard.ready.notify_one();\n    return {\n        .status = SubmitStatus::accepted,\n"),
+        ("    shard.ready.notify_one();\n    return true;\n",
+         "    RWX_COUNT(scheduler_notify_cancel);\n    shard.ready.notify_one();\n    return true;\n"),
+        ("std::chrono::steady_clock::now() >= deadline",
+         "RWX_CLOCK(scheduler_clock_reads, std::chrono::steady_clock::now()) >= deadline"),
+        ("                    shard.ready.wait(lock);\n",
+         "                    RWX_COUNT(scheduler_waits);\n                    shard.ready.wait(lock);\n                    RWX_COUNT(scheduler_wait_returns);\n"),
+        ("                shard.ready.wait_until(lock, deadline);\n",
+         "                RWX_COUNT(scheduler_waits);\n                shard.ready.wait_until(lock, deadline);\n                RWX_COUNT(scheduler_wait_returns);\n"),
+        ("        task.function(task.context.get());\n",
+         "        RWX_COUNT(scheduler_tasks);\n        task.function(task.context.get());\n"),
+    ],
+}
+
+
+def instrument(text: str, hooks: list[tuple[str, str]]) -> str:
+    if "RWX_COUNT" in text or "RWX_TRACE" in text:
+        raise ValueError("source already instrumented")
+    for before, after in hooks:
+        if text.count(before) != 1:
+            raise ValueError(f"poll-counter anchor missing or ambiguous: {before!r}")
+        text = text.replace(before, after, 1)
+    return text
+
+
+def export_overlay(source: Path, revision: str, destination: Path) -> dict:
+    if revision != SOURCE_REVISION:
+        raise ValueError(f"poll counters require exact source {SOURCE_REVISION}")
+    archive = subprocess.check_output(["git", "-C", str(source), "archive", "--format=zip", revision])
+    destination.mkdir(exist_ok=False)
+    with zipfile.ZipFile(io.BytesIO(archive)) as files:
+        for item in files.infolist():
+            path = Path(item.filename)
+            if path.is_absolute() or ".." in path.parts or (item.external_attr >> 16) & 0o170000 == 0o120000:
+                raise ValueError("unexpected source export path")
+        files.extractall(destination)
+        for item in files.infolist():
+            if not item.is_dir():
+                (destination / item.filename).chmod(((item.external_attr >> 16) & 0o777) or 0o644)
+    changes = {}
+    for relative, hooks in HOOKS.items():
+        path = destination / relative
+        before = sc.file_sha256(path)
+        prefix = "../" if "/compat/" in relative else ""
+        path.write_text(f'#include "{prefix}diagnostic_poll_counters.hpp"\n' + instrument(path.read_text(), hooks))
+        changes[relative] = {"original_sha256": before, "patched_sha256": sc.file_sha256(path)}
+    (destination / "src/diagnostic_poll_counters.hpp").write_bytes(HEADER.read_bytes())
+    return {"enabled": True, "source_revision": revision, "source_export": str(destination),
+            "changes": changes, "overlay_script": sc.program_identity(Path(__file__).resolve()),
+            "collector_header": sc.program_identity(HEADER), "scope": "thread lifetime; no wait durations"}
+
+
+def read_counters(directory: Path) -> list[dict]:
+    rows, identities = [], set()
+    for path in sorted(directory.glob("*.jsonl")):
+        if path.is_symlink() or path.stat().st_size > 32768:
+            raise ValueError("unexpected counter file")
+        lines = [json.loads(line) for line in path.read_text().splitlines()]
+        if len(lines) != 2:
+            raise ValueError(f"missing registration or completion: {path.name}")
+        header, row = lines
+        if not isinstance(header, dict) or not isinstance(row, dict):
+            raise ValueError("counter records must be objects")
+        identity = tuple(row.get(k) for k in ("pid", "tid", "serial"))
+        if (header.get("schema") != 1 or row.get("schema") != 1
+                or any(type(v) is not int for v in identity)
+                or identity[0] <= 0 or identity[1] <= 0 or identity[2] < 0
+                or tuple(header.get(k) for k in ("pid", "tid", "serial")) != identity
+                or identity in identities or row.get("complete") is not True
+                or row.get("overflow") is not False):
+            raise ValueError(f"invalid counter registration/completion: {path.name}")
+        values = row.get("counters", {})
+        if (not isinstance(values, dict) or set(values) != set(NAMES)
+                or any(type(v) is not int or not 0 <= v < 2**64 for v in values.values())):
+            raise ValueError("missing, unknown or invalid counter")
+        if values["rx_attempts"] != sum(values[k] for k in ("rx_datagrams", "rx_eagain", "rx_oversize", "rx_errors")):
+            raise ValueError("receive outcomes do not reconcile")
+        if values["channel_polls"] != sum(values[k] for k in ("channel_immediate_io", "channel_immediate_pacer", "channel_delayed")):
+            raise ValueError("channel outcomes do not reconcile")
+        if values["connection_polls"] != sum(values[k] for k in NAMES if k.startswith("batch_")):
+            raise ValueError("poll histogram does not reconcile")
+        minimum = sum(values[k] * n for k, n in (("batch_1", 1), ("batch_2_4", 2),
+                      ("batch_5_16", 5), ("batch_17_64", 17), ("batch_over_64", 65)))
+        maximum = sum(values[k] * n for k, n in (("batch_1", 1), ("batch_2_4", 4),
+                      ("batch_5_16", 16), ("batch_17_64", 64)))
+        if values["poll_packets"] < minimum or (not values["batch_over_64"] and values["poll_packets"] > maximum):
+            raise ValueError("packet count outside histogram bounds")
+        if values["readiness_notify_calls"] != values["readiness_no_waiters"] + values["readiness_notify_all"]:
+            raise ValueError("readiness outcomes do not reconcile")
+        for prefix in ("readiness", "scheduler"):
+            if values[prefix + "_waits"] != values[prefix + "_wait_returns"]:
+                raise ValueError("unfinished condition-variable call")
+        identities.add(identity)
+        rows.append({**row, "file": path.name})
+    return rows
+
+
+def analyze_case(directory: Path, result: dict, profile: str) -> dict:
+    try:
+        for role in ("caller", "listener"):
+            if "poll counters:" in sc.read_output(directory / f"many-socket-{role}.stderr"):
+                raise ValueError("collector reported an output failure")
+        rows = read_counters(directory / "poll-counters")
+        implementations = sc.PROFILE_IMPLEMENTATIONS[profile]
+        expected = {role: result["peer_process_resources"][role]["pid"]
+                    for role, impl in zip(("sender", "receiver"), implementations) if impl == "robotweax"}
+        if {r["pid"] for r in rows} != set(expected.values()):
+            raise ValueError("missing Robotweax endpoint or unexpected PID")
+        packets = result["wire_statistics"]["sender_packets_unique"]
+        if type(packets) is not int or packets <= 0:
+            raise ValueError("missing original packet denominator")
+        endpoints = {}
+        for role, pid in expected.items():
+            own = [r for r in rows if r["pid"] == pid]
+            totals = {k: sum(r["counters"][k] for r in own) for k in NAMES}
+            if role == "sender":
+                if (totals["tx_originals"] != packets or totals["tx_retransmissions"] != result["wire_statistics"]["retransmitted_packets"]
+                        or totals["poll_packets"] != totals["tx_originals"] + totals["tx_retransmissions"]):
+                    raise ValueError("sender packet counters do not reconcile with peer completion")
+            elif totals["rx_data"] < result["wire_statistics"]["receiver_packets_unique"]:
+                raise ValueError("receiver data coverage below peer completion")
+            endpoints[role] = {"pid": pid, "threads": own, "totals": totals,
+                               "per_original_packet": {k: v / packets for k, v in totals.items()}}
+        return {"valid": True, "endpoints": endpoints, "reference_only": not expected,
+                "scope": "registered thread lifetimes, including setup/shutdown; notify calls are not wakeups or wait durations"}
+    except (OSError, ValueError, KeyError, TypeError) as error:
+        return {"valid": False, "error": str(error)}
+
+
+def measurement_contract(entry: dict) -> bool:
+    """Evidence validity and the fixed loss-free transfer contract are separate."""
+    if not entry.get("transfer_pass") or entry.get("profiling", {}).get("valid") is not True:
+        return False
+    result = entry.get("result", {})
+    wire = result.get("wire_statistics", {})
+    originals = wire.get("sender_packets_unique")
+    expected = result.get("connections", 0) * result.get("messages_per_connection", 0)
+    if (type(originals) is not int or originals <= 0 or originals != expected
+            or wire.get("receiver_packets_unique") != originals
+            or wire.get("sender_packets_total") != originals
+            or wire.get("retransmitted_packets") != 0):
+        return False
+    delta = entry.get("system_udp_delta", {})
+    return all(type(delta.get(k)) is int and delta[k] == 0
+               for k in ("InErrors", "RcvbufErrors", "SndbufErrors", "InCsumErrors"))

--- a/benchmarks/prepare_throughput.py
+++ b/benchmarks/prepare_throughput.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import scalability_scorecard as sc
 import retransmission_trace as rt
+import poll_wake_counters as pc
 
 REFERENCE_REVISION = "899348d8318eb9a3c5a5b6ec43c4a1114288773a"
 ROOT = Path(__file__).resolve().parents[1]
@@ -46,10 +47,14 @@ def main(argv: list[str] | None = None) -> int:
                         help="development smoke only, recorded in manifest")
     parser.add_argument("--transport-trace", action="store_true",
                         help="instrument a fresh committed-source export; never a capacity result")
+    parser.add_argument("--poll-counters", action="store_true",
+                        help="aggregate poll/wake counters in an exact-source export; diagnostic only")
     args = parser.parse_args(argv)
     if platform.system() not in ("Linux", "Darwin"):
         parser.error("this diagnostic builder currently supports Linux and macOS")
-    if args.transport_trace and args.allow_dirty_robotweax:
+    if args.transport_trace and args.poll_counters:
+        parser.error("transport tracing and poll counters are separate experiments")
+    if (args.transport_trace or args.poll_counters) and args.allow_dirty_robotweax:
         parser.error("transport overlay requires a clean committed Robotweax source")
     compiler = shutil.which(args.cxx)
     if not compiler:
@@ -86,6 +91,11 @@ def main(argv: list[str] | None = None) -> int:
         if args.transport_trace:
             exported = out / "robotweax-traced-source"
             manifest["transport_trace"] = rt.export_overlay(
+                sources["robotweax"], identities["robotweax"]["revision"], exported)
+            sources["robotweax"] = exported
+        if args.poll_counters:
+            exported = out / "robotweax-counter-source"
+            manifest["poll_counters"] = pc.export_overlay(
                 sources["robotweax"], identities["robotweax"]["revision"], exported)
             sources["robotweax"] = exported
         run([compiler, "--version"], "compiler")

--- a/benchmarks/run_plain_capacity_ab.py
+++ b/benchmarks/run_plain_capacity_ab.py
@@ -55,7 +55,8 @@ def validate_manifests(manifests: dict, harness: dict, environment: dict) -> Non
             source = manifest["sources"][library]
             if source.get("dirty") is not False or source.get("revision") != revision:
                 raise ValueError(f"unexpected/dirty {variant} {library} source")
-        if manifest.get("transport_trace", {}).get("enabled", False) is not False:
+        if (manifest.get("transport_trace", {}).get("enabled", False) is not False
+                or manifest.get("poll_counters", {}).get("enabled", False) is not False):
             raise ValueError("instrumented builds cannot produce plain capacity evidence")
         if manifest.get("crypto") != "openssl" or manifest.get("linkage") != "static":
             raise ValueError("this follow-up requires the original static OpenSSL build profile")

--- a/benchmarks/run_retransmission_ab.py
+++ b/benchmarks/run_retransmission_ab.py
@@ -33,6 +33,8 @@ def validate_manifests(manifests: dict) -> None:
         raise ValueError("exactly four A/B plain/trace manifests are required")
     helpers, platforms, overlays = set(), set(), set()
     for (variant, mode), manifest in manifests.items():
+        if manifest.get("poll_counters", {}).get("enabled", False):
+            raise ValueError("poll counters cannot be used in this experiment")
         if not manifest.get("complete") or manifest["sources"]["robotweax"]["dirty"]:
             raise ValueError("all builds must be complete and based on clean revisions")
         if manifest["sources"]["robotweax"]["revision"] != REVISIONS[variant]:

--- a/benchmarks/throughput_diagnostics.py
+++ b/benchmarks/throughput_diagnostics.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 import scalability_scorecard as sc
 import retransmission_trace as rt
+import poll_wake_counters as pc
 
 try:
     import resource
@@ -90,7 +91,7 @@ def case_plan(profiles: list[str], repetitions: int, warmups: int,
 
 
 def perf_command(capture: str, data: Path, command: list[str], perf: str) -> list[str]:
-    if capture in ("none", "transport"):
+    if capture in ("none", "transport", "counters"):
         return command
     if capture == "cpu":
         # Software clock works without a virtualized hardware PMU. DWARF avoids
@@ -153,6 +154,12 @@ def run_case(path: Path) -> int:
             os.environ["ROBOTWEAX_TRANSPORT_TRACE_DIR"] = str(trace_directory)
         else:
             os.environ.pop("ROBOTWEAX_TRANSPORT_TRACE_DIR", None)
+        if request.get("capture") == "counters":
+            counter_directory = directory / "poll-counters"
+            counter_directory.mkdir(exist_ok=False)
+            os.environ["ROBOTWEAX_POLL_COUNTER_DIR"] = str(counter_directory)
+        else:
+            os.environ.pop("ROBOTWEAX_POLL_COUNTER_DIR", None)
         result = sc.run_many_socket_profile(
             request["profile"], {k: Path(v) for k, v in request["programs"].items()},
             sc.RunOptions(**request["options"]), directory,
@@ -181,6 +188,10 @@ def run_case(path: Path) -> int:
                 and entry["rate_pass"])
         if request.get("capture") == "transport":
             entry["profiling"] = rt.analyze_case(directory, result)
+        if request.get("capture") == "counters":
+            entry["profiling"] = pc.analyze_case(directory, result, request["profile"])
+            if not entry["profiling"]["valid"]:
+                return 1
         return 0
     except Exception as error:
         entry["error"] = str(error)
@@ -262,7 +273,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--build-manifest", type=Path, required=True)
     parser.add_argument("--output-directory", type=Path, required=True)
     parser.add_argument("--profile", action="append", choices=PROFILES)
-    parser.add_argument("--capture", choices=("none", "cpu", "scheduler", "transport"), default="none")
+    parser.add_argument("--capture", choices=("none", "cpu", "scheduler", "transport", "counters"), default="none")
     parser.add_argument("--repetitions", type=bounded_int(1, 10))
     parser.add_argument("--warmups", type=bounded_int(0, 2), default=1)
     parser.add_argument("--bytes-per-connection", type=bounded_int(1316, 1024**3), default=128 * 1024**2)
@@ -288,6 +299,15 @@ def main(argv: list[str] | None = None) -> int:
     if manifest.get("complete") is not True:
         parser.error("build manifest is incomplete")
     traced_build = manifest.get("transport_trace", {}).get("enabled", False)
+    counter_build = manifest.get("poll_counters", {}).get("enabled", False)
+    if counter_build != (args.capture == "counters") or (counter_build and traced_build):
+        parser.error("counter overlay requires capture=counters and cannot produce plain/perf/transport results")
+    if counter_build:
+        overlay = manifest["poll_counters"]
+        if (overlay.get("source_revision") != pc.SOURCE_REVISION
+                or overlay.get("overlay_script", {}).get("sha256") != sc.file_sha256(Path(pc.__file__))
+                or overlay.get("collector_header", {}).get("sha256") != sc.file_sha256(pc.HEADER)):
+            parser.error("counter source, overlay or collector differs from this runner")
     if traced_build != (args.capture == "transport"):
         parser.error("transport capture requires an overlay build; overlay builds cannot produce plain/perf capacity results")
     if args.pacing_burst_packets and not args.target_bps:
@@ -317,7 +337,8 @@ def main(argv: list[str] | None = None) -> int:
               "started_unix_ns": time.time_ns()}
     report["harness_files"] = [sc.program_identity(path) for path in
                                (Path(__file__).resolve(), ROOT / "benchmarks/scalability_scorecard.py",
-                                ROOT / "benchmarks/retransmission_trace.py")]
+                                ROOT / "benchmarks/retransmission_trace.py",
+                                ROOT / "benchmarks/poll_wake_counters.py", pc.HEADER)]
     sc.write_report(out / "report.json", report)
     options = sc.RunOptions("127.0.0.1", 1, args.bytes_per_connection, 1316,
                             args.timeout_seconds, 120, 500, .02)
@@ -352,7 +373,10 @@ def main(argv: list[str] | None = None) -> int:
         report["all_transfers_pass"] = all(e["transfer_pass"] and e.get("exit_code") == 0 for e in report["runs"])
         report["all_captures_usable"] = args.capture == "none" or all(e.get("profiling", {}).get("valid") for e in report["runs"])
         report["all_matched_rates_pass"] = not args.pacing_burst_packets or all(e.get("matched_rate_pass") for e in report["runs"])
-        return 0 if report["all_transfers_pass"] and report["all_captures_usable"] and report["all_matched_rates_pass"] else 1
+        report["counter_measurement_contract_pass"] = (args.capture != "counters"
+            or all(pc.measurement_contract(e) for e in report["runs"]))
+        return 0 if (report["all_transfers_pass"] and report["all_captures_usable"]
+                     and report["all_matched_rates_pass"] and report["counter_measurement_contract_pass"]) else 1
     finally:
         report["finished_unix_ns"] = time.time_ns()
         sc.write_report(out / "report.json", report)

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,7 @@ combining features.
 - [Protocol edge-case policy](protocol-edge-cases.md)
 - [Performance and scalability measurement](performance.md)
 - [Throughput profiling and empty-receive-buffer experiment](throughput-profiling.md)
+- [Aggregate poll/wake counters and fixed lab handoff](poll-wake-diagnostics.md)
 
 These pages document stable protocol behavior, resource contracts, and
 reproducible measurement methods. Internal implementation details that are not

--- a/docs/poll-wake-diagnostics.md
+++ b/docs/poll-wake-diagnostics.md
@@ -1,0 +1,182 @@
+# Aggregate poll/wake diagnosis after Lab PR #27
+
+This stage measures how much receive, polling, notification and pacing work
+Robotweax performs per original DATA packet. It prepares the next isolated
+optimization; it contains no production transport change or performance claim.
+
+The [Lab PR #27 report](https://github.com/Robotweax/srt_network_lab/pull/27)
+at `ae5d058a33e38f56e0cc8820c00ef32ec4cd9236` retained 16 complete transfers
+with zero retransmissions and recorded UDP errors. Its partial stacks do not
+establish repeated send-buffer scanning as the dominant cost. Receive syscalls,
+futex/wakeup and clock paths warrant counting before changing scheduling.
+Worker sample share is not scheduler overhead or proof of CPU saturation.
+The original failed capture/operator status remains part of that evidence;
+re-reading existing perf files did not turn it into a clean initial run.
+
+## Fixed sources and scope
+
+| Component | Required identity |
+|---|---|
+| Robotweax library, both builds | `8e1bdebed836cb7b732db852f51ef6a7b212e925` |
+| Haivision 1.5.7, both builds | `899348d8318eb9a3c5a5b6ec43c4a1114288773a` |
+| Harness | One clean committed checkout of `codex/poll-wake-diagnostics`; record its full SHA separately |
+| Shared public-API peer SHA-256 | `faf487b34f5661e4dc602130628ed216b8054a2ab364abcc275bdda1d826d2ae` |
+
+The counter builder exports the exact Robotweax library commit and patches
+five implementation files in that export only. Every source anchor must occur
+exactly once. It records original/patched hashes and the overlay/collector
+identities; the runner rejects mismatched counter identities. Public headers,
+class layouts, the public-API peer and ordinary builds are unchanged. Counter
+builds are rejected by plain/perf/transport captures and the existing ABBA
+runners. A counter build with its output environment disabled is still an
+instrumented build and is not a plain baseline.
+
+The collector uses fixed thread-local integer storage. An increment adds no
+clock read, allocation, lock or output operation. Each instrumented thread
+registers PID/TID once, opens one exclusive file and flushes a small registration
+record; aggregate counters are written at thread exit. Registration has a
+one-time cost, and counter increments still perturb execution. Each file needs
+both registration and completion records. Missing endpoint output, missing
+registered-thread completion, overflow, inconsistent counts and collector
+output errors invalidate the evidence. This proves coverage of registered
+instrumented threads, not every thread in the process.
+
+Counts cover thread lifetimes, including connection setup and shutdown.
+Process CPU from the peer ends at its completion event; the intervals differ.
+Normalize counters by completed original packets, retain raw totals and per-TID
+rows, and do not interpret their ratio to CPU as an exact per-call duration.
+Haivision internals have no added counters. Its reference-only capture reports
+`reference_only: true` and empty endpoints, never fabricated zero activity.
+
+## Lab operator: build first, then 16 serial transfers
+
+Use the original dedicated `srt-network-lab-runtime` Ubuntu ARM64 VM with
+4 vCPU and 6 GiB. Verify VM identity and absence of competing work. Local macOS
+smoke tests and hosted CI are separate checks. No builds, perf recording,
+packet capture, parameter sweeps or concurrent scaling tests during this run.
+
+Set `SRT` to the clean pinned harness checkout, `REFERENCE` to the clean exact
+Haivision checkout, and `WORK` to a fresh work directory. Record the harness SHA
+and toolchain before building both pairs. Do not use the harness tip as the
+library revision:
+
+```sh
+HARNESS=$(git -C "$SRT" rev-parse HEAD)
+printf '%s\n' "harness=$HARNESS"
+git -C "$SRT" worktree add --detach "$WORK/library-source" \
+  8e1bdebed836cb7b732db852f51ef6a7b212e925 || exit 1
+python3 "$SRT/benchmarks/prepare_throughput.py" \
+  --robotweax-source "$WORK/library-source" --reference-source "$REFERENCE" \
+  --output-directory "$WORK/plain-build" --linkage static --jobs 2 || exit 1
+python3 "$SRT/benchmarks/prepare_throughput.py" \
+  --robotweax-source "$WORK/library-source" --reference-source "$REFERENCE" \
+  --output-directory "$WORK/counter-build" --linkage static --jobs 2 \
+  --poll-counters || exit 1
+```
+
+Both builds retain Release/OpenSSL/static, normal Release `-O3 -DNDEBUG` plus
+`-g`, and common peer `-O2 -g`. Verify both manifests, pins, peer hash and build
+flags. Do not reuse the previous perf build or alter optimizations. Keep all
+configure/build/loader/compiler/OpenSSL evidence and binaries locally.
+
+Use the existing [temporary UDP-limit and restoration procedure](throughput-profiling.md#2-check-udp-limits-do-not-silently-tune-the-host)
+in the same operator shell. Record the prior values, restore them on failure
+and interruption, and verify restoration. The runner does not change sysctls.
+No perf privileges or kernel security changes are needed for counters.
+
+Each transfer uses one plain IPv4 loopback connection, Live/Message API,
+1316-byte payload, at least 1 GiB rounded to **815914 messages / 1073742824
+bytes**, pending 8192, FC 16384, 32-MiB requested SRT buffers, 8-MiB requested
+UDP buffers, TSBPD 120 ms, TLPKTDROP off, MAXBW 1,250,000,000 bytes/s,
+`target-bps=0`, timeout 45 s and shutdown grace 500 ms. These settings match
+the prior single-stream stage and are not production Live recommendations.
+
+The fixed sequence is six plain-before transfers, four counter transfers,
+six plain-after transfers. Each plain block contains one measurement in each
+direction plus automatic Haivision self-controls before and after; warmups=0.
+The counter block contains exactly one transfer per direction and no extra
+controls or warmups. Cooldown is 30 seconds before each block. There are no
+automatic retries or replacement transfers, including after a failure.
+
+The following is the transfer portion of the operator shell, after installing
+its cleanup/restoration trap. It preserves all three statuses and continues
+the remaining planned blocks after a failed block; do not wrap it in a retry:
+
+```sh
+run_poll_block() {
+  python3 "$SRT/benchmarks/throughput_diagnostics.py" \
+    --build-manifest "$1" --output-directory "$2" --capture "$3" \
+    --bytes-per-connection 1073741824 --repetitions 1 --warmups 0 \
+    --cooldown-seconds 30 \
+    --profile robotweax-self --profile haivision-self \
+    --profile robotweax-to-haivision --profile haivision-to-robotweax
+}
+plain_before_status=0
+counter_status=0
+plain_after_status=0
+run_poll_block "$WORK/plain-build/build-manifest.json" "$WORK/plain-before" none \
+  >"$WORK/plain-before.log" 2>&1 || plain_before_status=$?
+run_poll_block "$WORK/counter-build/build-manifest.json" "$WORK/counters" counters \
+  >"$WORK/counters.log" 2>&1 || counter_status=$?
+run_poll_block "$WORK/plain-build/build-manifest.json" "$WORK/plain-after" none \
+  >"$WORK/plain-after.log" 2>&1 || plain_after_status=$?
+printf 'plain-before=%s\ncounters=%s\nplain-after=%s\n' \
+  "$plain_before_status" "$counter_status" "$plain_after_status" \
+  >"$WORK/block-status.txt"
+```
+
+The enclosing operator must preserve an unsuccessful overall exit if any
+block failed, while still collecting artifacts and performing cleanup. An
+interrupted run is incomplete. Preserve every attempt and original status;
+do not overwrite a failure after repairing an analysis step.
+
+## Required result and decision
+
+For all 16 transfers retain payload validation, both peer exit codes, original
+and retransmitted packet counts, throughput, CPU user/system for both peers,
+context switches and all four VM-global UDP error deltas (`InErrors`,
+`RcvbufErrors`, `SndbufErrors`, `InCsumErrors`). Missing data is not zero.
+Acceptance requires complete payloads, reconciled packet statistics and zero
+retransmissions/recorded UDP errors for every transfer, including controls.
+The counter runner automatically enforces this loss-free contract for its
+four captures in `counter_measurement_contract_pass`; the Lab archive
+validator must also apply it to all twelve plain transfers. A macOS smoke test
+can validate counter output but cannot pass the Linux UDP-evidence contract.
+
+For each Robotweax endpoint provide totals and counts per original packet,
+with actual PID/TID rows, for these groups:
+
+| Group | Meaning and limits |
+|---|---|
+| `rx_*` | Receive attempts, successful datagrams, EAGAIN, oversized datagrams, other errors, decoded DATA/ACK; decoded means before dispatch, not accepted payload |
+| `channel_*` polls | Immediate continuation after I/O/send work, immediate sub-ms pacer continuation, delayed continuation |
+| `connection_polls`, `batch_*`, `poll_packets` | Connection polls and histogram of successful DATA sends per poll (0, 1, 2–4, 5–16, 17–64, >64); includes retransmissions, excludes FEC/control |
+| `tx_originals`, `tx_retransmissions` | Successful DATA sends, reconciled with sender completion statistics |
+| `poll_*_block`, `selection_*`, `pacer_*` | Branch/query counts for flow, crypto, time and empty queue; not elapsed blocked time or necessarily mutually exclusive across calls |
+| `channel_notify_*`, `scheduler_*` | Notify requests/coalescing/pending continuation, submissions, notify calls, dispatched tasks, condition-variable calls/returns |
+| `readiness_*` | Notify requests, no-waiter shortcut, notify-all calls, wait calls/returns |
+| `runtime_now_calls`, `*_clock_reads` | Existing runtime time-access calls and selected existing clock reads in elapsed-time and scheduler deadline checks; not a process-wide clock census |
+
+Notify calls are not actual kernel wakeups. A wait return can be spurious.
+Thread CPU samples, these event counts and wait durations are different
+measurements. Do not infer lock contention time or off-CPU time from counts.
+Compare instrumented rates separately with surrounding plain blocks to expose
+perturbation; do not pool them or claim an optimization gain. Report control
+variation and individual values; this one-pass stage is not a statistical
+throughput qualification.
+
+Use the result to choose exactly one subsequent experiment. Many empty polls
+with repeated EAGAIN or notifications may justify a narrowly scoped scheduling
+or coalescing change. Small successful batches need interpretation alongside
+flow/time/empty-queue counts. Large flow/pacer-block counts call for a separate
+window/timing investigation. Counts identify frequency, not cost saved: retain
+the CPU profile as context and validate any change using plain ABBA afterwards.
+Do not remove ACK handling, locks or pacing without their correctness proof.
+The ten-stream receive-pressure and Haivision failure investigation from Lab
+PR #26 remains separate.
+
+Deliver a new Lab result directory/PR containing raw JSON/JSONL/stdout/stderr,
+manifests, statuses, host/build evidence, SHA-256 archive manifest, validator
+and cleanup proof. Do not publish Haivision binaries or whole build trees.
+Keep earlier archives unchanged. Keep this diagnostic branch unmerged until
+the results and the next isolated change have been reviewed.

--- a/docs/throughput-profiling.md
+++ b/docs/throughput-profiling.md
@@ -3,8 +3,8 @@
 This diagnostic branch includes an **experimental empty-receive-buffer
 fast path and Lite-ACK receive-window credit correction**, not a complete transport
 qualification or a released throughput claim. Public API, locking and transport
-configuration remain unchanged. The latest follow-up is the
-[fixed-pin plain ABBA stage](#plain-abba-after-the-lite-ack-diagnosis); earlier
+configuration remain unchanged. The latest follow-up after the merged fixes and
+Lab PR #27 is the [aggregate poll/wake diagnostic stage](poll-wake-diagnostics.md); earlier
 experiments below retain their original pins and contracts. Use a dedicated Linux test VM to reproduce a Linux
 capacity observation; native macOS and hosted x86-64 CI are separate platform
 controls, not substitutes for that environment.

--- a/interop/tests/test_poll_wake_counters.py
+++ b/interop/tests/test_poll_wake_counters.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "benchmarks"))
+import poll_wake_counters as pc
+import throughput_diagnostics as diag
+
+
+class PollCounterTests(unittest.TestCase):
+    def record(self, directory, pid=10, tid=11, **values):
+        counters = dict.fromkeys(pc.NAMES, 0)
+        counters.update(values)
+        header = {"schema": 1, "pid": pid, "tid": tid, "serial": 0}
+        row = dict(header, counters=counters, overflow=False, complete=True)
+        path = directory / f"{pid}-{tid}.jsonl"
+        path.write_text(json.dumps(header) + '\n' + json.dumps(row) + '\n')
+        return path, row
+
+    def test_pinned_hooks_and_ambiguous_sources(self):
+        for relative, hooks in pc.HOOKS.items():
+            text = (pc.ROOT / relative).read_text()
+            patched = pc.instrument(text, hooks)
+            self.assertIn("RWX_COUNT", patched)
+            with self.assertRaises(ValueError):
+                pc.instrument(patched, hooks)
+        with self.assertRaises(ValueError):
+            pc.instrument("same same", [("same", "different")])
+        with self.assertRaises(ValueError):
+            pc.export_overlay(pc.ROOT, "unreviewed", Path("unused"))
+
+    def test_complete_records_and_reconciled_outcomes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            self.record(directory, rx_attempts=5, rx_datagrams=2, rx_eagain=3,
+                        channel_polls=3, channel_immediate_io=1, channel_delayed=2,
+                        connection_polls=3, batch_0=2, batch_2_4=1, poll_packets=3)
+            self.assertEqual(pc.read_counters(directory)[0]['counters']['rx_eagain'], 3)
+
+    def test_missing_overflow_unknown_and_unreconciled_data_fail(self):
+        mutations = [lambda r: r.update(complete=False), lambda r: r.update(overflow=True),
+                     lambda r: r.update(pid=True), lambda r: r['counters'].pop('rx_eagain'),
+                     lambda r: r['counters'].update(rx_errors=-1),
+                     lambda r: r['counters'].update(rx_errors=True),
+                     lambda r: r['counters'].update(rx_errors=2**64),
+                     lambda r: r['counters'].update(rx_attempts=1),
+                     lambda r: r['counters'].update(connection_polls=1),
+                     lambda r: r['counters'].update(channel_polls=1),
+                     lambda r: r['counters'].update(poll_packets=1),
+                     lambda r: r['counters'].update(connection_polls=1, batch_2_4=1, poll_packets=1),
+                     lambda r: r['counters'].update(readiness_notify_calls=1),
+                     lambda r: r['counters'].update(scheduler_waits=1)]
+        for mutate in mutations:
+            with self.subTest(mutate=mutate), tempfile.TemporaryDirectory() as tmp:
+                directory = Path(tmp)
+                path, row = self.record(directory)
+                header = path.read_text().splitlines()[0]
+                mutate(row)
+                path.write_text(header + '\n' + json.dumps(row) + '\n')
+                with self.assertRaises(ValueError):
+                    pc.read_counters(directory)
+
+    def test_incomplete_and_duplicate_thread_records_fail(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            path, _ = self.record(directory)
+            full = path.read_text()
+            path.write_text(full.splitlines()[0] + '\n')
+            with self.assertRaises(ValueError):
+                pc.read_counters(directory)
+            path.write_text(full)
+            (directory / 'duplicate.jsonl').write_text(full)
+            with self.assertRaises(ValueError):
+                pc.read_counters(directory)
+
+    def result(self):
+        return {'connections': 1, 'messages_per_connection': 4,
+                'peer_process_resources': {'sender': {'pid': 10}, 'receiver': {'pid': 20}},
+                'wire_statistics': {'sender_packets_unique': 4, 'receiver_packets_unique': 4,
+                                    'sender_packets_total': 4, 'retransmitted_packets': 0}}
+
+    def test_endpoint_mapping_and_packet_denominators(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            for role in ('caller', 'listener'):
+                (directory / f'many-socket-{role}.stderr').write_text('')
+            counterdir = directory / 'poll-counters'
+            counterdir.mkdir()
+            self.record(counterdir, tx_originals=4, connection_polls=1, batch_2_4=1, poll_packets=4)
+            self.record(counterdir, pid=20, tid=21, rx_attempts=4, rx_datagrams=4, rx_data=4)
+            result = pc.analyze_case(directory, self.result(), 'robotweax-self')
+            self.assertTrue(result['valid'], result)
+            self.assertEqual(result['endpoints']['sender']['per_original_packet']['connection_polls'], .25)
+            bad = self.result()
+            bad['wire_statistics']['sender_packets_unique'] = 5
+            self.assertFalse(pc.analyze_case(directory, bad, 'robotweax-self')['valid'])
+            self.assertFalse(pc.analyze_case(directory, self.result(), 'robotweax-to-haivision')['valid'])
+            (directory / 'many-socket-caller.stderr').write_text('poll counters: output failure')
+            self.assertFalse(pc.analyze_case(directory, self.result(), 'robotweax-self')['valid'])
+
+    def test_missing_endpoint_is_not_zero_and_reference_is_explicit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            for role in ('caller', 'listener'):
+                (directory / f'many-socket-{role}.stderr').write_text('')
+            self.assertFalse(pc.analyze_case(directory, self.result(), 'robotweax-self')['valid'])
+            result = pc.analyze_case(directory, self.result(), 'haivision-self')
+            self.assertTrue(result['valid'])
+            self.assertTrue(result['reference_only'])
+            self.assertEqual(result['endpoints'], {})
+
+    def test_counter_capture_is_separate_without_perf_or_warmups(self):
+        self.assertEqual(diag.perf_command('counters', Path('unused'), ['driver'], 'unused'), ['driver'])
+        self.assertEqual(diag.case_plan(['robotweax-self'], 1, 2, True, 'counters'),
+                         [{'profile': 'robotweax-self', 'kind': 'counters'}])
+
+    def test_loss_free_contract_rejects_missing_or_bad_evidence(self):
+        entry = {'transfer_pass': True, 'profiling': {'valid': True}, 'result': self.result(),
+                 'system_udp_delta': dict.fromkeys(('InErrors', 'RcvbufErrors', 'SndbufErrors', 'InCsumErrors'), 0)}
+        self.assertTrue(pc.measurement_contract(entry))
+        mutations = [lambda e: e['system_udp_delta'].pop('InErrors'),
+                     lambda e: e['system_udp_delta'].update(RcvbufErrors=1),
+                     lambda e: e['system_udp_delta'].update(SndbufErrors=False),
+                     lambda e: e['profiling'].update(valid=False),
+                     lambda e: e['result']['wire_statistics'].update(retransmitted_packets=1),
+                     lambda e: e['result']['wire_statistics'].update(sender_packets_total=5),
+                     lambda e: e['result']['wire_statistics'].update(receiver_packets_unique=3),
+                     lambda e: e['result'].update(messages_per_connection=5)]
+        for mutate in mutations:
+            altered = json.loads(json.dumps(entry))
+            mutate(altered)
+            self.assertFalse(pc.measurement_contract(altered))
+
+    def test_invalid_counter_output_keeps_payload_success_but_fails_case(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            path = directory / 'request.json'
+            path.write_text(json.dumps({'capture': 'counters', 'profile': 'robotweax-self',
+                'programs': {}, 'options': {'host': '127.0.0.1', 'connections': 1,
+                'bytes_per_connection': 5264, 'message_size': 1316, 'timeout_seconds': 15,
+                'latency_milliseconds': 120, 'shutdown_grace_milliseconds': 500, 'sampling_interval_seconds': .02},
+                'index': 0, 'kind': 'counters', 'target_bps': 0, 'peer_arguments': []}))
+            for role in ('caller', 'listener'):
+                (directory / f'many-socket-{role}.stdout').write_text('{"event":"capacity-options"}\n')
+                (directory / f'many-socket-{role}.stderr').write_text('')
+            with mock.patch.dict(os.environ):
+                with mock.patch.object(diag.sc, 'run_many_socket_profile', return_value=self.result()):
+                    with mock.patch.object(diag, 'udp_snapshot', return_value={}):
+                        self.assertEqual(diag.run_case(path), 1)
+            report = json.loads((directory / 'case.json').read_text())
+            self.assertTrue(report['transfer_pass'], report)
+            self.assertFalse(report['profiling']['valid'])
+
+    def test_plain_run_clears_inherited_counter_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'request.json'
+            path.write_text(json.dumps({'capture': 'none', 'profile': 'robotweax-self',
+                'programs': {}, 'options': {}, 'index': 0, 'kind': 'measurement', 'peer_arguments': []}))
+            with mock.patch.dict(os.environ, {'ROBOTWEAX_POLL_COUNTER_DIR': '/unrelated'}):
+                with mock.patch.object(diag, 'udp_snapshot', return_value={}):
+                    diag.run_case(path)  # Incomplete request fails after environment isolation.
+                self.assertNotIn('ROBOTWEAX_POLL_COUNTER_DIR', os.environ)
+
+    def test_capture_modes_reject_instrumented_plain_or_wrong_overlay(self):
+        for enabled, capture in ((True, 'none'), (True, 'transport'), (False, 'counters')):
+            with self.subTest(capture=capture), tempfile.TemporaryDirectory() as tmp:
+                path = Path(tmp) / 'manifest.json'
+                path.write_text(json.dumps({'complete': True, 'poll_counters': {'enabled': enabled}}))
+                with self.assertRaises(SystemExit) as caught:
+                    diag.main(['--build-manifest', str(path), '--output-directory', str(Path(tmp)/'out'),
+                               '--capture', capture])
+                self.assertEqual(caught.exception.code, 2)
+
+
+@unittest.skipUnless(sys.platform in ('linux', 'darwin') and shutil.which('c++'), 'POSIX diagnostic collector')
+class NativeCollectorTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.temporary = tempfile.TemporaryDirectory()
+        cls.root = Path(cls.temporary.name)
+        source = cls.root / 'collector.cpp'
+        source.write_text('''#include "poll_wake_counters.hpp"
+#include <thread>
+#include <cstring>
+using namespace robotweax::srt::diagnostics;
+int main(int argc, char** argv) {
+    RWX_COUNT(rx_attempts); RWX_COUNT(rx_eagain);
+    if (argc > 1 && std::strcmp(argv[1], "abrupt") == 0) { _exit(0); }
+    if (argc > 1 && std::strcmp(argv[1], "overflow") == 0) {
+        poll_counters().add(Counter::rx_eagain, UINT64_MAX); return 0;
+    }
+    std::thread worker([] { PollScope scope; scope.packets=3; });
+    worker.join();
+    { PollScope scope; }
+    return 0;
+}
+''')
+        cls.program = cls.root / 'collector'
+        subprocess.run(['c++', '-std=c++20', '-Wall', '-Wextra', '-Werror', '-pthread',
+                        '-I' + str(pc.HEADER.parent), str(source), '-o', str(cls.program)],
+                       check=True, capture_output=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.temporary.cleanup()
+
+    def test_real_thread_registration_flush_histograms_and_failures(self):
+        for mode in ('normal', 'abrupt', 'overflow'):
+            with self.subTest(mode=mode), tempfile.TemporaryDirectory() as tmp:
+                subprocess.run([str(self.program), mode], check=True,
+                               env={**os.environ, 'ROBOTWEAX_POLL_COUNTER_DIR': tmp})
+                if mode != 'normal':
+                    with self.assertRaises(ValueError):
+                        pc.read_counters(Path(tmp))
+                else:
+                    rows = pc.read_counters(Path(tmp))
+                    self.assertEqual(len(rows), 2)
+                    self.assertEqual(len({r['tid'] for r in rows}), 2)
+                    self.assertEqual(sum(r['counters']['batch_2_4'] for r in rows), 1)
+                    self.assertEqual(sum(r['counters']['batch_0'] for r in rows), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Lab PR #27 shows receive, notification and clock activity but does not establish a dominant sender bottleneck. This adds aggregate counters to distinguish frequent empty polls, small DATA batches, notification requests and flow/pacer blocking before choosing an optimization.

`prepare_throughput.py --poll-counters` instruments a fresh export of the exact library commit `8e1bdebed836cb7b732db852f51ef6a7b212e925`. Normal production sources, public headers/class layouts and the shared capacity peer are unchanged. Each thread registers once and writes its totals at exit; increments add no clock reads, allocations, locks or logging. The runner rejects incomplete/inconsistent output and prevents counter builds from being used as plain performance evidence.

The [lab handoff](https://github.com/Robotweax/srt/blob/f561baebdc6dd262c819db7d0949503477bd1c35/docs/poll-wake-diagnostics.md) specifies 6 plain-before + 4 counter + 6 plain-after transfers on the original dedicated ARM64 VM, with unchanged 1-GiB settings, exact library/reference pins, preserved failures and no retries. Counts include setup/shutdown and measure calls, not wait duration or actual kernel wakeups. Keep this diagnostic PR unmerged while the lab produces and reviews the evidence.

Validation on macOS:

- 633 Python harness tests passed, including native thread registration, incomplete output, overflow and loss-free evidence checks.
- Exported counter build: 602/602 native C++ tests passed with collection disabled; 4/4 deterministic Lite-ACK tests passed with collection enabled (32 originals, 92 flow-block observations, zero retransmissions).
- A 4-MiB public-API loopback smoke transfer produced reconciled sender/receiver counter reports. This is a functional check, not Linux performance evidence.
- Documentation validation, pinned clang-format 22.1.8 and diff checks passed; the production source/public-header/peer diff against the library pin is empty.

The Linux lab experiment has not been run by this PR.

[CI for this pin](https://github.com/Robotweax/srt/actions/runs/34684169802) completed successfully: 33 checks passed, including all 21 reference interoperability profiles and the CI gate; seven jobs were skipped by change classification.
