### PR TITLE
Schedule paced channel polls at absolute deadlines

### DIFF
--- a/benchmarks/run_pacer_deadline_ab.py
+++ b/benchmarks/run_pacer_deadline_ab.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Pinned plain ABBA for the absolute pacer-deadline candidate.
+
+72 serial 1-GiB transfers on the original Linux ARM64 VM. No retries,
+sysctl changes, instrumentation or automatic performance approval.
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import platform
+import signal
+import socket
+import statistics
+from pathlib import Path
+
+import run_plain_capacity_ab as common
+
+build, sc, diag = common.build, common.sc, common.diag
+REVISIONS = {
+    "baseline": "8e1bdebed836cb7b732db852f51ef6a7b212e925",
+    "candidate": "11814d3a1ebc217dbe95613b679960ac3152ff59",
+}
+PROFILES = ["robotweax-self", "haivision-self", "robotweax-to-haivision", "haivision-to-robotweax"]
+ARGUMENTS = {**common.ARGUMENTS, "bytes_per_connection": 1024**3}
+
+
+def cases() -> list[dict]:
+    return diag.case_plan(PROFILES, ARGUMENTS["repetitions"], ARGUMENTS["warmups"], True, "none")
+
+
+def analyze_block(report: dict, manifest: dict, exit_code: int) -> dict:
+    analysis = common.analyze_block(report, manifest, exit_code, arguments=ARGUMENTS, profiles=PROFILES)
+    for row, entry in zip(analysis["cases"], report.get("runs", [])):
+        resources = entry.get("result", {}).get("peer_process_resources", {})
+        row["peer_process_resources"] = resources
+        for role in ("sender", "receiver"):
+            own = resources.get(role) or {}
+            valid = common.number(own.get("pid"), integer=True, positive=True) and all(
+                common.number(own.get(k), integer=True) for k in
+                ("user_cpu_us", "system_cpu_us", "voluntary_context_switches", "involuntary_context_switches"))
+            if not valid:
+                error = f"missing/invalid {role} CPU, PID or context-switch evidence"
+                row["errors"].append(error)
+                analysis["errors"].append(f"case {row['index']}: {error}")
+            seconds = (own["user_cpu_us"] + own["system_cpu_us"]) / 1e6 if valid else None
+            row[f"{role}_cpu_seconds"] = seconds
+            byte_count = entry.get("result", {}).get("bytes_per_connection")
+            row[f"{role}_cpu_seconds_per_gib"] = (
+                seconds * 1024**3 / byte_count
+                if seconds is not None and common.number(byte_count, integer=True, positive=True) else None)
+    for summary in analysis["summary"]:
+        selected = [row for row in analysis["cases"]
+                    if row["kind"] == "measurement" and row["profile"] == summary["profile"]]
+        summary["evidence_passes"] = sum(not row["errors"] for row in selected)
+        for metric in ("sender_cpu_seconds", "receiver_cpu_seconds",
+                       "sender_cpu_seconds_per_gib", "receiver_cpu_seconds_per_gib"):
+            values = [row[metric] for row in selected if row["transfer_pass"] and row.get(metric) is not None]
+            summary[metric] = {"samples": len(values), "median": statistics.median(values) if values else None,
+                               "mean": statistics.mean(values) if values else None,
+                               "p95": sc.percentile(values, .95) if values else None}
+    analysis["measurement_contract_pass"] = not analysis["errors"]
+    return analysis
+
+
+def run_blocks(paths: dict, manifests: dict, out: Path, report: dict) -> int:
+    out.mkdir(parents=True, exist_ok=False)
+    report.update(complete=False, interrupted=False, plan=common.plan(), blocks=[],
+                  performance_decision_requires_review=True)
+    watched = [getattr(signal, name) for name in ("SIGINT", "SIGTERM", "SIGHUP") if hasattr(signal, name)]
+    previous = {sig: signal.getsignal(sig) for sig in watched}
+
+    def interrupt(signum, _frame):
+        # Let run_bounded terminate and reap its tracked case group. Repeated
+        # signals must not interrupt that cleanup or the report's finally path.
+        for sig in watched:
+            signal.signal(sig, signal.SIG_IGN)
+        report["interruption_signal"] = signum
+        raise KeyboardInterrupt
+
+    for sig in watched:
+        signal.signal(sig, interrupt)
+    try:
+        for index, variant in enumerate(common.plan()):
+            name = f"{index:02}-{variant}-plain"
+            arguments = ["--build-manifest", str(paths[variant]), "--output-directory", str(out / name)]
+            for key, value in ARGUMENTS.items():
+                arguments += ["--" + key.replace("_", "-"), str(value)]
+            for profile in PROFILES:
+                arguments += ["--profile", profile]
+            block = {"name": name, "variant": variant, "driver_arguments": arguments, "exit_code": None}
+            report["blocks"].append(block)
+            sc.write_report(out / "ab-report.json", report)
+            # Run in this process: diag.run_bounded owns the single nested case
+            # session and its peers. An extra block subprocess would obscure
+            # those groups from the outer operator during interruption.
+            with (out / f"{name}.log").open("x") as log:
+                try:
+                    with contextlib.redirect_stdout(log), contextlib.redirect_stderr(log):
+                        block["exit_code"] = diag.main(arguments)
+                except SystemExit as error:
+                    block["exit_code"] = error.code if type(error.code) is int else 1
+                except Exception as error:
+                    block["exit_code"] = 1
+                    block["error"] = repr(error)
+            try:
+                diagnostic = json.loads((out / name / "report.json").read_text())
+                block["analysis"] = analyze_block(diagnostic, manifests[variant], block["exit_code"])
+            except (OSError, ValueError, KeyError, TypeError, OverflowError) as error:
+                block["analysis"] = {"measurement_contract_pass": False, "errors": [f"unusable report: {error}"]}
+            print(json.dumps({"name": name, "exit_code": block["exit_code"],
+                              "measurement_contract_pass": block["analysis"]["measurement_contract_pass"]}), flush=True)
+            sc.write_report(out / "ab-report.json", report)
+        report["complete"] = True
+        report["measurement_contract_pass"] = all(b["analysis"]["measurement_contract_pass"] for b in report["blocks"])
+        return 0 if report["measurement_contract_pass"] else 1
+    except KeyboardInterrupt:
+        report["interrupted"] = True
+        code = 128 + report.get("interruption_signal", signal.SIGINT)
+        report["interruption_exit_code"] = code
+        if report["blocks"] and report["blocks"][-1]["exit_code"] is None:
+            report["blocks"][-1]["exit_code"] = code
+        return code
+    finally:
+        try:
+            sc.write_report(out / "ab-report.json", report)
+        finally:
+            for sig, handler in previous.items():
+                signal.signal(sig, handler)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    for variant in REVISIONS:
+        parser.add_argument(f"--{variant}-plain", type=Path, required=True)
+    parser.add_argument("--output-directory", type=Path, required=True)
+    args = parser.parse_args(argv)
+    if (platform.system() != "Linux" or platform.machine() not in ("aarch64", "arm64")
+            or socket.gethostname() != "lima-srt-network-lab-runtime"):
+        parser.error("use the original dedicated srt-network-lab-runtime Linux ARM64 VM")
+    environment = diag.host_metadata()
+    if environment["cpu_count"] != 4:
+        parser.error("retain the original four-vCPU configuration")
+    paths = {variant: getattr(args, f"{variant}_plain").resolve() for variant in REVISIONS}
+    manifests = {variant: json.loads(path.read_text()) for variant, path in paths.items()}
+    harness = build.source_identity(Path(__file__).resolve().parents[1])
+    common.validate_manifests(manifests, harness, environment, revisions=REVISIONS)
+    signatures = common.validate_build_files(paths, manifests)
+    if any(int(environment["sysctls"].get(f"net/core/{key}_max") or 0) < ARGUMENTS["udp_buffer"] for key in ("rmem", "wmem")):
+        parser.error("operator must record/configure/restore UDP maxima of at least 8 MiB")
+    report = {"schema_version": 1, "environment": environment, "manifests": manifests,
+              "toolchain_signatures": signatures, "harness_checkout": harness,
+              "harness_files": [sc.program_identity(Path(m.__file__).resolve()) for m in (common, diag, sc, build)],
+              "runner": sc.program_identity(Path(__file__).resolve()),
+              "scope": "plain IPv4 loopback; one connection; library pins distinct from the common harness pin"}
+    return run_blocks(paths, manifests, args.output_directory.resolve(), report)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/run_plain_capacity_ab.py
+++ b/benchmarks/run_plain_capacity_ab.py
@@ -42,20 +42,22 @@ def cases() -> list[dict]:
     return diag.case_plan(PROFILES, 3, 1, True, "none")
 
 
