### PR TITLE
Diagnose pacer deadline, dispatch and send delays at fixed pins

### DIFF
--- a/benchmarks/diagnostics/pacer_deadline_diagnostics.hpp
+++ b/benchmarks/diagnostics/pacer_deadline_diagnostics.hpp
@@ -1,0 +1,321 @@
+#pragma once
+
+// Diagnostic exports only. No public peer/API changes and no per-packet I/O.
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <pthread.h>
+#include <time.h>
+#include <unistd.h>
+#ifdef __linux__
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#endif
+
+// clang-format off
+#define RWX_DD_COUNTERS(X) \
+    X(ready_tasks) X(timer_tasks) X(wait_calls) X(wait_returns) \
+    X(timed_wait_calls) X(timed_wait_returns) X(early_wait_returns) \
+    X(channel_polls) X(connection_polls) X(rx_attempts) X(rx_eagain) \
+    X(rx_datagrams) X(flow_block) X(crypto_block) X(pacer_block) \
+    X(selection_empty) X(data_packets) X(original_packets) \
+    X(retransmitted_packets) X(data_without_pacer_deadline)
+#define RWX_DD_HISTOGRAMS(X) \
+    X(timer_remaining_on_submit_ns) X(timer_overdue_on_submit_ns) \
+    X(timer_dispatch_lateness_ns) X(ready_queue_ns) X(timer_queue_ns) \
+    X(wait_requested_ns) X(wait_elapsed_ns) X(wait_lateness_ns) \
+    X(task_elapsed_ns) X(task_to_send_ns) X(pacer_send_lateness_ns) \
+    X(pacer_lateness_at_task_start_ns) X(pacer_remaining_at_task_start_ns) \
+    X(pacer_send_earliness_ns) X(data_per_task) X(data_per_poll)
+// clang-format on
+
+namespace robotweax::srt::deadline_diagnostics {
+using Clock = std::chrono::steady_clock;
+using Time = Clock::time_point;
+#define RWX_DD_ENUM(name) name,
+enum class Count { RWX_DD_COUNTERS(RWX_DD_ENUM) size };
+enum class Metric { RWX_DD_HISTOGRAMS(RWX_DD_ENUM) size };
+#undef RWX_DD_ENUM
+#define RWX_DD_NAME(name) #name,
+inline constexpr const char* count_names[] = {RWX_DD_COUNTERS(RWX_DD_NAME)};
+inline constexpr const char* metric_names[] = {RWX_DD_HISTOGRAMS(RWX_DD_NAME)};
+#undef RWX_DD_NAME
+// Inclusive upper bounds; the last bucket is larger than the last bound.
+inline constexpr std::array<std::uint64_t, 18> bounds {0, 1, 2, 4, 16, 64, 256,
+    1'000, 2'000, 5'000, 10'000, 20'000, 50'000, 100'000, 250'000, 500'000,
+    1'000'000, 10'000'000};
+inline std::atomic<unsigned> serial_source {0};
+
+inline std::uint64_t elapsed(Time end, Time begin) noexcept
+{
+    if (end <= begin) {
+        return 0;
+    }
+    return static_cast<std::uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin)
+            .count());
+}
+
+struct Histogram {
+    std::array<std::uint64_t, bounds.size() + 1U> buckets {};
+    std::uint64_t count = 0, sum = 0, maximum = 0;
+};
+
+class Recorder {
+public:
+    void start(std::size_t shard, std::size_t shards) noexcept
+    {
+        if (started_) {
+            return;
+        }
+        started_ = true;
+        const char* directory = std::getenv("ROBOTWEAX_PACER_DEADLINE_DIR");
+        if (directory == nullptr || *directory == '\0') {
+            return;
+        }
+        pid_ = static_cast<std::uint64_t>(getpid());
+#ifdef __linux__
+        tid_ = static_cast<std::uint64_t>(syscall(SYS_gettid));
+        timer_slack_ns_ = prctl(PR_GET_TIMERSLACK, 0UL, 0UL, 0UL, 0UL);
+#else
+        if (pthread_threadid_np(nullptr, &tid_) != 0) {
+            return;
+        }
+#endif
+        serial_ = serial_source.fetch_add(1U, std::memory_order_relaxed);
+        shard_ = shard;
+        shards_ = shards;
+        std::array<char, 4096> path {};
+        const int n = std::snprintf(path.data(), path.size(),
+            "%s/%" PRIu64 "-%" PRIu64 "-%u.jsonl", directory, pid_, tid_,
+            serial_);
+        if (n <= 0 || static_cast<std::size_t>(n) >= path.size()) {
+            return;
+        }
+        file_ = std::fopen(path.data(), "wx");
+        if (file_ == nullptr) {
+            std::fputs("pacer diagnostics: cannot register worker\n", stderr);
+            return;
+        }
+        std::fprintf(file_,
+            "{\"schema\":1,\"event\":\"register\",\"pid\":%" PRIu64
+            ",\"tid\":%" PRIu64 ",\"serial\":%u,\"shard\":%zu,"
+            "\"shards\":%zu,\"timer_slack_ns\":%ld}\n",
+            pid_, tid_, serial_, shard_, shards_, timer_slack_ns_);
+        std::fflush(file_);
+        registered_at_ = checkpoint_at_ = Clock::now();
+    }
+
+    void add(Count name, std::uint64_t amount = 1) noexcept
+    {
+        if (file_ != nullptr) {
+            increment(counts_[static_cast<std::size_t>(name)], amount);
+        }
+    }
+
+    void observe(Metric name, std::uint64_t value) noexcept
+    {
+        if (file_ == nullptr) {
+            return;
+        }
+        auto& h = histograms_[static_cast<std::size_t>(name)];
+        std::size_t bucket = 0;
+        while (bucket < bounds.size() && value > bounds[bucket]) {
+            ++bucket;
+        }
+        increment(h.buckets[bucket], 1);
+        increment(h.count, 1);
+        increment(h.sum, value);
+        h.maximum = value > h.maximum ? value : h.maximum;
+    }
+
+    // At most one checkpoint per second, after a callback and outside its locks.
+    // Keep the last complete line if termination interrupts a later write.
+    void checkpoint(Time now) noexcept
+    {
+        if (file_ != nullptr
+            && now - checkpoint_at_ >= std::chrono::seconds {1}) {
+            checkpoint_at_ = now;
+            if (snapshots_ < 128U) {
+                snapshot(false, now);
+            } else {
+                checkpoint_limit_ = true;
+            }
+        }
+    }
+
+    ~Recorder()
+    {
+        if (file_ != nullptr) {
+            snapshot(true, Clock::now());
+            if (std::fclose(file_) != 0) {
+                std::fputs("pacer diagnostics: incomplete output\n", stderr);
+            }
+        }
+    }
+
+private:
+    void increment(std::uint64_t& value, std::uint64_t amount) noexcept
+    {
+        if (amount > std::numeric_limits<std::uint64_t>::max() - value) {
+            overflow_ = true;
+            value = std::numeric_limits<std::uint64_t>::max();
+        } else {
+            value += amount;
+        }
+    }
+
+    void snapshot(bool complete, Time now) noexcept
+    {
+        ++snapshots_;
+        std::fprintf(file_,
+            "{\"schema\":1,\"event\":\"snapshot\",\"ordinal\":%u,"
+            "\"complete\":%s,\"overflow\":%s,\"checkpoint_limit\":%s,"
+            "\"elapsed_ns\":%" PRIu64 ",\"counters\":{",
+            snapshots_, complete ? "true" : "false",
+            overflow_ ? "true" : "false", checkpoint_limit_ ? "true" : "false",
+            elapsed(now, registered_at_));
+        for (std::size_t i = 0; i < counts_.size(); ++i) {
+            std::fprintf(file_, "%s\"%s\":%" PRIu64, i == 0 ? "" : ",",
+                count_names[i], counts_[i]);
+        }
+        std::fputs("},\"histograms\":{", file_);
+        for (std::size_t i = 0; i < histograms_.size(); ++i) {
+            const auto& h = histograms_[i];
+            std::fprintf(file_,
+                "%s\"%s\":{\"count\":%" PRIu64 ",\"sum\":%" PRIu64
+                ",\"max\":%" PRIu64 ",\"buckets\":[",
+                i == 0 ? "" : ",", metric_names[i], h.count, h.sum, h.maximum);
+            for (std::size_t j = 0; j < h.buckets.size(); ++j) {
+                std::fprintf(
+                    file_, "%s%" PRIu64, j == 0 ? "" : ",", h.buckets[j]);
+            }
+            std::fputs("]}", file_);
+        }
+        std::fputs("}}\n", file_);
+        if (std::fflush(file_) != 0 || std::ferror(file_) != 0) {
+            std::fputs("pacer diagnostics: incomplete snapshot\n", stderr);
+        }
+    }
+
+    std::array<std::uint64_t, static_cast<std::size_t>(Count::size)> counts_ {};
+    std::array<Histogram, static_cast<std::size_t>(Metric::size)>
+        histograms_ {};
+    std::FILE* file_ = nullptr;
+    Time registered_at_ {}, checkpoint_at_ {};
+    std::uint64_t pid_ = 0, tid_ = 0;
+    std::size_t shard_ = 0, shards_ = 0;
+    unsigned serial_ = 0, snapshots_ = 0;
+    long timer_slack_ns_ = -1;
+    bool started_ = false, overflow_ = false, checkpoint_limit_ = false;
+};
+
+inline Recorder& recorder() noexcept
+{
+    static thread_local Recorder own;
+    return own;
+}
+
+inline thread_local Time task_start {};
+inline thread_local std::uint64_t task_packets = 0;
+
+struct TaskScope {
+    TaskScope(Time submitted, Time deadline, bool timed) noexcept
+    {
+        task_start = Clock::now();
+        task_packets = 0;
+        auto& r = recorder();
+        r.add(timed ? Count::timer_tasks : Count::ready_tasks);
+        r.observe(timed ? Metric::timer_queue_ns : Metric::ready_queue_ns,
+            elapsed(task_start, submitted));
+        if (timed) {
+            r.observe(Metric::timer_remaining_on_submit_ns,
+                elapsed(deadline, submitted));
+            r.observe(Metric::timer_overdue_on_submit_ns,
+                elapsed(submitted, deadline));
+            r.observe(Metric::timer_dispatch_lateness_ns,
+                elapsed(task_start, deadline));
+        }
+    }
+    ~TaskScope()
+    {
+        auto& r = recorder();
+        r.observe(Metric::data_per_task, task_packets);
+        const auto now = Clock::now();
+        r.observe(Metric::task_elapsed_ns, elapsed(now, task_start));
+        r.checkpoint(now);
+        task_start = {};
+    }
+};
+
+struct WaitScope {
+    Time start = Clock::now(), deadline {};
+    bool timed = false;
+    explicit WaitScope(Time target = {}, bool has_target = false) noexcept
+        : deadline(target)
+        , timed(has_target)
+    {
+        recorder().add(timed ? Count::timed_wait_calls : Count::wait_calls);
+        if (timed) {
+            recorder().observe(
+                Metric::wait_requested_ns, elapsed(deadline, start));
+        }
+    }
+    ~WaitScope()
+    {
+        const auto now = Clock::now();
+        auto& r = recorder();
+        r.add(timed ? Count::timed_wait_returns : Count::wait_returns);
+        if (timed) {
+            r.observe(Metric::wait_elapsed_ns, elapsed(now, start));
+            r.observe(Metric::wait_lateness_ns, elapsed(now, deadline));
+            if (now < deadline) {
+                r.add(Count::early_wait_returns);
+            }
+        }
+    }
+};
+
+struct PollScope {
+    std::uint64_t packets = 0;
+    PollScope() noexcept
+    {
+        recorder().add(Count::connection_polls);
+    }
+    ~PollScope()
+    {
+        recorder().observe(Metric::data_per_poll, packets);
+    }
+};
+
+inline void sent(Time deadline, bool has_deadline, bool retransmitted) noexcept
+{
+    const auto now = Clock::now();
+    auto& r = recorder();
+    r.add(Count::data_packets);
+    r.add(
+        retransmitted ? Count::retransmitted_packets : Count::original_packets);
+    ++task_packets;
+    if (task_start != Time {}) {
+        r.observe(Metric::task_to_send_ns, elapsed(now, task_start));
+    }
+    if (has_deadline) {
+        r.observe(Metric::pacer_lateness_at_task_start_ns,
+            elapsed(task_start, deadline));
+        r.observe(Metric::pacer_remaining_at_task_start_ns,
+            elapsed(deadline, task_start));
+        r.observe(Metric::pacer_send_lateness_ns, elapsed(now, deadline));
+        r.observe(Metric::pacer_send_earliness_ns, elapsed(deadline, now));
+    } else {
+        r.add(Count::data_without_pacer_deadline);
+    }
+}
+} // namespace robotweax::srt::deadline_diagnostics
+
+#define RWX_DD_COUNT(name)                                                     \
+    ::robotweax::srt::deadline_diagnostics::recorder().add(                    \
+        ::robotweax::srt::deadline_diagnostics::Count::name)