-def validate_manifests(manifests: dict, harness: dict, environment: dict) -> None:
-    if set(manifests) != set(REVISIONS):
+def validate_manifests(manifests: dict, harness: dict, environment: dict,
+                       *, revisions: dict = REVISIONS) -> None:
+    if set(manifests) != set(revisions):
         raise ValueError("exactly two plain build manifests are required")
     if harness.get("dirty") is not False:
         raise ValueError("run from a clean committed harness checkout")
     for variant, manifest in manifests.items():
         if manifest.get("complete") is not True:
             raise ValueError("incomplete build")
-        for library, revision in (("robotweax", REVISIONS[variant]),
+        for library, revision in (("robotweax", revisions[variant]),
                                   ("haivision", build.REFERENCE_REVISION)):
             source = manifest["sources"][library]
             if source.get("dirty") is not False or source.get("revision") != revision:
                 raise ValueError(f"unexpected/dirty {variant} {library} source")
-        if manifest.get("transport_trace", {}).get("enabled", False) is not False:
+        if (manifest.get("transport_trace", {}).get("enabled", False) is not False
+                or manifest.get("poll_counters", {}).get("enabled", False) is not False):
             raise ValueError("instrumented builds cannot produce plain capacity evidence")
         if manifest.get("crypto") != "openssl" or manifest.get("linkage") != "static":
             raise ValueError("this follow-up requires the original static OpenSSL build profile")
@@ -105,27 +107,29 @@ def number(value, *, integer: bool = False, positive: bool = False) -> bool:
             and math.isfinite(value) and value >= (1 if positive else 0))
 
 
-def analyze_block(report: dict, manifest: dict, exit_code: int) -> dict:
+def analyze_block(report: dict, manifest: dict, exit_code: int,
+                  *, arguments: dict = ARGUMENTS, profiles: list = PROFILES) -> dict:
     """Missing/partial evidence is a failure, never an inferred zero count."""
     errors, rows = [], []
+    expected_cases = diag.case_plan(profiles, arguments["repetitions"], arguments["warmups"], True, "none")
     if exit_code != 0 or report.get("finished") is not True or report.get("all_transfers_pass") is not True:
         errors.append("diagnostic block did not finish successfully")
     if report.get("capture") != "none" or report.get("udp_capacity_controlled") is not True:
         errors.append("not an uninstrumented UDP-capacity-controlled block")
-    arguments = report.get("arguments", {})
-    if (any(arguments.get(key) != value for key, value in ARGUMENTS.items())
-            or arguments.get("profile") != PROFILES
-            or arguments.get("allow_small_udp_buffers") is not False):
+    observed_arguments = report.get("arguments", {})
+    if (any(observed_arguments.get(key) != value for key, value in arguments.items())
+            or observed_arguments.get("profile") != profiles
+            or observed_arguments.get("allow_small_udp_buffers") is not False):
         errors.append("measurement arguments changed")
     if report.get("build_manifest") != manifest:
         errors.append("reported build differs from preflight manifest")
     runs = report.get("runs", [])
-    if len(runs) != len(cases()):
+    if len(runs) != len(expected_cases):
         errors.append("missing or extra transfers")
-    packets = math.ceil(ARGUMENTS["bytes_per_connection"] / 1316)
+    packets = math.ceil(arguments["bytes_per_connection"] / 1316)
     for index, entry in enumerate(runs):
         problems = []
-        if index >= len(cases()) or any(entry.get(key) != value for key, value in cases()[index].items()):
+        if index >= len(expected_cases) or any(entry.get(key) != value for key, value in expected_cases[index].items()):
             problems.append("unexpected case order/profile/kind")
         if entry.get("index") != index or entry.get("exit_code") != 0 or entry.get("transfer_pass") is not True:
             problems.append("failed/incomplete transfer")
@@ -134,7 +138,7 @@ def analyze_block(report: dict, manifest: dict, exit_code: int) -> dict:
         if (integrity.get("deterministic_payload_verified") is not True
                 or integrity.get("verified_connections") != 1
                 or result.get("connections") != 1 or result.get("message_size_bytes") != 1316
-                or result.get("requested_bytes_per_connection") != ARGUMENTS["bytes_per_connection"]
+                or result.get("requested_bytes_per_connection") != arguments["bytes_per_connection"]
                 or result.get("messages_per_connection") != packets
                 or result.get("bytes_per_connection") != packets * 1316):
             problems.append("payload/transfer contract not proven")
@@ -154,8 +158,8 @@ def analyze_block(report: dict, manifest: dict, exit_code: int) -> dict:
             options = result.get("capacity_options", {}).get(role, [])
             expected = {"encryption": "none", "tlpktdrop": False, "pending_packets": 8192,
                         "requested_maxbw_bytes_per_second": 1250000000, "target_bits_per_second": 0,
-                        "api_fc": 16384, "api_udp_rcvbuf": ARGUMENTS["udp_buffer"],
-                        "api_udp_sndbuf": ARGUMENTS["udp_buffer"]}
+                        "api_fc": 16384, "api_udp_rcvbuf": arguments["udp_buffer"],
+                        "api_udp_sndbuf": arguments["udp_buffer"]}
             if len(options) != 1 or any(options[0].get(key) != value for key, value in expected.items()):
                 problems.append(f"{role} capacity-option contract missing/changed")
         rate = result.get("rates", {}).get("useful_bits_per_second")
@@ -173,7 +177,7 @@ def analyze_block(report: dict, manifest: dict, exit_code: int) -> dict:
         rows.append(row)
         errors.extend(f"case {index}: {problem}" for problem in problems)
     summaries = []