--- a/benchmarks/pacer_deadline_diagnostics.py
+++ b/benchmarks/pacer_deadline_diagnostics.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Exact-pin timing overlay and strict, partial-aware worker histogram analysis."""
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import re
+import subprocess
+import zipfile
+from pathlib import Path
+
+import scalability_scorecard as sc
+
+ROOT = Path(__file__).resolve().parents[1]
+REVISIONS = ("8e1bdebed836cb7b732db852f51ef6a7b212e925", "11814d3a1ebc217dbe95613b679960ac3152ff59")
+HEADER = ROOT / "benchmarks/diagnostics/pacer_deadline_diagnostics.hpp"
+_header = HEADER.read_text()
+COUNTERS = tuple(re.findall(r"X\((\w+)\)", _header.split("#define RWX_DD_COUNTERS(X)")[1].split("#define RWX_DD_HISTOGRAMS")[0]))
+METRICS = tuple(re.findall(r"X\((\w+)\)", _header.split("#define RWX_DD_HISTOGRAMS(X)")[1].split("// clang-format on")[0]))
+BOUNDS = (0, 1, 2, 4, 16, 64, 256, 1000, 2000, 5000, 10000, 20000, 50000, 100000, 250000, 500000, 1000000, 10000000)
+SOURCE_HASHES = {
+    "8e1bdebed836cb7b732db852f51ef6a7b212e925": {
+        "src/compat/runtime_scheduler.hpp": "4dfaaf4e47b6b33615ed7abd2013ba84e4f9aa046c9fb5a0022e66e4fcf70c70",
+        "src/compat/runtime_scheduler.cpp": "b5aa3a2bd0d20df0f792200a5b592b89c958c8fc327aa28d000276b245b713ad",
+        "src/compat/transport_runtime.cpp": "6522669e023052bf3e3ff2f6e3aa2542db8ef978d6b5f152bc9d2ce03cf13245",
+        "src/session.cpp": "7de437efae425a4bdf78c76d292f2bfe88f6e0ff735b7c4a32289310f2d99a78"
+    },
+    "11814d3a1ebc217dbe95613b679960ac3152ff59": {
+        "src/compat/runtime_scheduler.hpp": "4dfaaf4e47b6b33615ed7abd2013ba84e4f9aa046c9fb5a0022e66e4fcf70c70",
+        "src/compat/runtime_scheduler.cpp": "2f62ea1a09bb5960c05d17c8a37d894866a909fa5229d73973cdaef31afc7139",
+        "src/compat/transport_runtime.cpp": "50705ca278d650b319c7183e77805856c793160e889317011fd38baf6a7895fd",
+        "src/session.cpp": "7de437efae425a4bdf78c76d292f2bfe88f6e0ff735b7c4a32289310f2d99a78"
+    }
+}
+
+HOOKS = {
+    "src/compat/runtime_scheduler.hpp": [
+        ("        std::shared_ptr<void> context;\n", "        std::shared_ptr<void> context;\n"
+         "        std::chrono::steady_clock::time_point diagnostic_submitted {};\n"
+         "        std::chrono::steady_clock::time_point diagnostic_deadline {};\n"
+         "        bool diagnostic_timed = false;\n"),
+    ],
+    "src/compat/runtime_scheduler.cpp": [
+        ("        shard.entries[tail] = std::move(task);\n",
+         "        task.diagnostic_submitted = std::chrono::steady_clock::now();\n"
+         "        task.diagnostic_timed = false;\n        shard.entries[tail] = std::move(task);\n"),
+        ("        const std::size_t slot = shard.add_timer(std::move(task), deadline);\n",
+         "        task.diagnostic_submitted = std::chrono::steady_clock::now();\n"
+         "        task.diagnostic_deadline = deadline;\n        task.diagnostic_timed = true;\n"
+         "        const std::size_t slot = shard.add_timer(std::move(task), deadline);\n"),
+        ("void RuntimeScheduler::run(std::size_t shard_index) noexcept\n{\n",
+         "void RuntimeScheduler::run(std::size_t shard_index) noexcept\n{\n"
+         "    rwx_dd::recorder().start(shard_index, shards_.size());\n"),
+        ("                    shard.ready.wait(lock);\n",
+         "                    { rwx_dd::WaitScope diagnostic_wait; shard.ready.wait(lock); }\n"),
+        ("                shard.ready.wait_until(lock, deadline);\n",
+         "                { rwx_dd::WaitScope diagnostic_wait(deadline, true);\n"
+         "                  shard.ready.wait_until(lock, deadline); }\n"),
+        ("        task.function(task.context.get());\n",
+         "        { rwx_dd::TaskScope diagnostic_task(task.diagnostic_submitted,\n"
+         "              task.diagnostic_deadline, task.diagnostic_timed);\n"
+         "          task.function(task.context.get()); }\n"),
+    ],
+    "src/compat/transport_runtime.cpp": [
+        ("RuntimePollResult DatagramChannel::run_once() noexcept\n{\n",
+         "RuntimePollResult DatagramChannel::run_once() noexcept\n{\n    RWX_DD_COUNT(channel_polls);\n"),
+        ("        const UdpIoResult received = socket.receive_from(datagram);\n",
+         "        RWX_DD_COUNT(rx_attempts);\n        const UdpIoResult received = socket.receive_from(datagram);\n"),
+        ("        if (received.error == Error::would_block) {\n            break;\n",
+         "        if (received.error == Error::would_block) {\n            RWX_DD_COUNT(rx_eagain);\n            break;\n"),
+        ("        received_any = true;\n        const auto decoded = decode_packet(\n",
+         "        RWX_DD_COUNT(rx_datagrams);\n        received_any = true;\n        const auto decoded = decode_packet(\n"),
+        ("RuntimePollResult ConnectionRuntime::poll() noexcept\n{\n",
+         "RuntimePollResult ConnectionRuntime::poll() noexcept\n{\n    rwx_dd::PollScope diagnostic_poll;\n"),
+        ("                >= flow_window_packets_) {\n            break;\n",
+         "                >= flow_window_packets_) {\n            RWX_DD_COUNT(flow_block);\n            break;\n"),
+        ("            && !session_.has_pending_retransmission()) {\n            break;\n",
+         "            && !session_.has_pending_retransmission()) {\n            RWX_DD_COUNT(crypto_block);\n            break;\n"),
+        ("        const auto packet = session_.next_paced_data_packet(\n",
+         "        const auto diagnostic_target = pacer_.query(packet_time, 0U).next_ready_microseconds;\n"
+         "        const auto packet = session_.next_paced_data_packet(\n"),
+        ("        if (!send_data(*packet, packet_time)) {\n            return {};\n        }\n",
+         "        if (!send_data(*packet, packet_time)) {\n            return {};\n        }\n"
+         "        ++diagnostic_poll.packets;\n"
+         "        rwx_dd::sent(deadline_from_origin_microseconds(origin_, diagnostic_target),\n"
+         "            diagnostic_target != 0U, packet->header.retransmitted);\n"),
+    ],
+    "src/session.cpp": [
+        ("    if (!pacer.query(now_microseconds, flow_count).ready) {\n",
+         "    if (!pacer.query(now_microseconds, flow_count).ready) {\n        RWX_DD_COUNT(pacer_block);\n"),
+        ("    auto packet = send_buffer_.next_packet();\n    if (packet.has_value()) {\n",
+         "    auto packet = send_buffer_.next_packet();\n    if (!packet.has_value()) { RWX_DD_COUNT(selection_empty); }\n    if (packet.has_value()) {\n"),
+    ],
+}
+
+
+def instrument(source: str, hooks: list[tuple[str, str]]) -> str:
+    for old, new in hooks:
+        if source.count(old) != 1:
+            raise ValueError(f"missing/ambiguous diagnostic anchor: {old[:90]!r}")
+        source = source.replace(old, new)
+    return source
+
+
+def patched_sources(source: Path, revision: str) -> dict[str, tuple[bytes, bytes]]:
+    if revision not in REVISIONS:
+        raise ValueError("deadline overlay accepts only the two reviewed library pins")
+    result = {}
+    for relative, hooks in HOOKS.items():
+        original = subprocess.check_output(["git", "-C", str(source), "show", f"{revision}:{relative}"])
+        if hashlib.sha256(original).hexdigest() != SOURCE_HASHES[revision][relative]:
+            raise ValueError(f"source hash mismatch: {relative}")
+        changed = instrument(original.decode(), hooks)
+        if relative.endswith(".cpp"):
+            changed = '#include "diagnostics/pacer_deadline_diagnostics.hpp"\nnamespace rwx_dd = robotweax::srt::deadline_diagnostics;\n' + changed
+        result[relative] = (original, changed.encode())
+    return result
+
+
+def export_overlay(source: Path, revision: str, destination: Path) -> dict:
+    patches = patched_sources(source, revision)
+    raw = subprocess.check_output(["git", "-C", str(source), "archive", "--format=zip", revision])
+    destination.mkdir(parents=True, exist_ok=False)
+    with zipfile.ZipFile(io.BytesIO(raw)) as archive:
+        for member in archive.infolist():
+            if not (destination / member.filename).resolve().is_relative_to(destination.resolve()):
+                raise ValueError("unsafe source archive path")
+        archive.extractall(destination)
+    installed = destination / "src/diagnostics/pacer_deadline_diagnostics.hpp"
+    installed.parent.mkdir(parents=True, exist_ok=True)
+    installed.write_bytes(HEADER.read_bytes())
+    files = []
+    for relative, (original, changed) in patches.items():
+        path = destination / relative
+        if path.read_bytes() != original:
+            raise ValueError("export differs from reviewed source")
+        path.write_bytes(changed)
+        files.append({"path": relative, "original_sha256": hashlib.sha256(original).hexdigest(),
+                      "patched_sha256": hashlib.sha256(changed).hexdigest()})
+    return {"enabled": True, "source_revision": revision, "files": files,
+            "overlay_script": sc.program_identity(Path(__file__).resolve()),
+            "collector_header": sc.program_identity(HEADER),
+            "scope": "worker-local timing histograms; private Task metadata; 1s checkpoints; not plain capacity"}
+
+
+def integer(value) -> bool:
+    return type(value) is int and 0 <= value <= 2**64 - 1
+
+
+def validate_snapshot(row: dict) -> None:
+    if not isinstance(row, dict):
+        raise ValueError("snapshot is not an object")
+    if (row.get("schema") != 1 or row.get("event") != "snapshot"
+            or type(row.get("complete")) is not bool or not integer(row.get("elapsed_ns"))
+            or not integer(row.get("ordinal")) or not 1 <= row["ordinal"] <= 129
+            or row.get("overflow") is not False or row.get("checkpoint_limit") is not False):
+        raise ValueError("invalid/overflowed snapshot")
+    counts, hist = row.get("counters", {}), row.get("histograms", {})
+    if set(counts) != set(COUNTERS) or any(not integer(v) for v in counts.values()) or set(hist) != set(METRICS):
+        raise ValueError("missing/invalid counter or histogram")
+    for name, h in hist.items():
+        if (not isinstance(h, dict) or any(not integer(h.get(k)) for k in ("count", "sum", "max"))
+                or not isinstance(h.get("buckets"), list) or len(h["buckets"]) != len(BOUNDS) + 1
+                or any(not integer(v) for v in h["buckets"]) or sum(h["buckets"]) != h["count"]
+                or h["sum"] > h["count"] * h["max"] or h["max"] > h["sum"]):
+            raise ValueError(f"invalid histogram: {name}")
+        minimum = sum(n * (0 if i == 0 else BOUNDS[i - 1] + 1) for i, n in enumerate(h["buckets"]))
+        maximum = sum(n * (BOUNDS[i] if i < len(BOUNDS) else h["max"]) for i, n in enumerate(h["buckets"]))
+        if not minimum <= h["sum"] <= maximum:
+            raise ValueError(f"histogram sum outside bucket bounds: {name}")
+        if h["count"]:
+            last = max(i for i, n in enumerate(h["buckets"]) if n)
+            if not (0 if last == 0 else BOUNDS[last - 1] + 1) <= h["max"] <= (BOUNDS[last] if last < len(BOUNDS) else 2**64 - 1):
+                raise ValueError(f"histogram maximum outside populated bucket: {name}")
+    if counts["original_packets"] + counts["retransmitted_packets"] != counts["data_packets"]:
+        raise ValueError("DATA counter mismatch")
+    tasks = counts["ready_tasks"] + counts["timer_tasks"]
+    equalities = {"data_per_task": tasks, "task_elapsed_ns": tasks,
+                  "ready_queue_ns": counts["ready_tasks"], "timer_queue_ns": counts["timer_tasks"],
+                  "timer_dispatch_lateness_ns": counts["timer_tasks"],
+                  "timer_remaining_on_submit_ns": counts["timer_tasks"],
+                  "timer_overdue_on_submit_ns": counts["timer_tasks"],
+                  "data_per_poll": counts["connection_polls"], "task_to_send_ns": counts["data_packets"],
+                  "wait_requested_ns": counts["timed_wait_calls"],
+                  "wait_elapsed_ns": counts["timed_wait_returns"], "wait_lateness_ns": counts["timed_wait_returns"],
+                  "pacer_send_lateness_ns": counts["data_packets"] - counts["data_without_pacer_deadline"],
+                  "pacer_lateness_at_task_start_ns": counts["data_packets"] - counts["data_without_pacer_deadline"],
+                  "pacer_remaining_at_task_start_ns": counts["data_packets"] - counts["data_without_pacer_deadline"],
+                  "pacer_send_earliness_ns": counts["data_packets"] - counts["data_without_pacer_deadline"]}
+    if any(hist[k]["count"] != v for k, v in equalities.items()):
+        raise ValueError("counter/histogram coverage mismatch")
+    if hist["data_per_task"]["sum"] != counts["data_packets"] or hist["data_per_poll"]["sum"] != counts["data_packets"]:
+        raise ValueError("DATA activation coverage mismatch")
+    if counts["timed_wait_calls"] != counts["timed_wait_returns"] or counts["wait_calls"] != counts["wait_returns"]:
+        raise ValueError("unbalanced completed waits")
+    if counts["early_wait_returns"] > counts["timed_wait_returns"]:
+        raise ValueError("early wait count mismatch")
+
+
+def read_worker(path: Path) -> dict:
+    if path.stat().st_size > 2 * 1024**2:
+        raise ValueError("worker output exceeds diagnostic bound")
+    rows, errors = [], []
+    for line in path.read_text().splitlines():
+        try:
+            rows.append(json.loads(line))
+        except ValueError:
+            errors.append("malformed/truncated line")
+            break
+    if not rows or not isinstance(rows[0], dict):
+        raise ValueError("missing worker registration")
+    header = rows[0]
+    if (header.get("schema") != 1 or header.get("event") != "register"
+            or any(not integer(header.get(k)) for k in ("pid", "tid", "serial", "shard", "shards"))
+            or not 1 <= header["shards"] <= 64 or header["shard"] >= header["shards"]
+            or not header["pid"] or not header["tid"] or type(header.get("timer_slack_ns")) is not int
+            or header["timer_slack_ns"] < -1):
+        raise ValueError("invalid worker identity")
+    last = None
+    for row in rows[1:]:
+        try:
+            validate_snapshot(row)
+            if row["ordinal"] != (last["ordinal"] + 1 if last else 1):
+                raise ValueError("snapshot ordinal mismatch")
+            if last and (last["complete"] or row["elapsed_ns"] < last["elapsed_ns"]
+                         or any(row["counters"][k] < last["counters"][k] for k in COUNTERS)):
+                raise ValueError("nonmonotonic/extra snapshot")
+            if last and any(row["histograms"][k][field] < last["histograms"][k][field]
+                            for k in METRICS for field in ("count", "sum", "max")):
+                raise ValueError("nonmonotonic histogram")
+            if last and any(new < old for k in METRICS for new, old in
+                            zip(row["histograms"][k]["buckets"], last["histograms"][k]["buckets"])):
+                raise ValueError("nonmonotonic histogram bucket")
+            last = row
+        except (ValueError, TypeError, KeyError) as error:
+            errors.append(str(error))
+            break
+    if last is None or not last["complete"]:
+        errors.append("missing final worker snapshot; earlier checkpoint is partial")
+    return {"file": path.name, "identity": header, "last_snapshot": last,
+            "complete": not errors, "errors": errors}
+
+
+def aggregate_histograms(workers: list[dict]) -> dict:
+    result = {}
+    for name in METRICS:
+        values = [w["last_snapshot"]["histograms"][name] for w in workers if w["last_snapshot"]]
+        h = {"count": sum(v["count"] for v in values), "sum": sum(v["sum"] for v in values),
+             "max": max((v["max"] for v in values), default=0),
+             "buckets": [sum(v["buckets"][i] for v in values) for i in range(len(BOUNDS) + 1)]}
+        h["mean"] = h["sum"] / h["count"] if h["count"] else None
+        h["unit"] = "packets" if name.startswith("data_per_") else "nanoseconds"
+        h["quantile_intervals"] = {}
+        for percent in (50, 95, 99):
+            interval, cumulative = None, 0
+            for i, n in enumerate(h["buckets"]):
+                cumulative += n
+                if h["count"] and cumulative * 100 >= h["count"] * percent:
+                    interval = [0 if i == 0 else BOUNDS[i - 1] + 1, BOUNDS[i] if i < len(BOUNDS) else None]
+                    break
+            h["quantile_intervals"][str(percent)] = interval
+        result[name] = h
+    return result
+
+
+def analyze_case(directory: Path, result: dict) -> dict:
+    workers, errors = [], []
+    for path in sorted((directory / "pacer-deadline").glob("*.jsonl")):
+        try:
+            workers.append(read_worker(path))
+        except (ValueError, TypeError, KeyError, OSError) as error:
+            errors.append(f"{path.name}: {error}")
+    if not workers:
+        errors.append("no registered scheduler workers")
+    identities = [(w["identity"]["pid"], w["identity"]["tid"], w["identity"]["serial"]) for w in workers]
+    if len(identities) != len(set(identities)):
+        errors.append("duplicate worker identity")
+    errors += [f"{w['file']}: {error}" for w in workers for error in w["errors"]]
+    endpoints = {}
+    expected_pids = set()
+    for role in ("sender", "receiver"):
+        if result.get(f"{role}_implementation") != "robotweax":
+            continue
+        pid = (result.get("peer_process_resources", {}).get(role) or {}).get("pid")
+        if not integer(pid) or pid == 0:
+            errors.append(f"missing {role} PID; retain partial worker data without attribution")
+            continue
+        expected_pids.add(pid)
+        own = [w for w in workers if w["identity"]["pid"] == pid]
+        if not own:
+            errors.append(f"no workers for {role} PID {pid}")
+        elif (len({w["identity"]["shards"] for w in own}) != 1
+              or len(own) != own[0]["identity"]["shards"]
+              or {w["identity"]["shard"] for w in own} != set(range(own[0]["identity"]["shards"]))):
+            errors.append(f"missing/duplicate shard coverage for {role}")
+        totals = {k: sum(w["last_snapshot"]["counters"][k] for w in own if w["last_snapshot"]) for k in COUNTERS}
+        originals = totals["original_packets"]
+        endpoints[role] = {"pid": pid, "workers": len(own), "totals": totals,
+                           "per_original": {k: v / originals if originals else None for k, v in totals.items()},
+                           "histograms": aggregate_histograms(own)}
+        if role == "sender":
+            wire = result.get("wire_statistics", {})
+            if (not integer(wire.get("sender_packets_unique")) or not wire["sender_packets_unique"]
+                    or not integer(wire.get("retransmitted_packets"))
+                    or totals["original_packets"] != wire.get("sender_packets_unique")
+                    or totals["retransmitted_packets"] != wire.get("retransmitted_packets")):
+                errors.append("sender diagnostic/public packet coverage mismatch")
+    if not expected_pids:
+        errors.append("missing completed endpoint identities; diagnostics remain partial")
+    elif {w["identity"]["pid"] for w in workers} != expected_pids:
+        errors.append("unexpected/missing Robotweax process")
+    return {"valid": not errors, "errors": errors, "workers": workers, "endpoints": endpoints,
+            "histogram_inclusive_bounds": list(BOUNDS), "last_bucket_unbounded": True,
+            "snapshot_scope": "whole worker lifetime through last recorded callback; partial != completion",
+            "timing_scope": "send timestamp is after successful send_data return; includes send bookkeeping",
+            "instrumented_rates_are_not_plain_capacity": True}

--- a/benchmarks/prepare_throughput.py
+++ b/benchmarks/prepare_throughput.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import scalability_scorecard as sc
 import retransmission_trace as rt
+import pacer_deadline_diagnostics as dd
 
 REFERENCE_REVISION = "899348d8318eb9a3c5a5b6ec43c4a1114288773a"
 ROOT = Path(__file__).resolve().parents[1]
@@ -46,10 +47,14 @@ def main(argv: list[str] | None = None) -> int:
                         help="development smoke only, recorded in manifest")
     parser.add_argument("--transport-trace", action="store_true",
                         help="instrument a fresh committed-source export; never a capacity result")
+    parser.add_argument("--pacer-deadline-diagnostics", action="store_true",
+                        help="exact-pin scheduler/Pacer timing overlay; never plain capacity")
     args = parser.parse_args(argv)
     if platform.system() not in ("Linux", "Darwin"):
         parser.error("this diagnostic builder currently supports Linux and macOS")
-    if args.transport_trace and args.allow_dirty_robotweax:
+    if args.transport_trace and args.pacer_deadline_diagnostics:
+        parser.error("diagnostic overlays cannot be combined")
+    if (args.transport_trace or args.pacer_deadline_diagnostics) and args.allow_dirty_robotweax:
         parser.error("transport overlay requires a clean committed Robotweax source")
     compiler = shutil.which(args.cxx)
     if not compiler:
@@ -86,6 +91,11 @@ def main(argv: list[str] | None = None) -> int:
         if args.transport_trace:
             exported = out / "robotweax-traced-source"
             manifest["transport_trace"] = rt.export_overlay(
+                sources["robotweax"], identities["robotweax"]["revision"], exported)
+            sources["robotweax"] = exported
+        if args.pacer_deadline_diagnostics:
+            exported = out / "robotweax-deadline-source"
+            manifest["pacer_deadline_diagnostics"] = dd.export_overlay(
                 sources["robotweax"], identities["robotweax"]["revision"], exported)
             sources["robotweax"] = exported
         run([compiler, "--version"], "compiler")

--- a/benchmarks/run_pacer_deadline_ab.py
+++ b/benchmarks/run_pacer_deadline_ab.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Pinned plain ABBA for the absolute pacer-deadline candidate.
+
+72 serial 1-GiB transfers on the original Linux ARM64 VM. No retries,
+sysctl changes, instrumentation or automatic performance approval.
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import platform
+import signal
+import socket
+import statistics
+from pathlib import Path
+
+import run_plain_capacity_ab as common
+
+build, sc, diag = common.build, common.sc, common.diag
+REVISIONS = {
+    "baseline": "8e1bdebed836cb7b732db852f51ef6a7b212e925",
+    "candidate": "11814d3a1ebc217dbe95613b679960ac3152ff59",
+}
+PROFILES = ["robotweax-self", "haivision-self", "robotweax-to-haivision", "haivision-to-robotweax"]
+ARGUMENTS = {**common.ARGUMENTS, "bytes_per_connection": 1024**3}
+
+
+def cases() -> list[dict]:
+    return diag.case_plan(PROFILES, ARGUMENTS["repetitions"], ARGUMENTS["warmups"], True, "none")
+
+
+def analyze_block(report: dict, manifest: dict, exit_code: int, *, arguments: dict = ARGUMENTS,
+                  profiles: list = PROFILES, capture: str = "none") -> dict:
+    analysis = common.analyze_block(report, manifest, exit_code, arguments=arguments, profiles=profiles, capture=capture)
+    for row, entry in zip(analysis["cases"], report.get("runs", [])):
+        resources = entry.get("result", {}).get("peer_process_resources", {})
+        row["peer_process_resources"] = resources
+        for role in ("sender", "receiver"):
+            own = resources.get(role) or {}
+            valid = common.number(own.get("pid"), integer=True, positive=True) and all(
+                common.number(own.get(k), integer=True) for k in
+                ("user_cpu_us", "system_cpu_us", "voluntary_context_switches", "involuntary_context_switches"))
+            if not valid:
+                error = f"missing/invalid {role} CPU, PID or context-switch evidence"
+                row["errors"].append(error)
+                analysis["errors"].append(f"case {row['index']}: {error}")
+            seconds = (own["user_cpu_us"] + own["system_cpu_us"]) / 1e6 if valid else None
+            row[f"{role}_cpu_seconds"] = seconds
+            byte_count = entry.get("result", {}).get("bytes_per_connection")
+            row[f"{role}_cpu_seconds_per_gib"] = (
+                seconds * 1024**3 / byte_count
+                if seconds is not None and common.number(byte_count, integer=True, positive=True) else None)
+    for summary in analysis["summary"]:
+        selected = [row for row in analysis["cases"]
+                    if row["kind"] == "measurement" and row["profile"] == summary["profile"]]
+        summary["evidence_passes"] = sum(not row["errors"] for row in selected)
+        for metric in ("sender_cpu_seconds", "receiver_cpu_seconds",
+                       "sender_cpu_seconds_per_gib", "receiver_cpu_seconds_per_gib"):
+            values = [row[metric] for row in selected if row["transfer_pass"] and row.get(metric) is not None]
+            summary[metric] = {"samples": len(values), "median": statistics.median(values) if values else None,
+                               "mean": statistics.mean(values) if values else None,
+                               "p95": sc.percentile(values, .95) if values else None}
+    analysis["measurement_contract_pass"] = not analysis["errors"]
+    return analysis
+
+
+def run_blocks(paths: dict, manifests: dict, out: Path, report: dict) -> int:
+    out.mkdir(parents=True, exist_ok=False)
+    report.update(complete=False, interrupted=False, plan=common.plan(), blocks=[],
+                  performance_decision_requires_review=True)
+    watched = [getattr(signal, name) for name in ("SIGINT", "SIGTERM", "SIGHUP") if hasattr(signal, name)]
+    previous = {sig: signal.getsignal(sig) for sig in watched}
+
+    def interrupt(signum, _frame):
+        # Let run_bounded terminate and reap its tracked case group. Repeated
+        # signals must not interrupt that cleanup or the report's finally path.
+        for sig in watched:
+            signal.signal(sig, signal.SIG_IGN)
+        report["interruption_signal"] = signum
+        raise KeyboardInterrupt
+
+    for sig in watched:
+        signal.signal(sig, interrupt)
+    try:
+        for index, variant in enumerate(common.plan()):
+            name = f"{index:02}-{variant}-plain"
+            arguments = ["--build-manifest", str(paths[variant]), "--output-directory", str(out / name)]
+            for key, value in ARGUMENTS.items():
+                arguments += ["--" + key.replace("_", "-"), str(value)]
+            for profile in PROFILES:
+                arguments += ["--profile", profile]
+            block = {"name": name, "variant": variant, "driver_arguments": arguments, "exit_code": None}
+            report["blocks"].append(block)
+            sc.write_report(out / "ab-report.json", report)
+            # Run in this process: diag.run_bounded owns the single nested case
+            # session and its peers. An extra block subprocess would obscure
+            # those groups from the outer operator during interruption.
+            with (out / f"{name}.log").open("x") as log:
+                try:
+                    with contextlib.redirect_stdout(log), contextlib.redirect_stderr(log):
+                        block["exit_code"] = diag.main(arguments)
+                except SystemExit as error:
+                    block["exit_code"] = error.code if type(error.code) is int else 1
+                except Exception as error:
+                    block["exit_code"] = 1
+                    block["error"] = repr(error)
+            try:
+                diagnostic = json.loads((out / name / "report.json").read_text())
+                block["analysis"] = analyze_block(diagnostic, manifests[variant], block["exit_code"])
+            except (OSError, ValueError, KeyError, TypeError, OverflowError) as error:
+                block["analysis"] = {"measurement_contract_pass": False, "errors": [f"unusable report: {error}"]}
+            print(json.dumps({"name": name, "exit_code": block["exit_code"],
+                              "measurement_contract_pass": block["analysis"]["measurement_contract_pass"]}), flush=True)
+            sc.write_report(out / "ab-report.json", report)
+        report["complete"] = True
+        report["measurement_contract_pass"] = all(b["analysis"]["measurement_contract_pass"] for b in report["blocks"])
+        return 0 if report["measurement_contract_pass"] else 1
+    except KeyboardInterrupt:
+        report["interrupted"] = True
+        code = 128 + report.get("interruption_signal", signal.SIGINT)
+        report["interruption_exit_code"] = code
+        if report["blocks"] and report["blocks"][-1]["exit_code"] is None:
+            report["blocks"][-1]["exit_code"] = code
+        return code
+    finally:
+        try:
+            sc.write_report(out / "ab-report.json", report)
+        finally:
+            for sig, handler in previous.items():
+                signal.signal(sig, handler)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    for variant in REVISIONS:
+        parser.add_argument(f"--{variant}-plain", type=Path, required=True)
+    parser.add_argument("--output-directory", type=Path, required=True)
+    args = parser.parse_args(argv)
+    if (platform.system() != "Linux" or platform.machine() not in ("aarch64", "arm64")
+            or socket.gethostname() != "lima-srt-network-lab-runtime"):
+        parser.error("use the original dedicated srt-network-lab-runtime Linux ARM64 VM")
+    environment = diag.host_metadata()
+    if environment["cpu_count"] != 4:
+        parser.error("retain the original four-vCPU configuration")
+    paths = {variant: getattr(args, f"{variant}_plain").resolve() for variant in REVISIONS}
+    manifests = {variant: json.loads(path.read_text()) for variant, path in paths.items()}
+    harness = build.source_identity(Path(__file__).resolve().parents[1])
+    common.validate_manifests(manifests, harness, environment, revisions=REVISIONS)
+    signatures = common.validate_build_files(paths, manifests)
+    if any(int(environment["sysctls"].get(f"net/core/{key}_max") or 0) < ARGUMENTS["udp_buffer"] for key in ("rmem", "wmem")):
+        parser.error("operator must record/configure/restore UDP maxima of at least 8 MiB")
+    report = {"schema_version": 1, "environment": environment, "manifests": manifests,
+              "toolchain_signatures": signatures, "harness_checkout": harness,
+              "harness_files": [sc.program_identity(Path(m.__file__).resolve()) for m in (common, diag, sc, build)],
+              "runner": sc.program_identity(Path(__file__).resolve()),
+              "scope": "plain IPv4 loopback; one connection; library pins distinct from the common harness pin"}
+    return run_blocks(paths, manifests, args.output_directory.resolve(), report)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/run_pacer_deadline_diagnostics.py
+++ b/benchmarks/run_pacer_deadline_diagnostics.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Forty fixed 16-MiB transfers: plain brackets and separate deadline diagnosis."""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import copy
+import json
+import platform
+import signal
+import socket
+from pathlib import Path
+
+import pacer_deadline_diagnostics as dd
+import run_pacer_deadline_ab as previous
+
+common, diag, sc, build = previous.common, previous.diag, previous.sc, previous.build
+REVISIONS = previous.REVISIONS
+PROFILES = ["robotweax-self", "robotweax-to-haivision"]
+ARGUMENTS = {**common.ARGUMENTS, "bytes_per_connection": 16 * 1024**2, "warmups": 0}
+
+
+def plan() -> list[dict]:
+    return [{"variant": variant, "capture": capture, "repetitions": repetitions}
+            for variant, capture, repetitions in
+            (("baseline", "none", 3), ("candidate", "none", 3),
+             ("baseline", "pacer", 2), ("candidate", "pacer", 2),
+             ("candidate", "none", 3), ("baseline", "none", 3))]
+
+
+def key(variant: str, capture: str) -> str:
+    return f"{variant}-{'plain' if capture == 'none' else 'diagnostic'}"
+
+
+def block_arguments(spec: dict) -> dict:
+    return {**ARGUMENTS, "capture": spec["capture"], "repetitions": spec["repetitions"]}
+
+
+def validate_manifests(manifests: dict, harness: dict, environment: dict) -> None:
+    if set(manifests) != {key(v, c) for v in REVISIONS for c in ("none", "pacer")}:
+        raise ValueError("exactly four fresh builds are required")
+    for capture in ("none", "pacer"):
+        normalized = {}
+        for variant, revision in REVISIONS.items():
+            m = manifests[key(variant, capture)]
+            overlay = m.get("pacer_deadline_diagnostics", {})
+            if overlay.get("enabled", False) is not (capture == "pacer"):
+                raise ValueError("plain/diagnostic build mismatch")
+            if capture == "pacer":
+                expected = dd.patched_sources(Path(m["sources"]["robotweax"]["path"]), revision)
+                files = [{"path": name, "original_sha256": dd.hashlib.sha256(raw).hexdigest(),
+                          "patched_sha256": dd.hashlib.sha256(patched).hexdigest()}
+                         for name, (raw, patched) in expected.items()]
+                if (overlay.get("source_revision") != revision or overlay.get("files") != files
+                        or overlay.get("overlay_script", {}).get("sha256") != sc.file_sha256(Path(dd.__file__))
+                        or overlay.get("collector_header", {}).get("sha256") != sc.file_sha256(dd.HEADER)):
+                    raise ValueError("diagnostic source/anchor/header identity mismatch")
+            normalized[variant] = copy.deepcopy(m)
+            normalized[variant].pop("pacer_deadline_diagnostics", None)
+        common.validate_manifests(normalized, harness, environment, revisions=REVISIONS)
+
+
+def analyze_block(report: dict, manifest: dict, exit_code: int, spec: dict) -> dict:
+    result = previous.analyze_block(report, manifest, exit_code,
+                                    arguments=block_arguments(spec), profiles=PROFILES, capture=spec["capture"])
+    if spec["capture"] == "pacer":
+        for row, case in zip(result["cases"], report.get("runs", [])):
+            row["profiling"] = case.get("profiling")
+            if (case.get("profiling") or {}).get("valid") is not True:
+                error = "missing/incomplete deadline diagnosis; preserve partial checkpoints"
+                row["errors"].append(error)
+                result["errors"].append(f"case {row['index']}: {error}")
+        result["summary"] = []  # Diagnostic rates remain per-case, never in plain aggregates.
+    result["measurement_contract_pass"] = not result["errors"]
+    return result
+
+
+def run_blocks(paths: dict, manifests: dict, out: Path, report: dict) -> int:
+    out.mkdir(parents=True, exist_ok=False)
+    report.update(complete=False, interrupted=False, plan=plan(), blocks=[],
+                  scope="16-MiB mechanism diagnosis, not a replacement/retry of the 1-GiB experiment")
+    watched = [getattr(signal, n) for n in ("SIGINT", "SIGTERM", "SIGHUP") if hasattr(signal, n)]
+    saved = {sig: signal.getsignal(sig) for sig in watched}
+
+    def interrupt(signum, _frame):
+        for sig in watched:
+            signal.signal(sig, signal.SIG_IGN)
+        report["interruption_signal"] = signum
+        raise KeyboardInterrupt
+
+    for sig in watched:
+        signal.signal(sig, interrupt)
+    try:
+        for index, spec in enumerate(plan()):
+            own = key(spec["variant"], spec["capture"])
+            name = f"{index:02}-{own}"
+            args = ["--build-manifest", str(paths[own]), "--output-directory", str(out / name)]
+            for option, value in block_arguments(spec).items():
+                args += ["--" + option.replace("_", "-"), str(value)]
+            for profile in PROFILES:
+                args += ["--profile", profile]
+            block = {"name": name, **spec, "driver_arguments": args, "exit_code": None}
+            report["blocks"].append(block)
+            sc.write_report(out / "diagnostic-report.json", report)
+            with (out / f"{name}.log").open("x") as log:
+                try:
+                    with contextlib.redirect_stdout(log), contextlib.redirect_stderr(log):
+                        block["exit_code"] = diag.main(args)
+                except SystemExit as error:
+                    block["exit_code"] = error.code if type(error.code) is int else 1
+                except Exception as error:
+                    block["exit_code"] = 1
+                    block["error"] = repr(error)
+            try:
+                raw = json.loads((out / name / "report.json").read_text())
+                block["analysis"] = analyze_block(raw, manifests[own], block["exit_code"], spec)
+            except (OSError, ValueError, TypeError, KeyError, OverflowError) as error:
+                block["analysis"] = {"measurement_contract_pass": False, "errors": [f"unusable report: {error}"]}
+            print(json.dumps({"name": name, "exit_code": block["exit_code"],
+                              "measurement_contract_pass": block["analysis"]["measurement_contract_pass"]}), flush=True)
+            sc.write_report(out / "diagnostic-report.json", report)
+        report["complete"] = True
+        report["measurement_contract_pass"] = all(b["analysis"]["measurement_contract_pass"] for b in report["blocks"])
+        return 0 if report["measurement_contract_pass"] else 1
+    except KeyboardInterrupt:
+        report["interrupted"] = True
+        code = 128 + report.get("interruption_signal", signal.SIGINT)
+        report["interruption_exit_code"] = code
+        if report["blocks"] and report["blocks"][-1]["exit_code"] is None:
+            report["blocks"][-1]["exit_code"] = code
+        return code
+    finally:
+        try:
+            sc.write_report(out / "diagnostic-report.json", report)
+        finally:
+            for sig, handler in saved.items():
+                signal.signal(sig, handler)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    for variant in REVISIONS:
+        for capture in ("none", "pacer"):
+            parser.add_argument("--" + key(variant, capture), required=True, type=Path)
+    parser.add_argument("--output-directory", required=True, type=Path)
+    args = parser.parse_args(argv)
+    if (platform.system() != "Linux" or platform.machine() not in ("arm64", "aarch64")
+            or socket.gethostname() != "lima-srt-network-lab-runtime"):
+        parser.error("use the original dedicated srt-network-lab-runtime Linux ARM64 VM")
+    environment = diag.host_metadata()
+    if environment["cpu_count"] != 4:
+        parser.error("retain the original four-vCPU configuration")
+    paths = {key(v, c): getattr(args, key(v, c).replace("-", "_")).resolve() for v in REVISIONS for c in ("none", "pacer")}
+    manifests = {name: json.loads(path.read_text()) for name, path in paths.items()}
+    harness = build.source_identity(Path(__file__).resolve().parents[1])
+    validate_manifests(manifests, harness, environment)
+    signatures = {}
+    for capture in ("none", "pacer"):
+        signatures[capture] = common.validate_build_files(
+            {v: paths[key(v, capture)] for v in REVISIONS}, {v: manifests[key(v, capture)] for v in REVISIONS})
+    if signatures["none"] != signatures["pacer"]:
+        parser.error("plain and diagnostic compiler/OpenSSL configuration differs")
+    if any(int(environment["sysctls"].get(f"net/core/{n}_max") or 0) < ARGUMENTS["udp_buffer"] for n in ("rmem", "wmem")):
+        parser.error("operator must record/configure/restore UDP maxima of at least 8 MiB")
+    report = {"schema_version": 1, "environment": environment, "harness_checkout": harness,
+              "manifests": manifests, "toolchain_signatures": signatures,
+              "harness_files": [sc.program_identity(Path(m.__file__)) for m in (dd, previous, common, diag, sc, build)],
+              "runner": sc.program_identity(Path(__file__)), "collector_header": sc.program_identity(dd.HEADER)}
+    return run_blocks(paths, manifests, args.output_directory.resolve(), report)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/run_pacer_deadline_operator.py
+++ b/benchmarks/run_pacer_deadline_operator.py
@@ -1,0 +1,67 @@
+"""Outer operator: forward interruptions to the owning runner; restore UDP independently."""
+from pathlib import Path
+import argparse,json,subprocess,signal,time,os
+KEYS=['net.core.rmem_max','net.core.wmem_max']
+SECURITY=['kernel.perf_event_paranoid','kernel.kptr_restrict']
+def main():
+ p=argparse.ArgumentParser();p.add_argument('--output-directory',type=Path,required=True);p.add_argument('command',nargs=argparse.REMAINDER);args=p.parse_args()
+ command=args.command[1:] if args.command[:1]==['--'] else args.command
+ assert command
+ root=args.output_directory;root.mkdir(exist_ok=False)
+ child=None;pending=None;status=1
+ e={'started_ns':time.time_ns(),'command':command,'runner_exit_code':None,'interruption_signal':None,'restoration':[],'uid':os.getuid()}
+ def save():
+  tmp=root/'execution.json.tmp';tmp.write_text(json.dumps(e,indent=2)+'\n');tmp.replace(root/'execution.json')
+ def values(keys):return {k:subprocess.check_output(['sysctl','-n',k],text=True).strip() for k in keys}
+ original=values(KEYS);e['original_sysctls']=original;e['security_before']=values(SECURITY);save()
+ watched=[signal.SIGINT,signal.SIGTERM,signal.SIGHUP]
+ def interrupted(sig,frame):
+  nonlocal pending
+  if pending is not None:return
+  pending=sig;e['interruption_signal']=sig
+  # The pinned runner owns the case session; it cleans/reaps that group.
+  if child is not None:
+   try:child.send_signal(sig)
+   except ProcessLookupError:pass
+ for sig in watched:signal.signal(sig,interrupted)
+ try:
+  for k in KEYS:
+   if pending is not None:break
+   subprocess.run(['sudo','-n','sysctl','-w',k+'=33554432'],check=True,capture_output=True,text=True)
+  e['measurement_sysctls']=values(KEYS)
+  if pending is None:
+   e['processes_before']=subprocess.check_output(['ps','-eo','pid,comm,pcpu,args','--sort=-pcpu'],text=True);save()
+   # Block delivery across Popen and assignment, then deliver pending signals.
+   previous=signal.pthread_sigmask(signal.SIG_BLOCK,watched)
+   try:
+    with (root/'runner.stdout').open('x') as out,(root/'runner.stderr').open('x') as err:
+     child=subprocess.Popen(command,stdout=out,stderr=err,start_new_session=True,preexec_fn=lambda:signal.pthread_sigmask(signal.SIG_SETMASK,previous))
+     signal.pthread_sigmask(signal.SIG_SETMASK,previous)
+     if pending is not None:
+      try:child.send_signal(pending)
+      except ProcessLookupError:pass
+     e['runner_pid']=child.pid
+     status=child.wait();e['runner_exit_code']=status
+   finally:signal.pthread_sigmask(signal.SIG_SETMASK,previous)
+  else:status=128+pending
+ except BaseException as error:
+  e['operator_error']=repr(error)
+  if child is not None and child.poll() is None:
+   child.send_signal(signal.SIGINT);status=child.wait();e['runner_exit_code']=status
+  else:status=1
+ finally:
+  for sig in watched:signal.signal(sig,signal.SIG_IGN)
+  for k,v in original.items():
+   try:
+    r=subprocess.run(['sudo','-n','sysctl','-w',k+'='+v],capture_output=True,text=True)
+    e['restoration'].append({'key':k,'exit_code':r.returncode,'stdout':r.stdout,'stderr':r.stderr})
+   except BaseException as error:e['restoration'].append({'key':k,'error':repr(error)})
+  try:
+   e['restored_sysctls']=values(KEYS);e['security_after']=values(SECURITY)
+   e['cleanup_pass']=e['restored_sysctls']==original and e['security_after']==e['security_before'] and all(x.get('exit_code')==0 for x in e['restoration'])
+  except BaseException as error:e['cleanup_pass']=False;e['cleanup_error']=repr(error)
+  # Preserve a nonzero original runner result even if cleanup also fails.
+  if status==0 and not e['cleanup_pass']:status=1
+  e['operator_exit_code']=status;e['finished_ns']=time.time_ns();save()
+ return status
+if __name__=='__main__':raise SystemExit(main())

--- a/benchmarks/run_plain_capacity_ab.py
+++ b/benchmarks/run_plain_capacity_ab.py
@@ -42,20 +42,23 @@ def cases() -> list[dict]:
     return diag.case_plan(PROFILES, 3, 1, True, "none")
 
 
-def validate_manifests(manifests: dict, harness: dict, environment: dict) -> None:
-    if set(manifests) != set(REVISIONS):
+def validate_manifests(manifests: dict, harness: dict, environment: dict,
+                       *, revisions: dict = REVISIONS) -> None:
+    if set(manifests) != set(revisions):
         raise ValueError("exactly two plain build manifests are required")
     if harness.get("dirty") is not False:
         raise ValueError("run from a clean committed harness checkout")
     for variant, manifest in manifests.items():
         if manifest.get("complete") is not True:
             raise ValueError("incomplete build")
-        for library, revision in (("robotweax", REVISIONS[variant]),
+        for library, revision in (("robotweax", revisions[variant]),
                                   ("haivision", build.REFERENCE_REVISION)):
             source = manifest["sources"][library]
             if source.get("dirty") is not False or source.get("revision") != revision:
                 raise ValueError(f"unexpected/dirty {variant} {library} source")
-        if manifest.get("transport_trace", {}).get("enabled", False) is not False:
+        if (manifest.get("transport_trace", {}).get("enabled", False) is not False
+                or manifest.get("poll_counters", {}).get("enabled", False) is not False
+                or manifest.get("pacer_deadline_diagnostics", {}).get("enabled", False) is not False):
             raise ValueError("instrumented builds cannot produce plain capacity evidence")
         if manifest.get("crypto") != "openssl" or manifest.get("linkage") != "static":
             raise ValueError("this follow-up requires the original static OpenSSL build profile")
@@ -105,27 +108,29 @@ def number(value, *, integer: bool = False, positive: bool = False) -> bool:
             and math.isfinite(value) and value >= (1 if positive else 0))
 
 