-    for profile in PROFILES:
+    for profile in profiles:
         selected = [row for row in rows if row["kind"] == "measurement" and row["profile"] == profile]
         summary = {"profile": profile, "attempts": len(selected),
                    "transfer_successes": sum(row["transfer_pass"] for row in selected),

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,7 @@ combining features.
 - [Protocol edge-case policy](protocol-edge-cases.md)
 - [Performance and scalability measurement](performance.md)
 - [Throughput profiling and empty-receive-buffer experiment](throughput-profiling.md)
+- [Absolute pacer-deadline experiment and fixed ABBA handoff](pacer-deadline-experiment.md)
 
 These pages document stable protocol behavior, resource contracts, and
 reproducible measurement methods. Internal implementation details that are not

--- a/docs/pacer-deadline-experiment.md
+++ b/docs/pacer-deadline-experiment.md
@@ -1,0 +1,166 @@
+# Absolute pacer-deadline experiment
+
+This candidate tests whether scheduling the next channel poll at its actual
+pacer deadline reduces sender CPU without losing throughput. It is an
+experiment, not a measured performance improvement or a production release.
+
+[Lab PR #28](https://github.com/Robotweax/srt_network_lab/blob/cda122a9a4b2414bec9b3ff623eec1038f91c837/results/2026-09-12-poll-wake-counters/report-de.md)
+recorded 3.41–3.66 sender polls per original DATA packet, about 74% of them
+without a DATA send. Over 98% of channel continuations took the immediate
+sub-millisecond pacer path. More than 99.5% of sender receive attempts ended in
+EAGAIN. Application notifications were already over 99.96% coalesced. These
+counts motivate a scheduling change but do not measure its potential CPU gain.
+
+## Candidate behavior and limits
+
+The connection returns an absolute `steady_clock` deadline tied to its origin.
+The channel retains the earliest connection deadline, capped by the existing
+idle interval for receive/control work, and submits that exact deadline to the
+scheduler. A short positive remainder no longer requests immediate polling or
+gets rounded to milliseconds. Processing time is not added to a previously
+computed relative delay.
+
+Due timers and ready work alternate when both are runnable on a scheduler
+shard. This preserves progress for other channels even when a hot sender's
+timer is already due by its next dispatch. Timer order and ready FIFO order
+remain intact within their respective queues. Existing notification, timer
+cancellation, active-poll follow-up and stop/context-lifetime handling remain
+in place; failure to schedule still breaks affected connections explicitly.
+
+Public headers and class layouts, the shared public-API peer, pacing rate,
+catch-up policy, flow window, buffer sizes and batch limits are unchanged.
+Only private runtime deadline representation and dispatch selection change.
+The diagnostic counter overlay from SRT PR #33 is separate and still tied to
+its original source; do not apply it to the new candidate without reviewing
+and pinning new anchors.
+
+The scheduler can wake after a deadline. The unchanged pacer computes its
+next deadline from `max(previous_deadline, actual_now) + interval`, so lateness
+does not create compensating burst credit. Lower CPU with substantially lower
+throughput would fail the purpose of this experiment. No busy-spin threshold,
+timer-resolution tuning, batching change or rate change is combined with it.
+
+## Fixed library and harness identities
+
+| Role | Exact revision |
+|---|---|
+| A: baseline Robotweax library | `8e1bdebed836cb7b732db852f51ef6a7b212e925` |
+| B: absolute-deadline Robotweax library | `11814d3a1ebc217dbe95613b679960ac3152ff59` |
+| Haivision 1.5.7, both variants | `899348d8318eb9a3c5a5b6ec43c4a1114288773a` |
+| Harness | One clean committed checkout of `codex/pacer-deadline` containing this document; record its full SHA separately |
+
+The common peer source SHA-256 remains
+`faf487b34f5661e4dc602130628ed216b8054a2ab364abcc275bdda1d826d2ae`.
+The harness commit follows the candidate commit and must not replace the
+candidate library pin in manifests. `run_pacer_deadline_ab.py` accepts only
+this pair. The earlier `run_plain_capacity_ab.py` retains its original pair
+and defaults; common validators also accept the new runner's explicit
+contract without changing the old experiment.
+
+## Lab handoff: build both variants before measuring
+
+Use the original dedicated `srt-network-lab-runtime` Ubuntu ARM64 VM with
+4 vCPU and 6 GiB. The runner checks Linux ARM64, the established hostname
+`lima-srt-network-lab-runtime` and four CPUs. The operator must also verify
+memory/VM identity and absence of competing work. Hosted CI and local macOS
+checks are separate evidence, not substitutes for the VM.
+
+Set `SRT` to the clean committed harness checkout, `REFERENCE` to the clean
+exact-pinned Haivision checkout and `WORK` to a new work directory:
+
+```sh
+HARNESS=$(git -C "$SRT" rev-parse HEAD)
+printf '%s\n' "harness=$HARNESS"
+git -C "$SRT" worktree add --detach "$WORK/baseline-source" \
+  8e1bdebed836cb7b732db852f51ef6a7b212e925 || exit 1
+git -C "$SRT" worktree add --detach "$WORK/candidate-source" \
+  11814d3a1ebc217dbe95613b679960ac3152ff59 || exit 1
+for variant in baseline candidate; do
+  python3 "$SRT/benchmarks/prepare_throughput.py" \
+    --robotweax-source "$WORK/$variant-source" --reference-source "$REFERENCE" \
+    --output-directory "$WORK/$variant-plain" --linkage static --jobs 2 || exit 1
+done
+```
+
+Both library pairs use Release/OpenSSL/static, normal Release `-O3 -DNDEBUG`
+with `-g`; both peers use the common `-O2 -g` flags. No overlay, sanitizers,
+new profiling flags or cached build reuse. Preserve compiler/OpenSSL/CMake,
+cache, loader and binary-hash evidence. Stop on a build error.
+
+Before running, review/test the operator interruption and restoration path.
+Use the [temporary UDP-limit procedure](throughput-profiling.md#2-check-udp-limits-do-not-silently-tune-the-host)
+with recorded prior values, independent restoration attempts and verification
+in the enclosing operator's cleanup path. The new runner itself never changes
+sysctls. No perf recording, concurrent builds or other load tests.
+
+```sh
+python3 "$SRT/benchmarks/run_pacer_deadline_ab.py" \
+  --baseline-plain "$WORK/baseline-plain/build-manifest.json" \
+  --candidate-plain "$WORK/candidate-plain/build-manifest.json" \
+  --output-directory "$WORK/pacer-abba-results" \
+  >"$WORK/pacer-abba.log" 2>&1
+status=$?
+printf '%s\n' "$status" >"$WORK/pacer-abba.exit-code.txt"
+```
+
+This is the measurement command, not a replacement for the enclosing
+operator's finally/trap and archive collection. Preserve its original status
+through cleanup. The operator must not use the flawed original interruption
+wrapper from Lab PR #28 unchanged.
+
+## Exact plan and failure handling
+
+Four blocks, **A → B → B → A**, with 30 seconds' cooldown before each block.
+Each block contains one Haivision self-control, then one excluded warmup and
+three measurements for each direction in this order: Robotweax self,
+Haivision self, Robotweax → Haivision, Haivision → Robotweax; one Haivision
+self-control ends the block.
+
+Total: **72 transfers = 48 measurements + 16 warmups + 8 controls**. There are
+six measured samples per direction/variant across two blocks. Keep blocks and
+individual values visible; three-point p95 values are descriptive only.
+
+Every transfer is at least 1 GiB rounded to 815914 messages / 1073742824
+payload bytes, 1316-byte payload, one plain IPv4-loopback connection,
+Live/Message, TSBPD 120 ms, TLPKTDROP off, pending 8192, FC 16384,
+32-MiB requested SRT buffers, 8-MiB requested UDP buffers, MAXBW
+1,250,000,000 bytes/s, application target 0, timeout 45 s and shutdown 500 ms.
+Keep this contract even if the candidate is slower or times out.
+
+No retries, replacement runs or selective deletion. A nonzero block status
+remains in the report and the remaining planned blocks still run. Interruption
+stops the plan and leaves an incomplete report. SIGINT/SIGTERM/SIGHUP are
+handled in the runner, which invokes the diagnostic driver in the same process;
+the driver owns and cleans up its tracked case session and peer descendants.
+Repeated handled signals are ignored during cleanup. Two synthetic tests
+exercise real SIGINT/SIGTERM with a case and peer that ignore those signals;
+they do not perform SRT transfers. Enclosing operator cleanup still needs to
+restore and verify UDP maxima after the runner exits.
+
+## Acceptance and result delivery
+
+`ab-report.json` requires all planned payloads, exact pins/options, complete
+packet statistics, zero retransmissions and recorded zero `InErrors`,
+`RcvbufErrors`, `SndbufErrors` and `InCsumErrors` deltas, including warmups and
+controls. Missing values are not zero. Both endpoint PIDs, CPU user/system and
+voluntary/involuntary context switches must be present. CPU summaries include
+both processes in seconds and seconds per actual payload GiB. Process CPU
+includes setup through completion, not the entire shutdown interval.
+
+Completed measurements with retransmissions remain visible in summaries while
+failing the contract. Warmups and controls are excluded from those summaries.
+Review CPU/GiB and throughput by direction/block together with all Haivision
+controls; R→H varied by 4.13% between the prior plain brackets despite only
+0.56% control spread, so small changes need careful interpretation.
+
+Success needs repeatable sender-CPU improvement with preserved or better
+throughput and complete transport correctness. Exit zero is not automatic
+performance/release approval. A regression is useful evidence and remains
+archived; do not silently switch to a different waiting or batching policy.
+
+Deliver a new Lab result directory/PR with raw requests/cases/reports,
+stdout/stderr, every original status, exact source/build/host identities,
+SHA-256 manifest, independently reproducible validator and verified cleanup.
+No Haivision binaries or whole build directories. Keep earlier evidence and
+the ten-stream PR #26 investigation separate. Keep this candidate unmerged
+pending lab review and a separate merge decision.

--- a/docs/throughput-profiling.md
+++ b/docs/throughput-profiling.md
@@ -3,8 +3,8 @@
 This diagnostic branch includes an **experimental empty-receive-buffer
 fast path and Lite-ACK receive-window credit correction**, not a complete transport
 qualification or a released throughput claim. Public API, locking and transport
-configuration remain unchanged. The latest follow-up is the
-[fixed-pin plain ABBA stage](#plain-abba-after-the-lite-ack-diagnosis); earlier
+configuration remain unchanged. The next experiment after Lab PR #28 is the
+[absolute pacer-deadline candidate and its fixed ABBA stage](pacer-deadline-experiment.md); earlier
 experiments below retain their original pins and contracts. Use a dedicated Linux test VM to reproduce a Linux
 capacity observation; native macOS and hosted x86-64 CI are separate platform
 controls, not substitutes for that environment.

--- a/interop/tests/test_pacer_deadline_ab.py
+++ b/interop/tests/test_pacer_deadline_ab.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import copy
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "benchmarks"))
+import run_pacer_deadline_ab as ab
+import test_throughput_diagnostics_plain_ab as fixtures
+
+
+class PacerDeadlineABTests(unittest.TestCase):
+    def manifests(self):
+        with patch.object(ab.common, "REVISIONS", ab.REVISIONS):
+            return fixtures.PlainCapacityABTests().manifests()
+
+    def diagnostic(self, manifest=None):
+        with patch.object(ab.common, "ARGUMENTS", ab.ARGUMENTS), patch.object(ab.common, "PROFILES", ab.PROFILES):
+            result = fixtures.PlainCapacityABTests().diagnostic(manifest)
+        for case in result["runs"]:
+            resources = case["result"]["peer_process_resources"]
+            resources["sender"].update(pid=100, voluntary_context_switches=20, involuntary_context_switches=2)
+            resources["receiver"] = {"pid": 200, "user_cpu_us": 500000, "system_cpu_us": 500000,
+                                     "voluntary_context_switches": 10, "involuntary_context_switches": 1}
+        return result
+
+    def test_fixed_72_transfer_plan_and_separate_library_pins(self):
+        cases = ab.cases() * len(ab.common.plan())
+        self.assertEqual(len(cases), 72)
+        self.assertEqual(sum(c["kind"] == "measurement" for c in cases), 48)
+        self.assertEqual(sum(c["kind"] == "warmup" for c in cases), 16)
+        self.assertEqual(sum(c["kind"].startswith("control-") for c in cases), 8)
+        self.assertEqual(ab.ARGUMENTS["bytes_per_connection"], 1024**3)
+        self.assertEqual(ab.REVISIONS["baseline"], "8e1bdebed836cb7b732db852f51ef6a7b212e925")
+        self.assertNotEqual(ab.REVISIONS, ab.common.REVISIONS)
+        self.assertTrue(all(len(pin) == 40 for pin in ab.REVISIONS.values()))
+
+    def test_exact_pair_and_instrumentation_guards(self):
+        manifests = self.manifests()
+        args = ({"dirty": False, "revision": "common-harness"}, {"platform": "Linux-test", "architecture": "aarch64"})
+        ab.common.validate_manifests(manifests, *args, revisions=ab.REVISIONS)
+        for mutation in (lambda m: m["candidate"]["sources"]["robotweax"].update(revision=ab.common.REVISIONS["candidate"]),
+                         lambda m: m["candidate"].update(poll_counters={"enabled": True}),
+                         lambda m: m["baseline"].update(transport_trace={"enabled": True}),
+                         lambda m: m["candidate"]["harness_checkout"].update(revision="different-harness")):
+            altered = copy.deepcopy(manifests)
+            mutation(altered)
+            with self.assertRaises(ValueError):
+                ab.common.validate_manifests(altered, *args, revisions=ab.REVISIONS)
+
+    def test_all_four_directions_and_both_process_resources_are_required(self):
+        report = self.diagnostic()
+        analysis = ab.analyze_block(report, {}, 0)
+        self.assertTrue(analysis["measurement_contract_pass"], analysis["errors"])
+        self.assertEqual(len(analysis["cases"]), 18)
+        self.assertEqual({s["profile"] for s in analysis["summary"]}, set(ab.PROFILES))
+        for role in ("sender", "receiver"):
+            for key in ("pid", "user_cpu_us", "system_cpu_us", "voluntary_context_switches", "involuntary_context_switches"):
+                altered = copy.deepcopy(report)
+                altered["runs"][2]["result"]["peer_process_resources"][role].pop(key)
+                self.assertFalse(ab.analyze_block(altered, {}, 0)["measurement_contract_pass"], (role, key))
+
+    def test_retransmissions_and_missing_udp_fail_in_every_case(self):
+        for index in range(len(ab.cases())):
+            for mode in ("retransmission", "missing-udp"):
+                report = self.diagnostic()
+                row = report["runs"][index]
+                if mode == "missing-udp":
+                    row["system_udp_delta"].pop("InErrors")
+                else:
+                    row["result"]["wire_statistics"]["retransmitted_packets"] = 1
+                    row["result"]["wire_statistics"]["sender_packets_total"] += 1
+                self.assertFalse(ab.analyze_block(report, {}, 0)["measurement_contract_pass"])
+
+    def test_summary_keeps_failed_contract_samples_and_excludes_warmups(self):
+        report = self.diagnostic()
+        for row in report["runs"]:
+            if row["kind"] != "measurement":
+                row["result"]["peer_process_resources"]["receiver"]["user_cpu_us"] = 999999999
+        report["runs"][2]["system_udp_delta"]["InErrors"] = 1
+        summary = ab.analyze_block(report, {}, 0)["summary"][0]
+        self.assertEqual(summary["receiver_cpu_seconds"]["median"], 1)
+        self.assertEqual(summary["receiver_cpu_seconds"]["samples"], 3)
+        self.assertEqual(summary["evidence_passes"], 2)
+
+    def test_runner_continues_after_failure_but_stops_on_interrupt(self):
+        for mode in ("pass", "fail", "missing", "interrupt"):
+            with self.subTest(mode=mode), tempfile.TemporaryDirectory() as tmp:
+                manifests = self.manifests()
+                paths = {v: Path(tmp) / f"{v}.json" for v in ab.REVISIONS}
+                report = {}
+                before = signal.getsignal(signal.SIGINT)
+
+                def execute(args):
+                    out = Path(args[args.index("--output-directory") + 1])
+                    variant = "candidate" if "candidate" in out.name else "baseline"
+                    first = out.name.startswith("00")
+                    if first and mode == "interrupt":
+                        raise KeyboardInterrupt
+                    if not (first and mode == "missing"):
+                        out.mkdir()
+                        (out / "report.json").write_text(json.dumps(self.diagnostic(manifests[variant])))
+                    return 1 if first and mode == "fail" else 0
+
+                with patch.object(ab.diag, "main", side_effect=execute) as run:
+                    status = ab.run_blocks(paths, manifests, Path(tmp) / "results", report)
+                self.assertEqual(status, 0 if mode == "pass" else 130 if mode == "interrupt" else 1)
+                self.assertEqual(run.call_count, 1 if mode == "interrupt" else 4)
+                self.assertEqual(report["complete"], mode != "interrupt")
+                self.assertEqual(report["interrupted"], mode == "interrupt")
+                self.assertEqual(signal.getsignal(signal.SIGINT), before)
+                self.assertTrue(report["performance_decision_requires_review"])
+
+    def test_rejects_other_hosts(self):
+        for system, machine, hostname in (("Darwin", "arm64", "lima-srt-network-lab-runtime"),
+                                          ("Linux", "x86_64", "lima-srt-network-lab-runtime"),
+                                          ("Linux", "aarch64", "different-vm")):
+            with patch.object(ab.platform, "system", return_value=system), patch.object(ab.platform, "machine", return_value=machine), patch.object(ab.socket, "gethostname", return_value=hostname):
+                with self.assertRaises(SystemExit):
+                    ab.main(["--baseline-plain", "unused", "--candidate-plain", "unused", "--output-directory", "unused"])
+
+    @unittest.skipUnless(os.name == "posix", "POSIX workload process groups")
+    def test_real_interrupt_cleans_case_and_signal_ignoring_peer(self):
+        for signum in (signal.SIGINT, signal.SIGTERM):
+            with self.subTest(signal=signum), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                ready = root / "ready.json"
+                workload = root / "workload.py"
+                workload.write_text("import os,signal,subprocess,sys,time,json\n"
+                    "signal.signal(signal.SIGTERM,signal.SIG_IGN)\n"
+                    "signal.signal(signal.SIGINT,signal.SIG_IGN)\n"
+                    "p=subprocess.Popen([sys.executable,'-c','import signal,time; signal.signal(signal.SIGTERM,signal.SIG_IGN); signal.signal(signal.SIGINT,signal.SIG_IGN); time.sleep(60)'])\n"
+                    f"open({str(ready)!r},'w').write(json.dumps({{'case':os.getpid(),'peer':p.pid,'group':os.getpgrp()}}))\n"
+                    "time.sleep(60)\n")
+                driver = root / "driver.py"
+                driver.write_text(f"import sys\nfrom pathlib import Path\nsys.path.insert(0,{str(Path(ab.__file__).parent)!r})\n"
+                    "import run_pacer_deadline_ab as ab\n"
+                    f"root=Path({str(root)!r})\n"
+                    "def diagnostic(args):\n"
+                    " out=root/'case';out.mkdir()\n"
+                    " return ab.diag.run_bounded([sys.executable,str(root/'workload.py')],out,120)\n"
+                    "ab.diag.main=diagnostic\n"
+                    "raise SystemExit(ab.run_blocks({'baseline':root/'a','candidate':root/'b'},{},root/'results',{}))\n")
+                process = subprocess.Popen([sys.executable, str(driver)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                ids = {}
+                try:
+                    deadline = time.monotonic() + 5
+                    while not ready.exists() and time.monotonic() < deadline:
+                        time.sleep(.01)
+                    ids = json.loads(ready.read_text())
+                    self.assertNotEqual(ids["group"], os.getpgrp())
+                    process.send_signal(signum)
+                    self.assertEqual(process.wait(timeout=10), 128 + signum)
+                    def active(pid):
+                        result = subprocess.run(["ps", "-o", "stat=", "-p", str(pid)], capture_output=True, text=True)
+                        return bool(result.stdout.strip()) and not result.stdout.strip().startswith("Z")
+                    deadline = time.monotonic() + 2
+                    while any(active(ids[k]) for k in ("case", "peer")) and time.monotonic() < deadline:
+                        time.sleep(.01)
+                    self.assertFalse(any(active(ids[k]) for k in ("case", "peer")))
+                    report = json.loads((root / "results/ab-report.json").read_text())
+                    self.assertTrue(report["interrupted"])
+                    self.assertFalse(report["complete"])
+                    self.assertEqual(len(report["blocks"]), 1)
+                    self.assertEqual(report["blocks"][0]["exit_code"], 128 + signum)
+                finally:
+                    if process.poll() is None:
+                        process.kill()
+                        process.wait()
+                    if ids:
+                        try:
+                            os.killpg(ids["group"], signal.SIGKILL)
+                        except ProcessLookupError:
+                            pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/interop/tests/test_pacer_deadline_ab.py
+++ b/interop/tests/test_pacer_deadline_ab.py
@@ -133,11 +133,19 @@ class PacerDeadlineABTests(unittest.TestCase):
             with self.subTest(signal=signum), tempfile.TemporaryDirectory() as tmp:
                 root = Path(tmp)
                 ready = root / "ready.json"
+                peer_ready = root / "peer-ready"
                 workload = root / "workload.py"
+                peer_code = ("import signal,time; from pathlib import Path; "
+                             "signal.signal(signal.SIGTERM,signal.SIG_IGN); "
+                             "signal.signal(signal.SIGINT,signal.SIG_IGN); "
+                             f"Path({str(peer_ready)!r}).write_text('ready'); time.sleep(60)")
                 workload.write_text("import os,signal,subprocess,sys,time,json\n"
                     "signal.signal(signal.SIGTERM,signal.SIG_IGN)\n"
                     "signal.signal(signal.SIGINT,signal.SIG_IGN)\n"
-                    "p=subprocess.Popen([sys.executable,'-c','import signal,time; signal.signal(signal.SIGTERM,signal.SIG_IGN); signal.signal(signal.SIGINT,signal.SIG_IGN); time.sleep(60)'])\n"
+                    f"p=subprocess.Popen([sys.executable,'-c',{peer_code!r}])\n"
+                    "deadline=time.monotonic()+3\n"
+                    f"while not os.path.exists({str(peer_ready)!r}) and time.monotonic()<deadline:time.sleep(.01)\n"
+                    f"assert os.path.exists({str(peer_ready)!r})\n"
                     f"open({str(ready)!r},'w').write(json.dumps({{'case':os.getpid(),'peer':p.pid,'group':os.getpgrp()}}))\n"
                     "time.sleep(60)\n")
                 driver = root / "driver.py"
@@ -173,8 +181,12 @@ class PacerDeadlineABTests(unittest.TestCase):
                     self.assertEqual(report["blocks"][0]["exit_code"], 128 + signum)
                 finally:
                     if process.poll() is None:
-                        process.kill()
-                        process.wait()
+                        process.send_signal(signal.SIGTERM)
+                        try:
+                            process.wait(timeout=10)
+                        except subprocess.TimeoutExpired:
+                            process.kill()
+                            process.wait()
                     if ids:
                         try:
                             os.killpg(ids["group"], signal.SIGKILL)

--- a/src/compat/runtime_scheduler.cpp
+++ b/src/compat/runtime_scheduler.cpp
@@ -348,6 +348,7 @@ RuntimeScheduler::Snapshot RuntimeScheduler::snapshot() const noexcept
 void RuntimeScheduler::run(std::size_t shard_index) noexcept
 {
     Shard& shard = *shards_[shard_index];
+    bool prefer_ready = false;
     for (;;) {
         Task task;
         {
@@ -357,8 +358,13 @@ void RuntimeScheduler::run(std::size_t shard_index) noexcept
                     const std::size_t timer_slot = shard.timer_heap.front();
                     const auto deadline =
                         shard.timer_slots[timer_slot].deadline;
-                    if (std::chrono::steady_clock::now() >= deadline) {
+                    // A hot channel can rearm a timer already due by the next
+                    // dispatch. Alternate with ready work so neither source
+                    // can monopolize a shard while both remain runnable.
+                    if ((!prefer_ready || shard.size == 0U)
+                        && std::chrono::steady_clock::now() >= deadline) {
                         task = shard.remove_timer(0U);
+                        prefer_ready = true;
                         break;
                     }
                 }
@@ -367,6 +373,7 @@ void RuntimeScheduler::run(std::size_t shard_index) noexcept
                     shard.entries[shard.head] = {};
                     shard.head = (shard.head + 1U) % shard.entries.size();
                     --shard.size;
+                    prefer_ready = false;
                     break;
                 }
                 if (shard.stop_requested) {

--- a/src/compat/transport_runtime.cpp
+++ b/src/compat/transport_runtime.cpp
@@ -781,7 +781,7 @@ bool DatagramChannel::start(std::shared_ptr<RuntimeScheduler> scheduler,
     send_work_notification_pending_ = false;
     active_thread_ = {};
     running_.store(true, std::memory_order_release);
-    if (schedule_next_locked(true, std::chrono::microseconds {0})) {
+    if (schedule_next_locked(true, {})) {
         return true;
     }
     running_.store(false, std::memory_order_release);
@@ -813,8 +813,8 @@ void DatagramChannel::notify_send_work() noexcept
         }
         scheduled_timer_ = {};
         send_work_notification_pending_ = false;
-        if (!schedule_next_locked(true, std::chrono::microseconds {0})
-            && !schedule_next_locked(false, std::chrono::microseconds {0})) {
+        if (!schedule_next_locked(true, {})
+            && !schedule_next_locked(false, {})) {
             running_.store(false, std::memory_order_release);
             scheduling_failed = true;
         }
@@ -861,7 +861,7 @@ void DatagramChannel::stop() noexcept
 }
 
 bool DatagramChannel::schedule_next_locked(
-    bool immediate, std::chrono::microseconds delay) noexcept
+    bool immediate, std::chrono::steady_clock::time_point deadline) noexcept
 {
     if (!running_.load(std::memory_order_relaxed) || scheduler_ == nullptr
         || scheduled_work_context_ == nullptr) {
@@ -880,8 +880,8 @@ bool DatagramChannel::schedule_next_locked(
         scheduled_timer_ = {};
         return true;
     }
-    const RuntimeScheduler::ScheduleResult scheduled = scheduler_->schedule_at(
-        affinity_, std::chrono::steady_clock::now() + delay, std::move(task));
+    const RuntimeScheduler::ScheduleResult scheduled =
+        scheduler_->schedule_at(affinity_, deadline, std::move(task));
     if (scheduled.status != RuntimeScheduler::SubmitStatus::accepted) {
         return false;
     }
@@ -923,11 +923,10 @@ void DatagramChannel::run_scheduled(
             const bool send_work_notification_pending =
                 send_work_notification_pending_;
             send_work_notification_pending_ = false;
-            const std::chrono::microseconds delay =
-                result.next_work_delay.value_or(idle_wait_);
             if (!schedule_next_locked(
                     result.immediate_work || send_work_notification_pending,
-                    delay)) {
+                    result.next_work_deadline.value_or(
+                        std::chrono::steady_clock::time_point {}))) {
                 running_.store(false, std::memory_order_release);
                 scheduling_failed = true;
             }
@@ -1099,44 +1098,33 @@ RuntimePollResult DatagramChannel::run_once() noexcept
     }
 
     bool send_work = false;
-    std::optional<std::chrono::microseconds> next_work_delay;
+    std::optional<std::chrono::steady_clock::time_point> next_work_deadline;
     {
         std::lock_guard lock(routes_mutex_);
         for (const auto& route : routes_) {
             const RuntimePollResult result = route.second->poll();
             send_work = result.immediate_work || send_work;
-            if (result.next_work_delay.has_value()
-                && (!next_work_delay.has_value()
-                    || *result.next_work_delay < *next_work_delay)) {
-                next_work_delay = result.next_work_delay;
+            if (result.next_work_deadline.has_value()
+                && (!next_work_deadline.has_value()
+                    || *result.next_work_deadline < *next_work_deadline)) {
+                next_work_deadline = result.next_work_deadline;
             }
         }
     }
     if (send_work || received_any) {
         return {
             .immediate_work = true,
-            .next_work_delay = std::nullopt,
+            .next_work_deadline = std::nullopt,
         };
     }
-    if (next_work_delay.has_value()
-        && *next_work_delay < std::chrono::milliseconds {1}) {
-        // Queue the final sub-millisecond pacing slice behind other work on
-        // this affinity shard. This preserves the old yield semantics while
-        // preventing one hot channel from monopolizing the shard.
-        return {
-            .immediate_work = true,
-            .next_work_delay = std::nullopt,
-        };
-    }
-    const auto delay = next_work_delay.has_value()
-        ? std::min(idle_wait_,
-              std::max(std::chrono::milliseconds {1},
-                  std::chrono::duration_cast<std::chrono::milliseconds>(
-                      *next_work_delay)))
-        : idle_wait_;
+    // Retain the pacer's absolute deadline, including sub-millisecond slices.
+    // Reconstructing it from a remaining delay would add poll/scheduling time.
+    // Keep the existing idle bound for inbound/control work on this channel.
+    const auto idle_deadline = std::chrono::steady_clock::now() + idle_wait_;
     return {
-        .next_work_delay =
-            std::chrono::duration_cast<std::chrono::microseconds>(delay),
+        .next_work_deadline = next_work_deadline.has_value()
+            ? std::min(*next_work_deadline, idle_deadline)
+            : idle_deadline,
     };
 }
 
@@ -2875,7 +2863,7 @@ RuntimePollResult ConnectionRuntime::poll() noexcept
     if (session_.has_pending_drop_requests()) {
         return {
             .immediate_work = true,
-            .next_work_delay = std::nullopt,
+            .next_work_deadline = std::nullopt,
         };
     }
 
@@ -2900,12 +2888,12 @@ RuntimePollResult ConnectionRuntime::poll() noexcept
     if (pace.ready || pace.next_ready_microseconds <= current) {
         return {
             .immediate_work = true,
-            .next_work_delay = std::nullopt,
+            .next_work_deadline = std::nullopt,
         };
     }
     return {
-        .next_work_delay =
-            std::chrono::microseconds {pace.next_ready_microseconds - current},
+        .next_work_deadline = deadline_from_origin_microseconds(
+            origin_, pace.next_ready_microseconds),
     };
 }
 

--- a/src/compat/transport_runtime.hpp
+++ b/src/compat/transport_runtime.hpp
@@ -150,7 +150,7 @@ struct RuntimeBufferPacketCounts {
 
 struct RuntimePollResult {
     bool immediate_work = false;
-    std::optional<std::chrono::microseconds> next_work_delay;
+    std::optional<std::chrono::steady_clock::time_point> next_work_deadline;
 };
 
 struct MessageIoResult {
@@ -217,6 +217,8 @@ public:
     }
 
 private:
+    friend struct DatagramChannelTestAccess;
+
     struct ScheduledWorkContext {
         std::weak_ptr<DatagramChannel> owner;
     };
@@ -231,8 +233,8 @@ private:
     static void run_scheduled(void* context) noexcept;
     void run_scheduled(const ScheduledWorkContext* context) noexcept;
     [[nodiscard]] RuntimePollResult run_once() noexcept;
-    [[nodiscard]] bool schedule_next_locked(
-        bool immediate, std::chrono::microseconds delay) noexcept;
+    [[nodiscard]] bool schedule_next_locked(bool immediate,
+        std::chrono::steady_clock::time_point deadline) noexcept;
     void dispatch(
         const PacketView& packet,
         std::span<const std::byte> datagram,

--- a/tests/test_compat_runtime.cpp
+++ b/tests/test_compat_runtime.cpp
@@ -25,6 +25,19 @@
 using namespace robotweax::srt;
 using namespace robotweax::srt::compat;
 
+namespace robotweax::srt::compat {
+struct DatagramChannelTestAccess {
+    static RuntimePollResult poll(DatagramChannel& channel)
+    {
+        return channel.run_once();
+    }
+    static void stop(DatagramChannel& channel)
+    {
+        channel.stop();
+    }
+};
+} // namespace robotweax::srt::compat
+
 namespace {
 
 struct InboxReadinessObserver {
@@ -87,6 +100,96 @@ void deliver(
 std::uint64_t injected_now(void* context) noexcept
 {
     return *static_cast<const std::uint64_t*>(context);
+}
+
+struct PollGate {
+    std::mutex mutex;
+    std::condition_variable changed;
+    bool entered = false;
+    bool released = false;
+};
+
+void wait_at_poll_gate(void* context) noexcept
+{
+    auto& gate = *static_cast<PollGate*>(context);
+    std::unique_lock lock(gate.mutex);
+    gate.entered = true;
+    gate.changed.notify_all();
+    gate.changed.wait(lock, [&] {
+        return gate.released;
+    });
+}
+
+UdpIoResult gate_datagram(
+    std::span<const std::byte> bytes, Ipv4Endpoint, void* context) noexcept
+{
+    wait_at_poll_gate(context);
+    return {.bytes_transferred = bytes.size()};
+}
+
+struct PollGateRelease {
+    std::shared_ptr<PollGate> gate;
+    void release()
+    {
+        std::lock_guard lock(gate->mutex);
+        gate->released = true;
+        gate->changed.notify_all();
+    }
+    ~PollGateRelease()
+    {
+        release();
+    }
+};
+
+void await_poll_gate(const std::shared_ptr<PollGate>& gate)
+{
+    std::unique_lock lock(gate->mutex);
+    REQUIRE(gate->changed.wait_for(lock, std::chrono::seconds {2}, [&] {
+        return gate->entered;
+    }));
+}
+
+RuntimeScheduler::Snapshot await_channel_timer(
+    const RuntimeScheduler& scheduler, std::uint64_t completed)
+{
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds {2};
+    auto state = scheduler.snapshot();
+    while ((state.timers != 1U || state.executing || state.queued != 0U
+               || state.completed < completed)
+        && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+        state = scheduler.snapshot();
+    }
+    REQUIRE_EQ(state.timers, 1U);
+    REQUIRE_EQ(state.queued, 0U);
+    REQUIRE_EQ(state.executing, 0U);
+    return state;
+}
+
+std::shared_ptr<ConnectionRuntime> queue_paced_fixture(
+    const std::shared_ptr<DatagramChannel>& channel, std::uint64_t& now)
+{
+    auto runtime = std::make_shared<
+        ConnectionRuntime>(ConnectionRuntime::Configuration {
+        .channel = channel,
+        .peer = {.address = {192, 0, 2, 20}, .port = 10'020},
+        .peer_socket_id = 1,
+        .initial_sequence = SequenceNumber {900},
+        .flow_window_packets = 256,
+        // Keep the clock-controlled pacer pending while inspecting scheduling.
+        .origin = ConnectionRuntime::Clock::now() + std::chrono::hours {1},
+        .now_function = injected_now,
+        .now_context = &now,
+    });
+    REQUIRE(channel->register_connection(1, runtime));
+    channel->set_idle_wait_for_testing(std::chrono::seconds {5});
+    const std::array<std::byte, 1'200> payload {};
+    for (int i = 0; i < 2; ++i) {
+        REQUIRE_EQ(runtime->queue_message(payload, 0, true, false, 0).status,
+            MessageIoStatus::success);
+    }
+    return runtime;
 }
 
 std::vector<std::byte> encrypt_fixture(
@@ -671,6 +774,7 @@ TEST(compat_runtime_reports_the_next_paced_send_deadline)
     CapturedDatagrams output;
     channel->set_send_hook_for_testing(capture_datagram, &output);
     std::uint64_t now = 1'000;
+    const auto origin = ConnectionRuntime::Clock::now();
     ConnectionRuntime runtime {{
         .channel = channel,
         .peer =
@@ -681,7 +785,7 @@ TEST(compat_runtime_reports_the_next_paced_send_deadline)
         .peer_socket_id = 0x3400U,
         .initial_sequence = SequenceNumber {900},
         .flow_window_packets = 256,
-        .origin = ConnectionRuntime::Clock::now(),
+        .origin = origin,
         .now_function = injected_now,
         .now_context = &now,
     }};
@@ -694,22 +798,180 @@ TEST(compat_runtime_reports_the_next_paced_send_deadline)
 
     const RuntimePollResult first = runtime.poll();
     REQUIRE(!first.immediate_work);
-    REQUIRE(first.next_work_delay.has_value());
-    REQUIRE_EQ(*first.next_work_delay, std::chrono::microseconds {10});
+    REQUIRE(first.next_work_deadline.has_value());
+    REQUIRE_EQ(
+        *first.next_work_deadline, origin + std::chrono::microseconds {1'010});
     REQUIRE_EQ(take_datagrams(output).size(), 1U);
 
     now += 9;
     const RuntimePollResult early = runtime.poll();
     REQUIRE(!early.immediate_work);
-    REQUIRE(early.next_work_delay.has_value());
-    REQUIRE_EQ(*early.next_work_delay, std::chrono::microseconds {1});
+    REQUIRE(early.next_work_deadline.has_value());
+    REQUIRE_EQ(*early.next_work_deadline, *first.next_work_deadline);
     REQUIRE(take_datagrams(output).empty());
 
     ++now;
     const RuntimePollResult ready = runtime.poll();
     REQUIRE(!ready.immediate_work);
-    REQUIRE(!ready.next_work_delay.has_value());
+    REQUIRE(!ready.next_work_deadline.has_value());
     REQUIRE_EQ(take_datagrams(output).size(), 1U);
+
+    // A late wake keeps the original pacing rule: no catch-up credit or burst.
+    REQUIRE_EQ(runtime.queue_message(payload, 0, true, false, 0).status,
+        MessageIoStatus::success);
+    REQUIRE_EQ(runtime.queue_message(payload, 0, true, false, 0).status,
+        MessageIoStatus::success);
+    now += 50;
+    const auto late = runtime.poll();
+    REQUIRE_EQ(*late.next_work_deadline,
+        origin + std::chrono::microseconds {now + 10});
+    REQUIRE_EQ(take_datagrams(output).size(), 1U);
+}
+
+TEST(compat_dispatcher_preserves_the_earliest_absolute_pacer_deadline)
+{
+    auto channel = std::make_shared<DatagramChannel>();
+    CapturedDatagrams output;
+    channel->set_send_hook_for_testing(capture_datagram, &output);
+    std::uint64_t now = 1'000;
+    // Controlled origins make the deadlines independent of wall-clock timing.
+    // They are already due on the scheduler clock; they must not move forward
+    // when the dispatcher aggregates or schedules them.
+    const auto origin = ConnectionRuntime::Clock::time_point {};
+    for (std::uint32_t id = 1; id <= 2; ++id) {
+        auto runtime = std::make_shared<ConnectionRuntime>(
+            ConnectionRuntime::Configuration {
+                .channel = channel,
+                .peer = {.address = {192, 0, 2, 20}, .port = 10'020},
+                .peer_socket_id = id,
+                .initial_sequence = SequenceNumber {900},
+                .flow_window_packets = 256,
+                .origin = origin + std::chrono::microseconds {id * 100},
+                .now_function = injected_now,
+                .now_context = &now,
+            });
+        REQUIRE(channel->register_connection(id, runtime));
+        const std::array<std::byte, 1'200> payload {};
+        for (int index = 0; index < 2; ++index) {
+            REQUIRE_EQ(
+                runtime->queue_message(payload, 0, true, false, 0).status,
+                MessageIoStatus::success);
+        }
+    }
+    const auto first = DatagramChannelTestAccess::poll(*channel);
+    REQUIRE(!first.immediate_work);
+    REQUIRE_EQ(
+        *first.next_work_deadline, origin + std::chrono::microseconds {1'110});
+    REQUIRE_EQ(take_datagrams(output).size(), 2U);
+    now += 9;
+    const auto early = DatagramChannelTestAccess::poll(*channel);
+    REQUIRE(!early.immediate_work);
+    REQUIRE_EQ(early.next_work_deadline, first.next_work_deadline);
+    REQUIRE(take_datagrams(output).empty());
+    ++now;
+    const auto before = ConnectionRuntime::Clock::now();
+    const auto drained = DatagramChannelTestAccess::poll(*channel);
+    const auto after = ConnectionRuntime::Clock::now();
+    REQUIRE_EQ(take_datagrams(output).size(), 2U);
+    REQUIRE(!drained.immediate_work);
+    REQUIRE(
+        *drained.next_work_deadline >= before + std::chrono::milliseconds {2});
+    REQUIRE(
+        *drained.next_work_deadline <= after + std::chrono::milliseconds {2});
+}
+
+TEST(compat_dispatcher_pacer_notifications_rearm_once_and_survive_restart)
+{
+    auto scheduler =
+        std::make_shared<RuntimeScheduler>(RuntimeScheduler::Configuration {
+            .shard_count = 1,
+            .queue_capacity_per_shard = 1,
+            .timer_capacity_per_shard = 1,
+        });
+    REQUIRE(scheduler->start());
+    auto channel = std::make_shared<DatagramChannel>();
+    auto sending = std::make_shared<PollGate>();
+    channel->set_send_hook_for_testing(gate_datagram, sending.get());
+    std::uint64_t now = 1'000;
+    auto runtime = queue_paced_fixture(channel, now);
+    PollGateRelease release_sending {sending};
+    REQUIRE(channel->start(scheduler, 0U));
+    await_poll_gate(sending);
+    // Multiple notifications during an active poll require exactly one follow-up.
+    for (int i = 0; i < 16; ++i) {
+        channel->notify_send_work();
+    }
+    release_sending.release();
+    const auto timed = await_channel_timer(*scheduler, 2U);
+    REQUIRE_EQ(timed.completed, 2U);
+    REQUIRE_EQ(timed.timers_scheduled, 1U);
+
+    auto busy = std::make_shared<PollGate>();
+    PollGateRelease release_busy {busy};
+    REQUIRE_EQ(scheduler->submit(0U, {wait_at_poll_gate, busy}),
+        RuntimeScheduler::SubmitStatus::accepted);
+    await_poll_gate(busy);
+    // Cancel the future timer, then coalesce notifications while its replacement
+    // waits in the ready queue. No second callback or timer may be created.
+    for (int i = 0; i < 16; ++i) {
+        channel->notify_send_work();
+    }
+    REQUIRE_EQ(scheduler->snapshot().queued, 1U);
+    REQUIRE_EQ(scheduler->snapshot().timers, 0U);
+    release_busy.release();
+    const auto rearmed = await_channel_timer(*scheduler, timed.completed + 2U);
+    REQUIRE_EQ(rearmed.completed, timed.completed + 2U);
+    REQUIRE_EQ(rearmed.timers_canceled, 1U);
+    REQUIRE_EQ(rearmed.timers_scheduled, 2U);
+
+    DatagramChannelTestAccess::stop(*channel);
+    REQUIRE_EQ(scheduler->snapshot().timers, 0U);
+    REQUIRE(!channel->running());
+    REQUIRE(channel->start(scheduler, 0U));
+    const auto restarted =
+        await_channel_timer(*scheduler, rearmed.completed + 1U);
+    REQUIRE_EQ(restarted.completed, rearmed.completed + 1U);
+    REQUIRE_EQ(restarted.timers_scheduled, 3U);
+    DatagramChannelTestAccess::stop(*channel);
+    REQUIRE_EQ(scheduler->snapshot().timers, 0U);
+    REQUIRE_EQ(scheduler->snapshot().queued, 0U);
+    scheduler->stop();
+}
+
+TEST(compat_dispatcher_pacer_timer_exhaustion_breaks_the_connection)
+{
+    auto scheduler =
+        std::make_shared<RuntimeScheduler>(RuntimeScheduler::Configuration {
+            .shard_count = 1,
+            .queue_capacity_per_shard = 1,
+            .timer_capacity_per_shard = 1,
+        });
+    REQUIRE(scheduler->start());
+    const auto unrelated = scheduler->schedule_at(0U,
+        ConnectionRuntime::Clock::now() + std::chrono::hours {1},
+        {wait_at_poll_gate, std::make_shared<PollGate>()});
+    REQUIRE_EQ(unrelated.status, RuntimeScheduler::SubmitStatus::accepted);
+    auto channel = std::make_shared<DatagramChannel>();
+    CapturedDatagrams output;
+    channel->set_send_hook_for_testing(capture_datagram, &output);
+    std::uint64_t now = 1'000;
+    auto runtime = queue_paced_fixture(channel, now);
+    REQUIRE(channel->start(scheduler, 0U));
+    const auto deadline =
+        ConnectionRuntime::Clock::now() + std::chrono::seconds {2};
+    while (channel->running() && ConnectionRuntime::Clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    REQUIRE(!channel->running());
+    // stop waits for any active callback; broken-state publication follows the
+    // scheduling failure and must be visible before another message is queued.
+    scheduler->stop();
+    const std::array<std::byte, 1> payload {};
+    REQUIRE_EQ(runtime->queue_message(payload, 0, true, false, 0).status,
+        MessageIoStatus::broken);
+    REQUIRE_EQ(scheduler->snapshot().rejected_full, 1U);
+    REQUIRE_EQ(scheduler->snapshot().timers, 0U);
+    REQUIRE_EQ(scheduler->snapshot().queued, 0U);
 }
 
 TEST(compat_runtime_waits_for_key_response_without_runnable_send_work)
@@ -744,7 +1006,7 @@ TEST(compat_runtime_waits_for_key_response_without_runnable_send_work)
 
     const RuntimePollResult waiting = runtime.poll();
     REQUIRE(!waiting.immediate_work);
-    REQUIRE(!waiting.next_work_delay.has_value());
+    REQUIRE(!waiting.next_work_deadline.has_value());
     const auto datagrams = take_datagrams(output);
     REQUIRE_EQ(datagrams.size(), 1U);
     const auto decoded = decode_packet(datagrams.front());

--- a/tests/test_compat_runtime.cpp
+++ b/tests/test_compat_runtime.cpp
@@ -170,6 +170,7 @@ RuntimeScheduler::Snapshot await_channel_timer(
 std::shared_ptr<ConnectionRuntime> queue_paced_fixture(
     const std::shared_ptr<DatagramChannel>& channel, std::uint64_t& now)
 {
+    REQUIRE_EQ(channel->socket.bind(IpEndpoint::loopback()), Error::none);
     auto runtime = std::make_shared<
         ConnectionRuntime>(ConnectionRuntime::Configuration {
         .channel = channel,
@@ -831,6 +832,7 @@ TEST(compat_runtime_reports_the_next_paced_send_deadline)
 TEST(compat_dispatcher_preserves_the_earliest_absolute_pacer_deadline)
 {
     auto channel = std::make_shared<DatagramChannel>();
+    REQUIRE_EQ(channel->socket.bind(IpEndpoint::loopback()), Error::none);
     CapturedDatagrams output;
     channel->set_send_hook_for_testing(capture_datagram, &output);
     std::uint64_t now = 1'000;
@@ -966,6 +968,7 @@ TEST(compat_dispatcher_pacer_timer_exhaustion_breaks_the_connection)
     // stop waits for any active callback; broken-state publication follows the
     // scheduling failure and must be visible before another message is queued.
     scheduler->stop();
+    REQUIRE_EQ(take_datagrams(output).size(), 1U);
     const std::array<std::byte, 1> payload {};
     REQUIRE_EQ(runtime->queue_message(payload, 0, true, false, 0).status,
         MessageIoStatus::broken);

--- a/tests/test_runtime_scheduler.cpp
+++ b/tests/test_runtime_scheduler.cpp
@@ -62,8 +62,8 @@ void wait_until_started(const std::shared_ptr<Gate>& gate)
 struct OrderedRecord {
     std::mutex mutex;
     std::condition_variable changed;
-    std::array<int, 2> values {};
-    std::array<std::thread::id, 2> threads {};
+    std::array<int, 4> values {};
+    std::array<std::thread::id, 4> threads {};
     std::size_t size = 0;
 };
 
@@ -314,6 +314,46 @@ TEST(compat_runtime_scheduler_preserves_equal_deadline_timer_order)
     REQUIRE_EQ(ordered->values[0], 10);
     REQUIRE_EQ(ordered->values[1], 20);
     REQUIRE_EQ(ordered->threads[0], ordered->threads[1]);
+}
+
+TEST(compat_runtime_scheduler_alternates_due_timers_and_ready_work)
+{
+    RuntimeScheduler scheduler({
+        .shard_count = 1,
+        .queue_capacity_per_shard = 2,
+        .timer_capacity_per_shard = 2,
+    });
+    REQUIRE(scheduler.start());
+    const auto gate = std::make_shared<Gate>();
+    GateRelease release {gate};
+    // Hold the worker after it has claimed a timer. Cancellation must report
+    // that ownership, and both classes of subsequent work must make progress.
+    const auto claimed = scheduler.schedule_at(0U, {}, {wait_at_gate, gate});
+    REQUIRE_EQ(claimed.status, RuntimeScheduler::SubmitStatus::accepted);
+    wait_until_started(gate);
+    REQUIRE(!scheduler.cancel_timer(claimed.token));
+    const auto ordered = std::make_shared<OrderedRecord>();
+    for (int value = 1; value <= 4; ++value) {
+        RuntimeScheduler::Task task {
+            record_order,
+            std::make_shared<OrderedTask>(OrderedTask {ordered, value}),
+        };
+        if (value % 2 == 0) {
+            REQUIRE_EQ(scheduler.schedule_at(0U, {}, std::move(task)).status,
+                RuntimeScheduler::SubmitStatus::accepted);
+        } else {
+            REQUIRE_EQ(scheduler.submit(0U, std::move(task)),
+                RuntimeScheduler::SubmitStatus::accepted);
+        }
+    }
+    release_gate(gate);
+    wait_until_completed(scheduler, 5U);
+    scheduler.stop();
+    REQUIRE_EQ(ordered->size, 4U);
+    for (std::size_t index = 0; index < ordered->size; ++index) {
+        REQUIRE_EQ(ordered->values[index], static_cast<int>(index + 1U));
+        REQUIRE_EQ(ordered->threads[index], ordered->threads[0]);
+    }
 }
 
 TEST(compat_runtime_scheduler_bounds_and_serializes_affinity_shards)


### PR DESCRIPTION
Lab PR #28 found 3.41–3.66 sender polls per original packet, about 74% without a DATA send. The channel currently requeues every sub-millisecond pacing wait immediately, repeating receive and connection work before the pacer is ready.

This candidate carries the absolute pacer deadline from the connection through the channel to the scheduler. It preserves the earliest deadline and existing idle bound, without adding the processing time to an old relative remainder. Due timers alternate with ready work so a hot timed channel cannot monopolize its shard. Public headers/class layouts, pacing rate and catch-up policy, buffers, batch limits and the shared public-API peer are unchanged.

The library candidate is `11814d3a1ebc217dbe95613b679960ac3152ff59`; the separate harness pin is `51bb660c3891ef7879ddc23fbaafd458dbc5db57`. The [fixed lab handoff](https://github.com/Robotweax/srt/blob/51bb660c3891ef7879ddc23fbaafd458dbc5db57/docs/pacer-deadline-experiment.md) compares baseline `8e1bdeb` against that candidate in 72 plain 1-GiB ABBA transfers across all four directions. It records both peers' CPU/GiB and context switches, preserves failures, and requires zero retransmissions/recorded UDP errors. Blocks run in-process so handled interruption reaches the driver's tracked case-group cleanup; there are no automatic retries or sysctl changes.

Validation on macOS:

- All 40 CTest targets passed, including 606 native cases, ABI, lifecycle, encryption and package-consumer checks.
- All 629 Python harness tests passed, including real SIGINT/SIGTERM cleanup with signal-ignoring synthetic case/peer processes.
- A 4-MiB public-API loopback transfer passed with 3188 originals and zero retransmissions.
- Documentation, pinned clang-format 22.1.8 and diff checks passed.

CI on final harness `51bb660c3891ef7879ddc23fbaafd458dbc5db57` [passed](https://github.com/Robotweax/srt/actions/runs/34691689809): 40 successful jobs, including Release on Linux (132/132 CTest targets), macOS (55/55), Windows (37/37), both sanitizers, FFmpeg, shared/ABI checks and the complete selected Haivision interoperability matrix. The new dispatcher fixtures explicitly bind loopback sockets before polling, fixing their initial Windows-only failure.

This remains a diagnostic candidate. Timer lateness can reduce throughput because the pacer does not grant catch-up burst credit. The Linux lab comparison has not run; keep this PR unmerged pending those results. Counter PR #33 remains separate.