-def analyze_block(report: dict, manifest: dict, exit_code: int) -> dict:
+def analyze_block(report: dict, manifest: dict, exit_code: int,
+                  *, arguments: dict = ARGUMENTS, profiles: list = PROFILES, capture: str = "none") -> dict:
     """Missing/partial evidence is a failure, never an inferred zero count."""
     errors, rows = [], []
+    expected_cases = diag.case_plan(profiles, arguments["repetitions"], arguments["warmups"], True, capture)
     if exit_code != 0 or report.get("finished") is not True or report.get("all_transfers_pass") is not True:
         errors.append("diagnostic block did not finish successfully")
-    if report.get("capture") != "none" or report.get("udp_capacity_controlled") is not True:
-        errors.append("not an uninstrumented UDP-capacity-controlled block")
-    arguments = report.get("arguments", {})
-    if (any(arguments.get(key) != value for key, value in ARGUMENTS.items())
-            or arguments.get("profile") != PROFILES
-            or arguments.get("allow_small_udp_buffers") is not False):
+    if report.get("capture") != capture or report.get("udp_capacity_controlled") is not True:
+        errors.append("capture or UDP-capacity-control contract mismatch")
+    observed_arguments = report.get("arguments", {})
+    if (any(observed_arguments.get(key) != value for key, value in arguments.items())
+            or observed_arguments.get("profile") != profiles
+            or observed_arguments.get("allow_small_udp_buffers") is not False):
         errors.append("measurement arguments changed")
     if report.get("build_manifest") != manifest:
         errors.append("reported build differs from preflight manifest")
     runs = report.get("runs", [])
-    if len(runs) != len(cases()):
+    if len(runs) != len(expected_cases):
         errors.append("missing or extra transfers")
-    packets = math.ceil(ARGUMENTS["bytes_per_connection"] / 1316)
+    packets = math.ceil(arguments["bytes_per_connection"] / 1316)
     for index, entry in enumerate(runs):
         problems = []
-        if index >= len(cases()) or any(entry.get(key) != value for key, value in cases()[index].items()):
+        if index >= len(expected_cases) or any(entry.get(key) != value for key, value in expected_cases[index].items()):
             problems.append("unexpected case order/profile/kind")
         if entry.get("index") != index or entry.get("exit_code") != 0 or entry.get("transfer_pass") is not True:
             problems.append("failed/incomplete transfer")
@@ -134,7 +139,7 @@ def analyze_block(report: dict, manifest: dict, exit_code: int) -> dict:
         if (integrity.get("deterministic_payload_verified") is not True
                 or integrity.get("verified_connections") != 1
                 or result.get("connections") != 1 or result.get("message_size_bytes") != 1316
-                or result.get("requested_bytes_per_connection") != ARGUMENTS["bytes_per_connection"]
+                or result.get("requested_bytes_per_connection") != arguments["bytes_per_connection"]
                 or result.get("messages_per_connection") != packets
                 or result.get("bytes_per_connection") != packets * 1316):
             problems.append("payload/transfer contract not proven")
@@ -154,8 +159,8 @@ def analyze_block(report: dict, manifest: dict, exit_code: int) -> dict:
             options = result.get("capacity_options", {}).get(role, [])
             expected = {"encryption": "none", "tlpktdrop": False, "pending_packets": 8192,
                         "requested_maxbw_bytes_per_second": 1250000000, "target_bits_per_second": 0,
-                        "api_fc": 16384, "api_udp_rcvbuf": ARGUMENTS["udp_buffer"],
-                        "api_udp_sndbuf": ARGUMENTS["udp_buffer"]}
+                        "api_fc": 16384, "api_udp_rcvbuf": arguments["udp_buffer"],
+                        "api_udp_sndbuf": arguments["udp_buffer"]}
             if len(options) != 1 or any(options[0].get(key) != value for key, value in expected.items()):
                 problems.append(f"{role} capacity-option contract missing/changed")
         rate = result.get("rates", {}).get("useful_bits_per_second")
@@ -173,7 +178,7 @@ def analyze_block(report: dict, manifest: dict, exit_code: int) -> dict:
         rows.append(row)
         errors.extend(f"case {index}: {problem}" for problem in problems)
     summaries = []
-    for profile in PROFILES:
+    for profile in profiles:
         selected = [row for row in rows if row["kind"] == "measurement" and row["profile"] == profile]
         summary = {"profile": profile, "attempts": len(selected),
                    "transfer_successes": sum(row["transfer_pass"] for row in selected),

--- a/benchmarks/throughput_diagnostics.py
+++ b/benchmarks/throughput_diagnostics.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 import scalability_scorecard as sc
 import retransmission_trace as rt
+import pacer_deadline_diagnostics as dd
 
 try:
     import resource
@@ -90,7 +91,7 @@ def case_plan(profiles: list[str], repetitions: int, warmups: int,
 
 
 def perf_command(capture: str, data: Path, command: list[str], perf: str) -> list[str]:
-    if capture in ("none", "transport"):
+    if capture in ("none", "transport", "pacer"):
         return command
     if capture == "cpu":
         # Software clock works without a virtualized hardware PMU. DWARF avoids
@@ -153,6 +154,12 @@ def run_case(path: Path) -> int:
             os.environ["ROBOTWEAX_TRANSPORT_TRACE_DIR"] = str(trace_directory)
         else:
             os.environ.pop("ROBOTWEAX_TRANSPORT_TRACE_DIR", None)
+        if request.get("capture") == "pacer":
+            diagnostic_directory = directory / "pacer-deadline"
+            diagnostic_directory.mkdir(exist_ok=False)
+            os.environ["ROBOTWEAX_PACER_DEADLINE_DIR"] = str(diagnostic_directory)
+        else:
+            os.environ.pop("ROBOTWEAX_PACER_DEADLINE_DIR", None)
         result = sc.run_many_socket_profile(
             request["profile"], {k: Path(v) for k, v in request["programs"].items()},
             sc.RunOptions(**request["options"]), directory,
@@ -186,6 +193,13 @@ def run_case(path: Path) -> int:
         entry["error"] = str(error)
         return 1
     finally:
+        if request.get("capture") == "pacer":
+            # A timeout may still leave useful checkpoints. Preserve them even
+            # when no peer completion event/result exists; do not infer success.
+            try:
+                entry["profiling"] = dd.analyze_case(directory, entry.get("result", {}))
+            except Exception as error:
+                entry["profiling"] = {"valid": False, "errors": [str(error)]}
         after = udp_snapshot()
         entry["system_udp_delta"] = {k: after[k] - v for k, v in before.items() if k in after}
         entry["finished_unix_ns"] = time.time_ns()
@@ -262,7 +276,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--build-manifest", type=Path, required=True)
     parser.add_argument("--output-directory", type=Path, required=True)
     parser.add_argument("--profile", action="append", choices=PROFILES)
-    parser.add_argument("--capture", choices=("none", "cpu", "scheduler", "transport"), default="none")
+    parser.add_argument("--capture", choices=("none", "cpu", "scheduler", "transport", "pacer"), default="none")
     parser.add_argument("--repetitions", type=bounded_int(1, 10))
     parser.add_argument("--warmups", type=bounded_int(0, 2), default=1)
     parser.add_argument("--bytes-per-connection", type=bounded_int(1316, 1024**3), default=128 * 1024**2)
@@ -290,6 +304,8 @@ def main(argv: list[str] | None = None) -> int:
     traced_build = manifest.get("transport_trace", {}).get("enabled", False)
     if traced_build != (args.capture == "transport"):
         parser.error("transport capture requires an overlay build; overlay builds cannot produce plain/perf capacity results")
+    if manifest.get("pacer_deadline_diagnostics", {}).get("enabled", False) != (args.capture == "pacer"):
+        parser.error("pacer capture requires its overlay; that overlay cannot produce plain/perf results")
     if args.pacing_burst_packets and not args.target_bps:
         parser.error("bounded pacing requires a positive target rate")
     for identity in [*manifest["programs"].values(), *manifest["libraries"].values()]:
@@ -297,7 +313,7 @@ def main(argv: list[str] | None = None) -> int:
             parser.error("a peer or library changed since the recorded build")
     programs = {name: value["path"] for name, value in manifest["programs"].items()}
     profiles = args.profile or ["robotweax-self", "robotweax-to-haivision"]
-    if args.capture == "transport" and any(sc.PROFILE_IMPLEMENTATIONS[p][0] != "robotweax" for p in profiles):
+    if args.capture in ("transport", "pacer") and any(sc.PROFILE_IMPLEMENTATIONS[p][0] != "robotweax" for p in profiles):
         parser.error("transport attribution currently requires a Robotweax sender")
     if any("haivision" in sc.PROFILE_IMPLEMENTATIONS[p] for p in profiles) and "haivision" not in programs:
         parser.error("selected profile needs the reference peer")
@@ -317,7 +333,7 @@ def main(argv: list[str] | None = None) -> int:
               "started_unix_ns": time.time_ns()}
     report["harness_files"] = [sc.program_identity(path) for path in
                                (Path(__file__).resolve(), ROOT / "benchmarks/scalability_scorecard.py",
-                                ROOT / "benchmarks/retransmission_trace.py")]
+                                ROOT / "benchmarks/retransmission_trace.py", ROOT / "benchmarks/pacer_deadline_diagnostics.py")]
     sc.write_report(out / "report.json", report)
     options = sc.RunOptions("127.0.0.1", 1, args.bytes_per_connection, 1316,
                             args.timeout_seconds, 120, 500, .02)
@@ -339,6 +355,8 @@ def main(argv: list[str] | None = None) -> int:
                     entry.update(json.loads((directory / "case.json").read_text()))
                 else:
                     entry["error"] = "capture/driver exited without a case report; see command.log"
+                    if args.capture == "pacer":
+                        entry["profiling"] = dd.analyze_case(directory, {})
                 if args.capture in ("cpu", "scheduler"):
                     entry["profiling"] = render_capture(args.capture, directory, entry.get("result", {}), perf)
             except Exception as error:

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,8 @@ combining features.
 - [Protocol edge-case policy](protocol-edge-cases.md)
 - [Performance and scalability measurement](performance.md)
 - [Throughput profiling and empty-receive-buffer experiment](throughput-profiling.md)
+- [Absolute pacer-deadline experiment and its failed lab result](pacer-deadline-experiment.md)
+- [Pacer deadline, dispatch and send diagnosis](pacer-deadline-diagnostics.md)
 
 These pages document stable protocol behavior, resource contracts, and
 reproducible measurement methods. Internal implementation details that are not

--- a/docs/pacer-deadline-diagnostics.md
+++ b/docs/pacer-deadline-diagnostics.md
@@ -1,0 +1,191 @@
+# Pacer deadline, dispatch and send diagnosis
+
+Lab PR #29 rejected library candidate `11814d3`: every Robotweax-sender case
+timed out after receiving only 11–12% of its planned messages. The precise
+delay mechanism was not observed. This stage locates that delay; it does not
+change pacing, batching, flow control, fairness or public API behavior.
+
+The harness branch is based on baseline `8e1bdeb`. Its normal `src` and
+`include` trees are unchanged. Build instrumentation is applied only to fresh
+exports of the exact sources below. The failed candidate in SRT PR #34 and the
+counter overlay in PR #33 remain separate.
+
+## Exact identities and four builds
+
+| Role | Revision |
+|---|---|
+| A: Robotweax baseline | `8e1bdebed836cb7b732db852f51ef6a7b212e925` |
+| B: failed absolute-deadline candidate | `11814d3a1ebc217dbe95613b679960ac3152ff59` |
+| Haivision 1.5.7 in all builds | `899348d8318eb9a3c5a5b6ec43c4a1114288773a` |
+| Common harness | One clean committed checkout containing this document; record its full SHA separately |
+
+The unchanged common public-API peer SHA-256 is
+`faf487b34f5661e4dc602130628ed216b8054a2ab364abcc275bdda1d826d2ae`.
+Both pins have reviewed whole-file SHA-256 identities and unique replacement
+anchors in `pacer_deadline_diagnostics.py`. A wrong pin, changed source,
+missing anchor, changed collector or mixed overlay fails validation. The
+export records original/patched hashes for four private source files.
+
+Use the original dedicated Ubuntu ARM64 VM `srt-network-lab-runtime`, hostname
+`lima-srt-network-lab-runtime`, 4 vCPU and configured 6 GiB. Verify VM identity,
+memory, toolchain and absence of competing work. Build all four pairs before
+measuring, using the same clean harness. With `SRT`, `REFERENCE` and a new
+`WORK` directory set to their intended paths:
+
+```sh
+HARNESS=$(git -C "$SRT" rev-parse HEAD)
+git -C "$SRT" worktree add --detach "$WORK/baseline-source" \
+  8e1bdebed836cb7b732db852f51ef6a7b212e925 || exit 1
+git -C "$SRT" worktree add --detach "$WORK/candidate-source" \
+  11814d3a1ebc217dbe95613b679960ac3152ff59 || exit 1
+for variant in baseline candidate; do
+  python3 "$SRT/benchmarks/prepare_throughput.py" \
+    --robotweax-source "$WORK/$variant-source" --reference-source "$REFERENCE" \
+    --output-directory "$WORK/$variant-plain" --linkage static --jobs 2 || exit 1
+  python3 "$SRT/benchmarks/prepare_throughput.py" \
+    --robotweax-source "$WORK/$variant-source" --reference-source "$REFERENCE" \
+    --output-directory "$WORK/$variant-diagnostic" --linkage static --jobs 2 \
+    --pacer-deadline-diagnostics || exit 1
+done
+```
+
+Normal Release/OpenSSL/static builds, library `-O3 -DNDEBUG` plus `-g`, common
+peer `-O2 -g`. No cached builds, sanitizer, perf capture, alternate timer
+settings or extra overlay. Preserve source/host/build identities, flags,
+binary hashes and original command statuses. Stop on a build error.
+
+## Fixed 40-transfer plan
+
+Each transfer requests 16 MiB: 12749 messages of 1316 bytes, or 16777684
+actual payload bytes. One plain IPv4-loopback Live/Message connection,
+TSBPD 120 ms, TLPKTDROP off, Pending 8192, FC 16384, requested SRT buffers
+32 MiB and UDP buffers 8 MiB, MAXBW 1250000000 bytes/s, target 0, timeout
+45 s and shutdown 500 ms. No changes if a case is slow or fails.
+
+| Block | Library/build | Cases |
+|---|---|---:|
+| 00 | A plain | H self-control, 3 R→R, 3 R→H, H self-control |
+| 01 | B plain | H self-control, 3 R→R, 3 R→H, H self-control |
+| 02 | A diagnostic | 2 R→R, 2 R→H |
+| 03 | B diagnostic | 2 R→R, 2 R→H |
+| 04 | B plain | H self-control, 3 R→R, 3 R→H, H self-control |
+| 05 | A plain | H self-control, 3 R→R, 3 R→H, H self-control |
+
+**40 transfers = 24 plain measurements + 8 Haivision controls + 8 diagnostic
+cases.** Zero warmups; 30 seconds' cooldown before each block. These short
+plain brackets describe instrumentation disturbance and direction drift, not
+a replacement for the failed 1-GiB capacity experiment or a production CPU
+comparison. Keep each block/case visible; no combined plain/diagnostic rate
+summary. At this transfer size, startup effects can be substantial.
+
+## What the collector measures
+
+Every scheduler worker registers PID, TID, shard index/count and, on Linux,
+its current timer slack from a read-only query (`-1` means unavailable).
+There is no timer-slack or timer-resolution adjustment. Worker-local counters
+and fixed histograms measure:
+
+- Accepted submission to actual callback start, separated into ready/timed
+  tasks. Timer remaining/overdue time at submission covers dispatched tasks;
+  cancelled tasks have no dispatch sample.
+- Timed-wait requested duration, actual return duration and return lateness,
+  plus early returns. `condition_variable` return includes mutex reacquisition;
+  this does not isolate pure kernel sleep or count physical CPU wakeups.
+- Pacer deadline relative to the task start, and relative to the successful
+  DATA-send return, sampled for the same paced DATA packets. Initial packets
+  without a prior Pacer deadline have a separate counter.
+- Task start to DATA-send return, callback duration, DATA per callback and
+  connection poll, receive attempts/EAGAIN, and Pacer/flow/crypto/empty-selection
+  blocks. Send timestamps include `send_data` bookkeeping and do not represent
+  hardware egress timestamps. Control/FEC packets are excluded from DATA counts.
+
+Nanosecond histogram bounds are inclusive. Packet-count histograms use the
+same numeric bounds with explicit packet units. Quantiles are reported as
+bucket intervals, never invented exact percentiles. Read active sender shards
+alongside the whole endpoint; marginal histograms are not a per-packet trace.
+
+Extra clock reads, an additional read-only Pacer query and private `Task`
+timestamp fields perturb timing and memory traffic. No public class layout
+changes. The exporter modifies only diagnostics; measurements with this
+overlay are always labeled instrumented even if output is incomplete.
+
+## Partial output and failure handling
+
+There is no per-packet output. Workers write registration, at most one
+checkpoint per second after callbacks, and a final snapshot at orderly thread
+exit. Checkpoints are capped at 128 per worker plus the final row. The
+collector flags counter saturation or exhausted checkpoint budget; the reader
+limits each worker file to 2 MiB. Checkpoint I/O runs outside callback locks,
+but still delays the next callback and is part of observer overhead.
+
+On timeout or forced process termination, earlier valid checkpoints are
+retained. Registration without a final snapshot, truncated JSON, missing
+workers, nonmonotonic counters/histograms or packet coverage mismatch fails
+diagnostic completeness. Partial worker PIDs do not imply a known sender or
+receiver role if the corresponding completion evidence is absent. Missing
+CPU/packet statistics are not zero. No signal-unsafe collector I/O is added.
+
+Ordinary failures retain their original status and remaining planned blocks
+continue. SIGINT/SIGTERM/SIGHUP stop the plan; the runner invokes the existing
+case driver in-process so its tracked case group and inherited peer processes
+are cleaned. No retries, replacement transfers or selective deletion.
+
+## Operator and execution
+
+`run_pacer_deadline_operator.py` carries the reviewed outer operator from
+[Lab PR #29](https://github.com/Robotweax/srt_network_lab/blob/9d544ef77deadf4638fa85899e181a73c20c45f8/results/2026-09-12-pacer-deadline-abba/report-de.md).
+It records prior UDP maxima, temporarily sets both to 32 MiB, forwards signals
+to the owning runner, then independently restores/verifies both prior values
+and verifies unchanged security settings. A nonzero runner status is preserved
+even when cleanup also fails. Run the five fake-sysctl operator scenarios and
+the atomic readiness tests on the VM before any SRT transfer:
+
+```sh
+python3 -m unittest discover -s "$SRT/interop/tests" -p 'test_pacer_deadline*.py' -v
+```
+
+Those synthetic tests include success, runner failure, SIGINT/SIGTERM with
+signal-ignoring case/peer, and failure of the first restore while the second
+still runs. Ready JSON is written, closed and atomically renamed, including
+the old 72-transfer harness test. Preserve any failed preparation; repair it
+before measurement. Repeating a flaky test is not its repair.
+
+After inspecting the operator on the actual VM, invoke exactly once:
+
+```sh
+python3 "$SRT/benchmarks/run_pacer_deadline_operator.py" \
+  --output-directory "$WORK/operator" -- \
+  python3 "$SRT/benchmarks/run_pacer_deadline_diagnostics.py" \
+    --baseline-plain "$WORK/baseline-plain/build-manifest.json" \
+    --candidate-plain "$WORK/candidate-plain/build-manifest.json" \
+    --baseline-diagnostic "$WORK/baseline-diagnostic/build-manifest.json" \
+    --candidate-diagnostic "$WORK/candidate-diagnostic/build-manifest.json" \
+    --output-directory "$WORK/deadline-results"
+operator_status=$?
+printf '%s\n' "$operator_status" > "$WORK/operator.exit-code.txt"
+```
+
+Preserve all logs and statuses and independently check for remaining peers and
+unchanged binaries/source checkouts after cleanup. The runner validates exact
+pins, common harness, four build signatures and requested UDP capacity. It
+never changes sysctls itself. The operator uses `sudo -n`; no password prompt
+or unattended privilege setup is part of this stage.
+
+## Result contract and interpretation
+
+Every completed case, including controls and diagnostics, must prove full
+deterministic payload, exact options, complete public packet statistics and
+zero retransmissions. All 40 cases need explicit zero deltas for UDP
+`InErrors`, `RcvbufErrors`, `SndbufErrors`, `InCsumErrors`. Both completed peer
+PIDs, CPU U/S and voluntary/involuntary context switches are required. Keep
+failed cases and partial metrics. An exit-zero diagnostic is not performance
+approval; diagnose whether delay accumulates before callback start or during
+poll/send processing, and inspect flow/empty/Pacer counters before attributing
+it to the operating system.
+
+Deliver a new Lab result directory/PR with raw requests/cases/reports, worker
+JSONL, original stdout/stderr/status, exact source/overlay/build/host identities,
+SHA-256 manifest, independently reproducible validation and verified cleanup.
+Keep original archives unchanged; no Haivision binaries or whole build trees.
+Do not implement a new pacing budget, busy-spin threshold or batching policy
+inside this measurement. That requires a separate candidate and review.

--- a/docs/pacer-deadline-experiment.md
+++ b/docs/pacer-deadline-experiment.md
@@ -1,0 +1,173 @@
+# Absolute pacer-deadline experiment
+
+**Result:** [Lab PR #29](https://github.com/Robotweax/srt_network_lab/blob/9d544ef77deadf4638fa85899e181a73c20c45f8/results/2026-09-12-pacer-deadline-abba/report-de.md)
+attempted all 72 transfers. All 16 candidate Robotweax-sender cases timed out;
+56 transfers completed. This candidate failed the performance criterion and
+should not be merged in this form. The text below preserves the original
+experiment contract. The next stage is a separate, smaller
+[deadline/dispatch/send diagnosis](pacer-deadline-diagnostics.md).
+
+This candidate tests whether scheduling the next channel poll at its actual
+pacer deadline reduces sender CPU without losing throughput. It is an
+experiment, not a measured performance improvement or a production release.
+
+[Lab PR #28](https://github.com/Robotweax/srt_network_lab/blob/cda122a9a4b2414bec9b3ff623eec1038f91c837/results/2026-09-12-poll-wake-counters/report-de.md)
+recorded 3.41–3.66 sender polls per original DATA packet, about 74% of them
+without a DATA send. Over 98% of channel continuations took the immediate
+sub-millisecond pacer path. More than 99.5% of sender receive attempts ended in
+EAGAIN. Application notifications were already over 99.96% coalesced. These
+counts motivate a scheduling change but do not measure its potential CPU gain.
+
+## Candidate behavior and limits
+
+The connection returns an absolute `steady_clock` deadline tied to its origin.
+The channel retains the earliest connection deadline, capped by the existing
+idle interval for receive/control work, and submits that exact deadline to the
+scheduler. A short positive remainder no longer requests immediate polling or
+gets rounded to milliseconds. Processing time is not added to a previously
+computed relative delay.
+
+Due timers and ready work alternate when both are runnable on a scheduler
+shard. This preserves progress for other channels even when a hot sender's
+timer is already due by its next dispatch. Timer order and ready FIFO order
+remain intact within their respective queues. Existing notification, timer
+cancellation, active-poll follow-up and stop/context-lifetime handling remain
+in place; failure to schedule still breaks affected connections explicitly.
+
+Public headers and class layouts, the shared public-API peer, pacing rate,
+catch-up policy, flow window, buffer sizes and batch limits are unchanged.
+Only private runtime deadline representation and dispatch selection change.
+The diagnostic counter overlay from SRT PR #33 is separate and still tied to
+its original source; do not apply it to the new candidate without reviewing
+and pinning new anchors.
+
+The scheduler can wake after a deadline. The unchanged pacer computes its
+next deadline from `max(previous_deadline, actual_now) + interval`, so lateness
+does not create compensating burst credit. Lower CPU with substantially lower
+throughput would fail the purpose of this experiment. No busy-spin threshold,
+timer-resolution tuning, batching change or rate change is combined with it.
+
+## Fixed library and harness identities
+
+| Role | Exact revision |
+|---|---|
+| A: baseline Robotweax library | `8e1bdebed836cb7b732db852f51ef6a7b212e925` |
+| B: absolute-deadline Robotweax library | `11814d3a1ebc217dbe95613b679960ac3152ff59` |
+| Haivision 1.5.7, both variants | `899348d8318eb9a3c5a5b6ec43c4a1114288773a` |
+| Harness | One clean committed checkout of `codex/pacer-deadline` containing this document; record its full SHA separately |
+
+The common peer source SHA-256 remains
+`faf487b34f5661e4dc602130628ed216b8054a2ab364abcc275bdda1d826d2ae`.
+The harness commit follows the candidate commit and must not replace the
+candidate library pin in manifests. `run_pacer_deadline_ab.py` accepts only
+this pair. The earlier `run_plain_capacity_ab.py` retains its original pair
+and defaults; common validators also accept the new runner's explicit
+contract without changing the old experiment.
+
+## Lab handoff: build both variants before measuring
+
+Use the original dedicated `srt-network-lab-runtime` Ubuntu ARM64 VM with
+4 vCPU and 6 GiB. The runner checks Linux ARM64, the established hostname
+`lima-srt-network-lab-runtime` and four CPUs. The operator must also verify
+memory/VM identity and absence of competing work. Hosted CI and local macOS
+checks are separate evidence, not substitutes for the VM.
+
+Set `SRT` to the clean committed harness checkout, `REFERENCE` to the clean
+exact-pinned Haivision checkout and `WORK` to a new work directory:
+
+```sh
+HARNESS=$(git -C "$SRT" rev-parse HEAD)
+printf '%s\n' "harness=$HARNESS"
+git -C "$SRT" worktree add --detach "$WORK/baseline-source" \
+  8e1bdebed836cb7b732db852f51ef6a7b212e925 || exit 1
+git -C "$SRT" worktree add --detach "$WORK/candidate-source" \
+  11814d3a1ebc217dbe95613b679960ac3152ff59 || exit 1
+for variant in baseline candidate; do
+  python3 "$SRT/benchmarks/prepare_throughput.py" \
+    --robotweax-source "$WORK/$variant-source" --reference-source "$REFERENCE" \
+    --output-directory "$WORK/$variant-plain" --linkage static --jobs 2 || exit 1
+done
+```
+
+Both library pairs use Release/OpenSSL/static, normal Release `-O3 -DNDEBUG`
+with `-g`; both peers use the common `-O2 -g` flags. No overlay, sanitizers,
+new profiling flags or cached build reuse. Preserve compiler/OpenSSL/CMake,
+cache, loader and binary-hash evidence. Stop on a build error.
+
+Before running, review/test the operator interruption and restoration path.
+Use the [temporary UDP-limit procedure](throughput-profiling.md#2-check-udp-limits-do-not-silently-tune-the-host)
+with recorded prior values, independent restoration attempts and verification
+in the enclosing operator's cleanup path. The new runner itself never changes
+sysctls. No perf recording, concurrent builds or other load tests.
+
+```sh
+python3 "$SRT/benchmarks/run_pacer_deadline_ab.py" \
+  --baseline-plain "$WORK/baseline-plain/build-manifest.json" \
+  --candidate-plain "$WORK/candidate-plain/build-manifest.json" \
+  --output-directory "$WORK/pacer-abba-results" \
+  >"$WORK/pacer-abba.log" 2>&1
+status=$?
+printf '%s\n' "$status" >"$WORK/pacer-abba.exit-code.txt"
+```
+
+This is the measurement command, not a replacement for the enclosing
+operator's finally/trap and archive collection. Preserve its original status
+through cleanup. The operator must not use the flawed original interruption
+wrapper from Lab PR #28 unchanged.
+
+## Exact plan and failure handling
+
+Four blocks, **A → B → B → A**, with 30 seconds' cooldown before each block.
+Each block contains one Haivision self-control, then one excluded warmup and
+three measurements for each direction in this order: Robotweax self,
+Haivision self, Robotweax → Haivision, Haivision → Robotweax; one Haivision
+self-control ends the block.
+
+Total: **72 transfers = 48 measurements + 16 warmups + 8 controls**. There are
+six measured samples per direction/variant across two blocks. Keep blocks and
+individual values visible; three-point p95 values are descriptive only.
+
+Every transfer is at least 1 GiB rounded to 815914 messages / 1073742824
+payload bytes, 1316-byte payload, one plain IPv4-loopback connection,
+Live/Message, TSBPD 120 ms, TLPKTDROP off, pending 8192, FC 16384,
+32-MiB requested SRT buffers, 8-MiB requested UDP buffers, MAXBW
+1,250,000,000 bytes/s, application target 0, timeout 45 s and shutdown 500 ms.
+Keep this contract even if the candidate is slower or times out.
+
+No retries, replacement runs or selective deletion. A nonzero block status
+remains in the report and the remaining planned blocks still run. Interruption
+stops the plan and leaves an incomplete report. SIGINT/SIGTERM/SIGHUP are
+handled in the runner, which invokes the diagnostic driver in the same process;
+the driver owns and cleans up its tracked case session and peer descendants.
+Repeated handled signals are ignored during cleanup. Two synthetic tests
+exercise real SIGINT/SIGTERM with a case and peer that ignore those signals;
+they do not perform SRT transfers. Enclosing operator cleanup still needs to
+restore and verify UDP maxima after the runner exits.
+
+## Acceptance and result delivery
+
+`ab-report.json` requires all planned payloads, exact pins/options, complete
+packet statistics, zero retransmissions and recorded zero `InErrors`,
+`RcvbufErrors`, `SndbufErrors` and `InCsumErrors` deltas, including warmups and
+controls. Missing values are not zero. Both endpoint PIDs, CPU user/system and
+voluntary/involuntary context switches must be present. CPU summaries include
+both processes in seconds and seconds per actual payload GiB. Process CPU
+includes setup through completion, not the entire shutdown interval.
+
+Completed measurements with retransmissions remain visible in summaries while
+failing the contract. Warmups and controls are excluded from those summaries.
+Review CPU/GiB and throughput by direction/block together with all Haivision
+controls; R→H varied by 4.13% between the prior plain brackets despite only
+0.56% control spread, so small changes need careful interpretation.
+
+Success needs repeatable sender-CPU improvement with preserved or better
+throughput and complete transport correctness. Exit zero is not automatic
+performance/release approval. A regression is useful evidence and remains
+archived; do not silently switch to a different waiting or batching policy.
+
+Deliver a new Lab result directory/PR with raw requests/cases/reports,
+stdout/stderr, every original status, exact source/build/host identities,
+SHA-256 manifest, independently reproducible validator and verified cleanup.
+No Haivision binaries or whole build directories. Keep earlier evidence and
+the ten-stream PR #26 investigation separate. Keep this candidate unmerged
+pending lab review and a separate merge decision.

--- a/docs/throughput-profiling.md
+++ b/docs/throughput-profiling.md
@@ -4,7 +4,7 @@ This diagnostic branch includes an **experimental empty-receive-buffer
 fast path and Lite-ACK receive-window credit correction**, not a complete transport
 qualification or a released throughput claim. Public API, locking and transport
 configuration remain unchanged. The latest follow-up is the
-[fixed-pin plain ABBA stage](#plain-abba-after-the-lite-ack-diagnosis); earlier
+[pacer deadline/dispatch/send diagnosis](pacer-deadline-diagnostics.md); earlier
 experiments below retain their original pins and contracts. Use a dedicated Linux test VM to reproduce a Linux
 capacity observation; native macOS and hosted x86-64 CI are separate platform
 controls, not substitutes for that environment.

--- a/interop/tests/test_pacer_deadline_ab.py
+++ b/interop/tests/test_pacer_deadline_ab.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import copy
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "benchmarks"))
+import run_pacer_deadline_ab as ab
+import test_throughput_diagnostics_plain_ab as fixtures
+
+
+class PacerDeadlineABTests(unittest.TestCase):
+    def manifests(self):
+        with patch.object(ab.common, "REVISIONS", ab.REVISIONS):
+            return fixtures.PlainCapacityABTests().manifests()
+
+    def diagnostic(self, manifest=None):
+        with patch.object(ab.common, "ARGUMENTS", ab.ARGUMENTS), patch.object(ab.common, "PROFILES", ab.PROFILES):
+            result = fixtures.PlainCapacityABTests().diagnostic(manifest)
+        for case in result["runs"]:
+            resources = case["result"]["peer_process_resources"]
+            resources["sender"].update(pid=100, voluntary_context_switches=20, involuntary_context_switches=2)
+            resources["receiver"] = {"pid": 200, "user_cpu_us": 500000, "system_cpu_us": 500000,
+                                     "voluntary_context_switches": 10, "involuntary_context_switches": 1}
+        return result
+
+    def test_fixed_72_transfer_plan_and_separate_library_pins(self):
+        cases = ab.cases() * len(ab.common.plan())
+        self.assertEqual(len(cases), 72)
+        self.assertEqual(sum(c["kind"] == "measurement" for c in cases), 48)
+        self.assertEqual(sum(c["kind"] == "warmup" for c in cases), 16)
+        self.assertEqual(sum(c["kind"].startswith("control-") for c in cases), 8)
+        self.assertEqual(ab.ARGUMENTS["bytes_per_connection"], 1024**3)
+        self.assertEqual(ab.REVISIONS["baseline"], "8e1bdebed836cb7b732db852f51ef6a7b212e925")
+        self.assertNotEqual(ab.REVISIONS, ab.common.REVISIONS)
+        self.assertTrue(all(len(pin) == 40 for pin in ab.REVISIONS.values()))
+
+    def test_exact_pair_and_instrumentation_guards(self):
+        manifests = self.manifests()
+        args = ({"dirty": False, "revision": "common-harness"}, {"platform": "Linux-test", "architecture": "aarch64"})
+        ab.common.validate_manifests(manifests, *args, revisions=ab.REVISIONS)
+        for mutation in (lambda m: m["candidate"]["sources"]["robotweax"].update(revision=ab.common.REVISIONS["candidate"]),
+                         lambda m: m["candidate"].update(poll_counters={"enabled": True}),
+                         lambda m: m["baseline"].update(transport_trace={"enabled": True}),
+                         lambda m: m["candidate"]["harness_checkout"].update(revision="different-harness")):
+            altered = copy.deepcopy(manifests)
+            mutation(altered)
+            with self.assertRaises(ValueError):
+                ab.common.validate_manifests(altered, *args, revisions=ab.REVISIONS)
+
+    def test_all_four_directions_and_both_process_resources_are_required(self):
+        report = self.diagnostic()
+        analysis = ab.analyze_block(report, {}, 0)
+        self.assertTrue(analysis["measurement_contract_pass"], analysis["errors"])
+        self.assertEqual(len(analysis["cases"]), 18)
+        self.assertEqual({s["profile"] for s in analysis["summary"]}, set(ab.PROFILES))
+        for role in ("sender", "receiver"):
+            for key in ("pid", "user_cpu_us", "system_cpu_us", "voluntary_context_switches", "involuntary_context_switches"):
+                altered = copy.deepcopy(report)
+                altered["runs"][2]["result"]["peer_process_resources"][role].pop(key)
+                self.assertFalse(ab.analyze_block(altered, {}, 0)["measurement_contract_pass"], (role, key))
+
+    def test_retransmissions_and_missing_udp_fail_in_every_case(self):
+        for index in range(len(ab.cases())):
+            for mode in ("retransmission", "missing-udp"):
+                report = self.diagnostic()
+                row = report["runs"][index]
+                if mode == "missing-udp":
+                    row["system_udp_delta"].pop("InErrors")
+                else:
+                    row["result"]["wire_statistics"]["retransmitted_packets"] = 1
+                    row["result"]["wire_statistics"]["sender_packets_total"] += 1
+                self.assertFalse(ab.analyze_block(report, {}, 0)["measurement_contract_pass"])
+
+    def test_summary_keeps_failed_contract_samples_and_excludes_warmups(self):
+        report = self.diagnostic()
+        for row in report["runs"]:
+            if row["kind"] != "measurement":
+                row["result"]["peer_process_resources"]["receiver"]["user_cpu_us"] = 999999999
+        report["runs"][2]["system_udp_delta"]["InErrors"] = 1
+        summary = ab.analyze_block(report, {}, 0)["summary"][0]
+        self.assertEqual(summary["receiver_cpu_seconds"]["median"], 1)
+        self.assertEqual(summary["receiver_cpu_seconds"]["samples"], 3)
+        self.assertEqual(summary["evidence_passes"], 2)
+
+    def test_runner_continues_after_failure_but_stops_on_interrupt(self):
+        for mode in ("pass", "fail", "missing", "interrupt"):
+            with self.subTest(mode=mode), tempfile.TemporaryDirectory() as tmp:
+                manifests = self.manifests()
+                paths = {v: Path(tmp) / f"{v}.json" for v in ab.REVISIONS}
+                report = {}
+                before = signal.getsignal(signal.SIGINT)
+
+                def execute(args):
+                    out = Path(args[args.index("--output-directory") + 1])
+                    variant = "candidate" if "candidate" in out.name else "baseline"
+                    first = out.name.startswith("00")
+                    if first and mode == "interrupt":
+                        raise KeyboardInterrupt
+                    if not (first and mode == "missing"):
+                        out.mkdir()
+                        (out / "report.json").write_text(json.dumps(self.diagnostic(manifests[variant])))
+                    return 1 if first and mode == "fail" else 0
+
+                with patch.object(ab.diag, "main", side_effect=execute) as run:
+                    status = ab.run_blocks(paths, manifests, Path(tmp) / "results", report)
+                self.assertEqual(status, 0 if mode == "pass" else 130 if mode == "interrupt" else 1)
+                self.assertEqual(run.call_count, 1 if mode == "interrupt" else 4)
+                self.assertEqual(report["complete"], mode != "interrupt")
+                self.assertEqual(report["interrupted"], mode == "interrupt")
+                self.assertEqual(signal.getsignal(signal.SIGINT), before)
+                self.assertTrue(report["performance_decision_requires_review"])
+
+    def test_rejects_other_hosts(self):
+        for system, machine, hostname in (("Darwin", "arm64", "lima-srt-network-lab-runtime"),
+                                          ("Linux", "x86_64", "lima-srt-network-lab-runtime"),
+                                          ("Linux", "aarch64", "different-vm")):
+            with patch.object(ab.platform, "system", return_value=system), patch.object(ab.platform, "machine", return_value=machine), patch.object(ab.socket, "gethostname", return_value=hostname):
+                with self.assertRaises(SystemExit):
+                    ab.main(["--baseline-plain", "unused", "--candidate-plain", "unused", "--output-directory", "unused"])
+
+    @unittest.skipUnless(os.name == "posix", "POSIX workload process groups")
+    def test_real_interrupt_cleans_case_and_signal_ignoring_peer(self):
+        for signum in (signal.SIGINT, signal.SIGTERM):
+            with self.subTest(signal=signum), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                ready = root / "ready.json"
+                peer_ready = root / "peer-ready"
+                ready_temporary = root / "ready.tmp"
+                workload = root / "workload.py"
+                peer_code = ("import signal,time; from pathlib import Path; "
+                             "signal.signal(signal.SIGTERM,signal.SIG_IGN); "
+                             "signal.signal(signal.SIGINT,signal.SIG_IGN); "
+                             f"Path({str(peer_ready)!r}).write_text('ready'); time.sleep(60)")
+                workload.write_text("import os,signal,subprocess,sys,time,json\n"
+                    "signal.signal(signal.SIGTERM,signal.SIG_IGN)\n"
+                    "signal.signal(signal.SIGINT,signal.SIG_IGN)\n"
+                    f"p=subprocess.Popen([sys.executable,'-c',{peer_code!r}])\n"
+                    "deadline=time.monotonic()+3\n"
+                    f"while not os.path.exists({str(peer_ready)!r}) and time.monotonic()<deadline:time.sleep(.01)\n"
+                    f"assert os.path.exists({str(peer_ready)!r})\n"
+                    f"with open({str(ready_temporary)!r},'w') as marker:\n"
+                    " time.sleep(.05)\n"
+                    " marker.write(json.dumps({'case':os.getpid(),'peer':p.pid,'group':os.getpgrp()}))\n"
+                    f"os.replace({str(ready_temporary)!r},{str(ready)!r})\n"
+                    "time.sleep(60)\n")
+                driver = root / "driver.py"
+                driver.write_text(f"import sys\nfrom pathlib import Path\nsys.path.insert(0,{str(Path(ab.__file__).parent)!r})\n"
+                    "import run_pacer_deadline_ab as ab\n"
+                    f"root=Path({str(root)!r})\n"
+                    "def diagnostic(args):\n"
+                    " out=root/'case';out.mkdir()\n"
+                    " return ab.diag.run_bounded([sys.executable,str(root/'workload.py')],out,120)\n"
+                    "ab.diag.main=diagnostic\n"
+                    "raise SystemExit(ab.run_blocks({'baseline':root/'a','candidate':root/'b'},{},root/'results',{}))\n")
+                process = subprocess.Popen([sys.executable, str(driver)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                ids = {}
+                try:
+                    deadline = time.monotonic() + 5
+                    while not ready.exists() and time.monotonic() < deadline:
+                        time.sleep(.01)
+                    ids = json.loads(ready.read_text())
+                    self.assertNotEqual(ids["group"], os.getpgrp())
+                    process.send_signal(signum)
+                    self.assertEqual(process.wait(timeout=10), 128 + signum)
+                    def active(pid):
+                        result = subprocess.run(["ps", "-o", "stat=", "-p", str(pid)], capture_output=True, text=True)
+                        return bool(result.stdout.strip()) and not result.stdout.strip().startswith("Z")
+                    deadline = time.monotonic() + 2
+                    while any(active(ids[k]) for k in ("case", "peer")) and time.monotonic() < deadline:
+                        time.sleep(.01)
+                    self.assertFalse(any(active(ids[k]) for k in ("case", "peer")))
+                    report = json.loads((root / "results/ab-report.json").read_text())
+                    self.assertTrue(report["interrupted"])
+                    self.assertFalse(report["complete"])
+                    self.assertEqual(len(report["blocks"]), 1)
+                    self.assertEqual(report["blocks"][0]["exit_code"], 128 + signum)
+                finally:
+                    if process.poll() is None:
+                        process.send_signal(signal.SIGTERM)
+                        try:
+                            process.wait(timeout=10)
+                        except subprocess.TimeoutExpired:
+                            process.kill()
+                            process.wait()
+                    if ids:
+                        try:
+                            os.killpg(ids["group"], signal.SIGKILL)
+                        except ProcessLookupError:
+                            pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/interop/tests/test_pacer_deadline_diagnostics.py
+++ b/interop/tests/test_pacer_deadline_diagnostics.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import copy
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "benchmarks"))
+import pacer_deadline_diagnostics as dd
+import run_pacer_deadline_diagnostics as runner
+import throughput_diagnostics as diag
+import test_throughput_diagnostics_plain_ab as fixtures
+
+
+def snapshot(complete=True):
+    return {"schema": 1, "event": "snapshot", "ordinal": 1, "complete": complete,
+            "overflow": False, "checkpoint_limit": False, "elapsed_ns": 1,
+            "counters": dict.fromkeys(dd.COUNTERS, 0),
+            "histograms": {k: {"count": 0, "sum": 0, "max": 0, "buckets": [0] * (len(dd.BOUNDS) + 1)} for k in dd.METRICS}}
+
+
+def registration(pid=123, shard=0, shards=1):
+    return {"schema": 1, "event": "register", "pid": pid, "tid": pid + shard,
+            "serial": shard, "shard": shard, "shards": shards, "timer_slack_ns": 50000}
+
+
+class DeadlineDiagnosticsTests(unittest.TestCase):
+    def block_fixture(self, spec):
+        args = runner.block_arguments(spec)
+        cases = diag.case_plan(runner.PROFILES, spec["repetitions"], 0, True, spec["capture"])
+        with patch.object(runner.common, "ARGUMENTS", args), patch.object(runner.common, "PROFILES", runner.PROFILES), \
+                patch.object(runner.common, "cases", return_value=cases):
+            report = fixtures.PlainCapacityABTests().diagnostic()
+        report["capture"] = spec["capture"]
+        for row in report["runs"]:
+            resources = row["result"]["peer_process_resources"]
+            resources["sender"].update(pid=100, voluntary_context_switches=20, involuntary_context_switches=2)
+            resources["receiver"] = {**resources["sender"], "pid": 200}
+            if spec["capture"] == "pacer":
+                row["profiling"] = {"valid": True}
+        return report
+
+    def test_successful_plan_and_capture_failure_keep_separate_summaries(self):
+        paths = {runner.key(v, c): Path("manifest") for v in runner.REVISIONS for c in ("none", "pacer")}
+        manifests = dict.fromkeys(paths, {})
+        for spec in runner.plan():
+            raw = self.block_fixture(spec)
+            checked = runner.analyze_block(raw, {}, 0, spec)
+            self.assertTrue(checked["measurement_contract_pass"], checked["errors"])
+            if spec["capture"] == "pacer":
+                self.assertEqual(checked["summary"], [])
+                raw["runs"][0]["profiling"] = {"valid": False, "workers": ["partial"]}
+                failed = runner.analyze_block(raw, {}, 0, spec)
+                self.assertFalse(failed["measurement_contract_pass"])
+                self.assertEqual(len(failed["cases"]), 4)
+                self.assertEqual(failed["cases"][0]["profiling"]["workers"], ["partial"])
+            else:
+                self.assertEqual([s["mbps"]["samples"] for s in checked["summary"]], [3, 3])
+                raw["runs"][0]["system_udp_delta"].pop("InErrors")
+                self.assertFalse(runner.analyze_block(raw, {}, 0, spec)["measurement_contract_pass"])
+        with tempfile.TemporaryDirectory() as directory:
+            def execute(args):
+                out = Path(args[args.index("--output-directory") + 1]); out.mkdir()
+                spec = runner.plan()[int(out.name[:2])]
+                (out / "report.json").write_text(json.dumps(self.block_fixture(spec)))
+                return 0
+            report = {}
+            with patch.object(runner.diag, "main", side_effect=execute):
+                self.assertEqual(runner.run_blocks(paths, manifests, Path(directory) / "out", report), 0)
+            self.assertTrue(report["complete"])
+            self.assertEqual(sum(len(b["analysis"]["cases"]) for b in report["blocks"]), 40)
+
+    def test_manifest_pins_overlay_identity_and_plain_guards(self):
+        manifests = {}
+        originals = fixtures.PlainCapacityABTests().manifests()
+        fake_patches = {"source.cpp": (b"original", b"instrumented")}
+        for variant, revision in runner.REVISIONS.items():
+            for capture in ("none", "pacer"):
+                m = copy.deepcopy(originals[variant])
+                m["sources"]["robotweax"].update(revision=revision, path=str(dd.ROOT))
+                if capture == "pacer":
+                    m["pacer_deadline_diagnostics"] = {
+                        "enabled": True, "source_revision": revision,
+                        "files": [{"path": n, "original_sha256": dd.hashlib.sha256(a).hexdigest(),
+                                   "patched_sha256": dd.hashlib.sha256(b).hexdigest()} for n, (a, b) in fake_patches.items()],
+                        "overlay_script": {"sha256": runner.sc.file_sha256(Path(dd.__file__))},
+                        "collector_header": {"sha256": runner.sc.file_sha256(dd.HEADER)}}
+                manifests[runner.key(variant, capture)] = m
+        args = ({"dirty": False, "revision": "common-harness"}, {"platform": "Linux-test", "architecture": "aarch64"})
+        with patch.object(dd, "patched_sources", return_value=fake_patches):
+            runner.validate_manifests(manifests, *args)
+            mutations = [lambda m: m.pop("candidate-plain"),
+                         lambda m: m["candidate-diagnostic"]["pacer_deadline_diagnostics"]["collector_header"].update(sha256="wrong"),
+                         lambda m: m["candidate-diagnostic"]["pacer_deadline_diagnostics"].update(files=[]),
+                         lambda m: m["baseline-plain"].update(pacer_deadline_diagnostics={"enabled": True}),
+                         lambda m: m["candidate-plain"]["sources"]["robotweax"].update(revision="wrong"),
+                         lambda m: m["baseline-diagnostic"].update(poll_counters={"enabled": True})]
+            for mutate in mutations:
+                changed = copy.deepcopy(manifests); mutate(changed)
+                with self.assertRaises(ValueError):
+                    runner.validate_manifests(changed, *args)
+
+    def test_fixed_forty_case_plan_and_capture_separation(self):
+        plan = runner.plan()
+        self.assertEqual([b["variant"] for b in plan], ["baseline", "candidate", "baseline", "candidate", "candidate", "baseline"])
+        kinds = [case["kind"] for b in plan for case in diag.case_plan(runner.PROFILES, b["repetitions"], 0, True, b["capture"])]
+        self.assertEqual(len(kinds), 40)
+        self.assertEqual(kinds.count("measurement"), 24)
+        self.assertEqual(kinds.count("pacer"), 8)
+        self.assertEqual(sum(k.startswith("control-") for k in kinds), 8)
+        self.assertNotIn("warmup", kinds)
+        self.assertEqual(runner.ARGUMENTS["bytes_per_connection"], 16 * 1024**2)
+        self.assertEqual(diag.perf_command("pacer", Path("unused"), ["peer"], "unused"), ["peer"])
+
+    def test_exact_source_hashes_and_unique_anchors(self):
+        # Exercise the fixed-pin guard without requiring historical Git objects
+        # in shallow CI or freezing future mainline library edits. The actual
+        # historical exports are additionally built and tested independently.
+        sources = {}
+        for name, hooks in dd.HOOKS.items():
+            original = "\n".join(old for old, _ in hooks).encode()
+            sources[name] = original
+            for revision in dd.REVISIONS:
+                self.assertRegex(dd.SOURCE_HASHES[revision][name], r"^[0-9a-f]{64}$")
+            changed = dd.instrument(original.decode(), hooks)
+            self.assertNotEqual(changed, original.decode())
+            with self.assertRaises(ValueError):
+                dd.instrument(original.decode() * 2, hooks)
+        hashes = {revision: {name: dd.hashlib.sha256(raw).hexdigest() for name, raw in sources.items()}
+                  for revision in dd.REVISIONS}
+        with patch.object(dd, "SOURCE_HASHES", hashes), patch.object(dd.subprocess, "check_output",
+                side_effect=lambda command: sources[command[-1].split(":", 1)[1]]):
+            for revision in dd.REVISIONS:
+                exported = dd.patched_sources(dd.ROOT, revision)
+                self.assertEqual(set(exported), set(sources))
+                self.assertTrue(all(before != after for before, after in exported.values()))
+        with self.assertRaises(ValueError):
+            dd.patched_sources(dd.ROOT, "unreviewed")
+        with patch.object(dd.subprocess, "check_output", return_value=b"changed"):
+            with self.assertRaisesRegex(ValueError, "source hash"):
+                dd.patched_sources(dd.ROOT, dd.REVISIONS[0])
+
+    def test_header_and_analyzer_bucket_contract(self):
+        text = dd.HEADER.read_text().split("bounds {")[1].split("};")[0]
+        actual = tuple(int(n.replace("'", "")) for n in re.findall(r"[0-9][0-9']*", text))
+        self.assertEqual(actual, dd.BOUNDS)
+        self.assertEqual(len(dd.COUNTERS), len(set(dd.COUNTERS)))
+        self.assertEqual(len(dd.METRICS), len(set(dd.METRICS)))
+
+    def test_missing_nan_overflow_and_inconsistent_histograms_fail(self):
+        dd.validate_snapshot(snapshot())
+        mutations = [lambda s: s["counters"].pop("data_packets"),
+                     lambda s: s["counters"].update(data_packets=float("nan")),
+                     lambda s: s.update(overflow=True), lambda s: s.update(checkpoint_limit=True),
+                     lambda s: s["histograms"]["data_per_task"].update(count=1),
+                     lambda s: s["counters"].update(timer_tasks=1),
+                     lambda s: s["histograms"]["task_elapsed_ns"].update(max=1)]
+        for mutate in mutations:
+            s = snapshot(); mutate(s)
+            with self.assertRaises(ValueError):
+                dd.validate_snapshot(s)
+        with self.assertRaises(ValueError):
+            dd.validate_snapshot(None)
+
+    def test_partial_truncated_and_nonmonotonic_snapshots_are_preserved(self):
+        with tempfile.TemporaryDirectory() as directory:
+            p = Path(directory) / "worker.jsonl"
+            prefix = json.dumps(registration()) + "\n" + json.dumps(snapshot(False)) + "\n"
+            p.write_text(prefix + '{"event":')
+            r = dd.read_worker(p)
+            self.assertFalse(r["complete"])
+            self.assertIsNotNone(r["last_snapshot"])
+            self.assertIn("malformed/truncated line", r["errors"])
+            final = snapshot(); final.update(ordinal=2, elapsed_ns=2)
+            p.write_text(prefix + json.dumps(final) + "\n")
+            self.assertTrue(dd.read_worker(p)["complete"])
+            p.write_text(prefix + json.dumps(snapshot()) + "\n")
+            self.assertIn("snapshot ordinal mismatch", dd.read_worker(p)["errors"])
+
+    def test_missing_worker_or_pid_never_becomes_zero_coverage(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory); (root / "pacer-deadline").mkdir()
+            p = root / "pacer-deadline/worker.jsonl"
+            p.write_text(json.dumps(registration(shards=2)) + "\n" + json.dumps(snapshot()) + "\n")
+            result = {"sender_implementation": "robotweax", "receiver_implementation": "haivision",
+                      "peer_process_resources": {"sender": {"pid": 123}},
+                      "wire_statistics": {"sender_packets_unique": 1, "retransmitted_packets": 0}}
+            checked = dd.analyze_case(root, result)
+            self.assertFalse(checked["valid"])
+            self.assertTrue(any("shard coverage" in e for e in checked["errors"]))
+            self.assertTrue(any("packet coverage" in e for e in checked["errors"]))
+            checked = dd.analyze_case(root, {})
+            self.assertFalse(checked["valid"])
+            self.assertEqual(len(checked["workers"]), 1)
+
+    def test_quantiles_are_bucket_intervals(self):
+        s = snapshot(); h = s["histograms"]["task_elapsed_ns"]
+        h.update(count=2, sum=8000, max=4000); h["buckets"][dd.BOUNDS.index(5000)] = 2
+        result = dd.aggregate_histograms([{"last_snapshot": s}])["task_elapsed_ns"]
+        self.assertEqual(result["mean"], 4000)
+        self.assertEqual(result["quantile_intervals"]["99"], [2001, 5000])
+
+    def test_case_failure_keeps_partial_diagnostic_analysis(self):
+        with tempfile.TemporaryDirectory() as directory:
+            p = Path(directory) / "request.json"
+            p.write_text(json.dumps({"capture": "pacer", "profile": "robotweax-self", "programs": {}, "index": 0,
+                                    "options": {}, "kind": "pacer", "peer_arguments": []}))
+            partial = {"valid": False, "workers": [{"last_snapshot": snapshot(False)}]}
+            with patch.object(diag.sc, "RunOptions"), patch.object(diag.sc, "run_many_socket_profile", side_effect=RuntimeError("timeout")), \
+                    patch.object(diag, "udp_snapshot", return_value={}), patch.object(diag.dd, "analyze_case", return_value=partial), \
+                    patch.dict(os.environ, clear=False):
+                self.assertEqual(diag.run_case(p), 1)
+            case = json.loads((p.parent / "case.json").read_text())
+            self.assertFalse(case["transfer_pass"])
+            self.assertEqual(case["error"], "timeout")
+            self.assertEqual(case["profiling"], partial)
+
+    def test_failed_blocks_continue_but_interrupt_ends_plan(self):
+        paths = {runner.key(v, c): Path("manifest") for v in runner.REVISIONS for c in ("none", "pacer")}
+        for error, expected in ((RuntimeError("ordinary failure"), 6), (KeyboardInterrupt(), 1)):
+            with tempfile.TemporaryDirectory() as directory, patch.object(runner.diag, "main", side_effect=error) as call:
+                report = {}; code = runner.run_blocks(paths, {}, Path(directory) / "out", report)
+                self.assertEqual(call.call_count, expected)
+                self.assertNotEqual(code, 0)
+                self.assertEqual(report["complete"], expected == 6)
+                self.assertEqual(report["interrupted"], expected == 1)
+
+    @unittest.skipUnless(os.name == "posix" and shutil.which("c++"), "POSIX C++ collector")
+    def test_compiled_collector_final_and_abrupt_exit_checkpoint(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory); source = root / "collector.cpp"; binary = root / "collector"
+            source.write_text('#include "' + str(dd.HEADER) + '"\n#include <thread>\n#include <string_view>\n'
+                'int main(int argc,char**) { std::thread worker([&] {\n'
+                'namespace d = robotweax::srt::deadline_diagnostics; d::recorder().start(0,1);\n'
+                '{ d::TaskScope task(d::Clock::now(), {}, false); d::PollScope poll;\n'
+                'd::sent(d::Clock::now(), true, false); ++poll.packets; }\n'
+                'if(argc>1) { d::recorder().checkpoint(d::Clock::now()+std::chrono::seconds(2)); std::_Exit(7); }\n'
+                '}); worker.join(); }\n')
+            built = subprocess.run(["c++", "-std=c++20", "-Wall", "-Wextra", "-Werror", str(source), "-pthread", "-o", str(binary)], capture_output=True, text=True)
+            self.assertEqual(built.returncode, 0, built.stderr)
+            for partial in (False, True):
+                out = root / str(partial); out.mkdir()
+                finished = subprocess.run([str(binary), *(["partial"] if partial else [])],
+                    env={**os.environ, "ROBOTWEAX_PACER_DEADLINE_DIR": str(out)}, capture_output=True, text=True)
+                self.assertEqual(finished.returncode, 7 if partial else 0, finished.stderr)
+                files = list(out.glob("*.jsonl")); self.assertEqual(len(files), 1)
+                worker = dd.read_worker(files[0])
+                self.assertEqual(worker["complete"], not partial, worker)
+                self.assertEqual(worker["last_snapshot"]["counters"]["original_packets"], 1)
+                self.assertEqual(worker["last_snapshot"]["histograms"]["data_per_task"]["sum"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/interop/tests/test_pacer_deadline_operator.py
+++ b/interop/tests/test_pacer_deadline_operator.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import json,os,subprocess,signal,tempfile,time,sys
+import unittest
+
+@unittest.skipUnless(os.name == "posix" and hasattr(signal, "pthread_sigmask"), "POSIX signal masks and process groups")
+class DeadlineOperatorTests(unittest.TestCase):
+    def test_exit_signals_and_independent_restoration(self):
+        base=Path(__file__).resolve().parents[2]/'benchmarks';harness=base;results=[]
+        for mode in ['success','runner-failure','SIGINT','SIGTERM','restore-first-fails']:
+         with tempfile.TemporaryDirectory() as d:
+          root=Path(d);bin=root/'bin';bin.mkdir();state=root/'state.json';state.write_text(json.dumps({'net.core.rmem_max':'212992','net.core.wmem_max':'212992','kernel.perf_event_paranoid':'4','kernel.kptr_restrict':'1'}))
+          (bin/'sudo').write_text('#!/bin/sh\nshift\nexec "$@"\n');(bin/'sudo').chmod(0o755)
+          (bin/'sysctl').write_text('#!/usr/bin/env python3\nimport os,json,sys\nfrom pathlib import Path\np=Path(os.environ["TEST_STATE"]);s=json.loads(p.read_text())\nif sys.argv[1]=="-n":print(s[sys.argv[2]])\nelse:\n k,v=sys.argv[2].split("=")\n if os.environ["TEST_MODE"]=="restore-first-fails" and k=="net.core.rmem_max" and v=="212992":sys.exit(7)\n s[k]=v;p.write_text(json.dumps(s))\n');(bin/'sysctl').chmod(0o755)
+          (bin/'ps').write_text('#!/bin/sh\nexit 0\n');(bin/'ps').chmod(0o755)
+          driver=root/'driver.py'
+          if mode in ['SIGINT','SIGTERM']:
+           peer=root/'peer.py';peer.write_text('import signal,time,os\nfrom pathlib import Path\nsignal.signal(signal.SIGINT,signal.SIG_IGN)\nsignal.signal(signal.SIGTERM,signal.SIG_IGN)\nPath('+repr(str(root/'peer-ready'))+').write_text(str(os.getpid()))\ntime.sleep(60)\n')
+           case=root/'case.py';case.write_text('import signal,subprocess,sys,time,json,os\nfrom pathlib import Path\nsignal.signal(signal.SIGINT,signal.SIG_IGN)\nsignal.signal(signal.SIGTERM,signal.SIG_IGN)\np=subprocess.Popen([sys.executable,'+repr(str(peer))+'])\nwhile not Path('+repr(str(root/'peer-ready'))+').exists():time.sleep(.01)\nPath('+repr(str(root/'ready.tmp'))+').write_text(json.dumps({"case":os.getpid(),"peer":p.pid}))\nPath('+repr(str(root/'ready.tmp'))+').replace('+repr(str(root/'ready.json'))+')\ntime.sleep(60)\n')
+           driver.write_text(f'import sys\nfrom pathlib import Path\nsys.path.insert(0,{str(harness)!r})\nimport run_pacer_deadline_diagnostics as ab\nroot=Path({str(root)!r})\ndef diagnostic(args):\n out=root/"case-output";out.mkdir()\n return ab.diag.run_bounded([sys.executable,str(root/"case.py")],out,90)\nab.diag.main=diagnostic\nraise SystemExit(ab.run_blocks({{"baseline-plain":root/"a"}},{{}},root/"result",{{}}))\n')
+          else:driver.write_text('raise SystemExit('+('7' if mode in ['runner-failure','restore-first-fails'] else '0')+')\n')
+          env=os.environ|{'PATH':str(bin)+':'+os.environ['PATH'],'TEST_STATE':str(state),'TEST_MODE':mode}
+          proc=subprocess.Popen([sys.executable,str(base/'run_pacer_deadline_operator.py'),'--output-directory',str(root/'operator'),'--',sys.executable,str(driver)],env=env,stdout=subprocess.DEVNULL,stderr=subprocess.PIPE,text=True)
+          ids={}
+          try:
+           if mode in ['SIGINT','SIGTERM']:
+            limit=time.monotonic()+8
+            while not (root/'ready.json').exists() and time.monotonic()<limit:time.sleep(.01)
+            ids=json.loads((root/'ready.json').read_text());proc.send_signal(getattr(signal,mode))
+           _,err=proc.communicate(timeout=15);e=json.loads((root/'operator/execution.json').read_text())
+           expected=128+getattr(signal,mode) if mode.startswith('SIG') else 7 if mode in ['runner-failure','restore-first-fails'] else 0
+           assert proc.returncode==expected and e['runner_exit_code']==expected,(mode,e,err)
+           assert e['cleanup_pass']==(mode!='restore-first-fails')
+           assert len(e['restoration'])==2 and json.loads(state.read_text())['net.core.wmem_max']=='212992'
+           for pid in ids.values():
+            observed=subprocess.run(['/bin/ps','-o','stat=','-p',str(pid)],capture_output=True,text=True).stdout.strip();assert not observed or observed.startswith('Z'),observed
+           results.append({'mode':mode,'pass':True,'expected_exit_code':expected,'execution':e,'case_and_peer_stopped':True if ids else None})
+          finally:
+           if proc.poll() is None:proc.send_signal(signal.SIGTERM);proc.wait(timeout=15)
+        print(json.dumps({'tests_pass':True,'synthetic_only':True,'cases':results},indent=2))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Lab PR [srt_network_lab#29](https://github.com/Robotweax/srt_network_lab/pull/29) timed out in all 16 Robotweax-sender cases for the absolute-deadline candidate. This adds a separate, fixed-pin experiment to measure where the delay accumulates: timer submission/dispatch, timed-wait return, callback start, connection poll and successful DATA-send return.

The normal `src`/`include` trees and shared public-API peer remain identical to main (`8e1bdeb`). Instrumentation is applied only to fresh exports of the exact baseline and failed candidate; whole-file hashes, unique patch anchors, collector identity and all four build manifests are validated. No pacing policy or product candidate is introduced here. #34 remains a separate unmerged draft.

The new runner executes exactly **40 × 16-MiB transfers** on the original Linux ARM64 VM: 24 plain measurements, 8 Haivision controls and 8 separately labeled diagnostic cases. Worker-local counters and bounded histograms retain partial checkpoints after failure. Both endpoint PIDs/CPU/context switches, payload, options, public packet statistics and UDP error evidence remain mandatory. Instrumented rates never enter the plain summaries.

This also imports the prior harness/analyzer from #34, repairs its synthetic readiness race with a close-and-atomic-rename protocol, and versions the outer UDP-restoration operator reviewed in Lab #29. Five fake-sysctl cases exercise success, runner failure, SIGINT, SIGTERM and independent restoration after the first restore fails.

## Evidence

- Harness: `a26788258b8b24a0659b605b1130be4fd557dff3`

- Baseline A: `8e1bdebed836cb7b732db852f51ef6a7b212e925`
- Candidate B: `11814d3a1ebc217dbe95613b679960ac3152ff59`
- Haivision 1.5.7: `899348d8318eb9a3c5a5b6ec43c4a1114288773a`
- Shared peer SHA-256: `faf487b34f5661e4dc602130628ed216b8054a2ab364abcc275bdda1d826d2ae`
- Lab #29 evidence pin: `9d544ef77deadf4638fa85899e181a73c20c45f8`
- Procedure: [docs/pacer-deadline-diagnostics.md](https://github.com/Robotweax/srt/blob/a26788258b8b24a0659b605b1130be4fd557dff3/docs/pacer-deadline-diagnostics.md)

## Validation

- Both exact instrumented A/B exports compiled in Release/OpenSSL on macOS ARM64; each passed all 40 native CTest targets, including 602/602 baseline and 606/606 candidate core cases.
- Full Python harness suite: **642 tests passed**. The 21 deadline-specific tests include the compiled collector's normal/abrupt exit paths and all five outer-operator scenarios.
- Real local 16-MiB R→R smoke for each instrumented library: 12749/12749 DATA packets, zero retransmissions, complete diagnostics from all four workers and all 16 histograms. This is a macOS functional smoke, not Linux capacity evidence.
- clang-format 22.1.8, documentation validation (44 installed Markdown files), whitespace checks and unchanged mainline source/peer checks passed.
- [GitHub CI run 34701946793](https://github.com/Robotweax/srt/actions/runs/34701946793) passed at the pinned harness commit: 33 successful jobs, 7 intentionally skipped. Linux Release 126/126 CTest targets, macOS 48/48, Windows 30/30, ASan/UBSan 56/56; all 21 selected reference-interoperability shards passed. Python CI confirmed 642 tests. No Linux laboratory experiment has been run for this PR.

The exported source trees intentionally have no Git metadata. Their native CTest run excludes `robotweax_srt_remote_harness_tests`; the complete current Python harness is tested separately in the real Git checkout. An accidental unfiltered export run exposed those Git/executable-mode prerequisites; its original failed log is retained with the local evidence.

## Performance and risk

Only the private diagnostic exports add task metadata, clock reads, a read-only Pacer query and per-worker fixed histogram storage. Checkpoints occur at most once per second after callbacks, capped at 128 plus a final snapshot. Missing, truncated, saturated, inconsistent or incomplete output fails validation while preserving earlier valid checkpoints. Timed-wait return includes mutex reacquisition; send return includes bookkeeping and is not hardware egress. Histogram percentiles are bucket intervals. These observer effects and short-transfer startup effects prevent treating this diagnosis as production throughput/CPU qualification.
